### PR TITLE
Fix test name typo

### DIFF
--- a/powermeter/homeassistant_test.py
+++ b/powermeter/homeassistant_test.py
@@ -25,7 +25,7 @@ class TestPowermeters(unittest.TestCase):
         self.assertEqual(homeassistant.get_powermeter_watts(), [800])
 
     @patch("requests.Session.get")
-    def test_homeassistant_path_refix(self, mock_get):
+    def test_homeassistant_path_prefix(self, mock_get):
         mock_response = MagicMock()
         mock_response.json.side_effect = [{"state": 1000}]
         mock_get.return_value = mock_response


### PR DESCRIPTION
## Summary
- rename `test_homeassistant_path_refix` to `test_homeassistant_path_prefix`

## Testing
- `pytest -q` *(fails: ModbusTcpClient.__init__() takes 2 positional arguments but 3 were given)*

------
https://chatgpt.com/codex/tasks/task_e_68533d5016d8832e8609269aa4825e89