### PR TITLE
Fix Modbus doc keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,10 +369,11 @@ If the payload is a simple integer value, you can omit this option.
 
 ```ini
 [MODBUS]
-IP =
+HOST =
 PORT =
 UNIT_ID =
-REGISTER =
+ADDRESS =
+COUNT =
 ```
 
 ### Script


### PR DESCRIPTION
- correct README Modbus example section to use HOST/ADDRESS/COUNT keys