### PR TITLE
Add support for new B2500 port 2220 for Shelly Pro 3EM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.4
+
+### Added
+- Added support for Shelly Pro 3EM on port 2220 (B2500 firmware version >=226)
+- Added backward compatibility for Shelly Pro 3EM devices through shellypro3em_old (port 1010) and shellypro3em_new (port 2220) device types
+
 ## 1.0.3
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@
 This project emulates Smart Meter devices for Marstek storage systems such as the B2500, Marstek Jupiter, and Marstek Venus energy storage systems while allowing integration with almost any smart meter. It does this by emulating one or more of the following devices:
 - CT001
 - Shelly Pro 3EM
+  - Uses port 1010 (B2500 firmware up to version 224) and port 2220 (B2500 firmware version 226+)
+  - Can be specifically targeted with shellypro3em_old (port 1010) or shellypro3em_new (port 2220)
 - Shelly EM gen3
 - Shelly Pro EM50
+
+**Note:** If your B2500 or Marstek storage system supports it, always prefer a Shelly device type over CT001 for better compatibility and reliability.
 
 ## Getting Started
 
@@ -47,7 +51,15 @@ The B2500 Meter project can be installed and run in several ways depending on yo
      - Set the `Power Input Alias` to a comma-separated list of three entity IDs (one for each phase)
      - If using calculated power, also set the `Power Output Alias` to a comma-separated list of three entity IDs
      - Example: `sensor.phase1,sensor.phase2,sensor.phase3`
-   - Set `Device Types` (comma-separated list) to the device types you want to emulate (ct001, shellypro3em, shellyemg3, shellyproem50)
+   - Set `Device Types` (comma-separated list) to the device types you want to emulate:
+     - `ct001`: CT001 emulator
+     - `shellypro3em`: Shelly Pro 3EM emulator (uses both ports 1010 and 2220 for compatibility with all B2500 firmware versions)
+     - `shellypro3em_old`: Shelly Pro 3EM emulator using port 1010 (for B2500 firmware up to v224)
+     - `shellypro3em_new`: Shelly Pro 3EM emulator using port 2220 (for B2500 firmware v226+)
+     - `shellyemg3`: Shelly EM gen3 emulator
+     - `shellyproem50`: Shelly Pro EM50 emulator
+     
+     **Important:** Always prefer a Shelly device type over CT001 if supported by your energy storage system.
    - Click "Save" to apply the configuration
 
    B) Using a Custom Configuration File for Advanced Configuration:
@@ -118,7 +130,7 @@ Configuration is managed via `config.ini`. Each powermeter type has specific set
 
 ```ini
 [GENERAL]
-# Comma-separated list of device types to emulate (ct001, shellypro3em, shellyemg3, shellyproem50)
+# Comma-separated list of device types to emulate (ct001, shellypro3em, shellyemg3, shellyproem50, shellypro3em_old, shellypro3em_new)
 DEVICE_TYPE = ct001
 # Skip initial powermeter test on startup
 SKIP_POWERMETER_TEST = False

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -20,6 +20,7 @@ ports:
   12345/tcp: 12345
   12345/udp: 12345
   1010/udp: 1010
+  2220/udp: 2220
   2222/udp: 2222
   2223/udp: 2223
 map:
@@ -30,7 +31,7 @@ options:
   power_output_alias: ""
   poll_interval: 1
   disable_absolute_values: false
-  device_types: "ct001"
+  device_types: "shellypro3em"
 schema:
   power_input_alias: str
   power_output_alias: str?

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -13,7 +13,7 @@ configuration:
     description: "If enabled, the ct001 emulator will allow negative values. This is only compatible with newer versions of the B2500 firmware. Ignore this if you are emulating a different device."
   device_types:
     name: Emulated Devices
-    description: "Comma-separated list of devices to emulate (ct001, shellypro3em, shellyemg3, shellyproem50)."
+    description: "Comma-separated list of devices to emulate (ct001, shellypro3em, shellyemg3, shellyproem50, shellypro3em_old, shellypro3em_new). The device type shellypro3em_old uses port 1010 (used up until B2500 firmware version 224). The device type shellypro3em_new uses the new port 2220 (used for B2500 firmare >=226). If you use shellypro3em, it will use shellypro3em_old and shellypro3em_new simultaneously for backwards compatibility. If possible, always prefer a Shelly device type over ct001."
   custom_config:
     name: Custom Config
     description: "Optional. Name of a custom config.ini file to use instead of the UI configuration. The file must be placed in the add-on's configuration directory."

--- a/main.py
+++ b/main.py
@@ -84,10 +84,15 @@ def run_device(
 
         device.before_send = update_readings
 
-    elif device_type == "shellypro3em":
+    elif device_type == "shellypro3em_old":
         print(f"Shelly Pro 3EM Settings:")
         print(f"Device ID: {device_id}")
         device = Shelly(powermeters=powermeters, device_id=device_id, udp_port=1010)
+
+    elif device_type == "shellypro3em_new":
+        print(f"Shelly Pro 3EM Settings:")
+        print(f"Device ID: {device_id}")
+        device = Shelly(powermeters=powermeters, device_id=device_id, udp_port=2220)
 
     elif device_type == "shellyemg3":
         print(f"Shelly EM Gen3 Settings:")
@@ -119,7 +124,7 @@ def main():
         "-d",
         "--device-types",
         nargs="+",
-        choices=["ct001", "shellypro3em", "shellyemg3", "shellyproem50"],
+        choices=["ct001", "shellypro3em", "shellyemg3", "shellyproem50", "shellypro3em_old", "shellypro3em_new"],
         help="List of device types to emulate",
     )
     parser.add_argument("--device-ids", nargs="+", help="List of device IDs")
@@ -156,6 +161,13 @@ def main():
             device_ids.append(f"{device_type}-ec4609c439c{len(device_ids) + 1}")
         else:
             device_ids.append(f"device-{len(device_ids) + 1}")
+
+    # For backward compatibility, replace shellypro3em with shellypro3em_old and shellypro3em_new
+    if "shellypro3em" in device_types:
+        shellypro3em_index = device_types.index("shellypro3em")
+        device_types[shellypro3em_index] = "shellypro3em_old"
+        device_types.append("shellypro3em_new")
+        device_ids.append(device_ids[shellypro3em_index])
 
     print(f"Device Types: {device_types}")
     print(f"Device IDs: {device_ids}")


### PR DESCRIPTION
- Added support for Shelly Pro 3EM on port 2220 (B2500 firmware v226+)
- Added backward compatibility through shellypro3em_old (port 1010) and shellypro3em_new (port 2220)
- Updated README with detailed device type information and port explanations
- Updated CHANGELOG.md with new 1.0.4 version info