### PR TITLE
build from current checkout instead of cloning repository

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,3 @@ __pycache__
 .env
 .git
 **/*_test.py
-ha_addon/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
     with:
       registry: ghcr.io
       platform: ${{ matrix.platform }}
-      context: ./ha_addon
-      dockerfile: ha_addon/Dockerfile
+      context: .
+      dockerfile: ./ha_addon/Dockerfile
       build-args: |
         BUILD_FROM=ghcr.io/hassio-addons/base:14.2.2
       image-suffix: "-addon"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN pip install pipenv && pipenv install --deploy --ignore-pipfile
 # Copy the rest of the application code to the working directory
 COPY . /app/
 
+# Remove ha_addon directory to avoid conflicts
+RUN rm -rf /app/ha_addon
+
 # Expose the ports your application will be listening on
 EXPOSE 12345/tcp
 EXPOSE 12345/udp

--- a/ha_addon/Dockerfile
+++ b/ha_addon/Dockerfile
@@ -5,16 +5,15 @@ ARG BUILD_VERSION
 FROM ${BUILD_FROM:-ghcr.io/hassio-addons/base:17.0.1} AS builder
 
 RUN apk add --no-cache \
-    git \
     python3 \
     py3-pip
 
 WORKDIR /app
 
-# Clone the repository and remove .git directory
-RUN git clone https://github.com/tomquist/b2500-meter.git . && \
-    rm -rf .git && \
-    rm -rf ha_addon
+# Copy the source code from build context (current checkout state)
+COPY . ./
+# Save run.sh before removing ha_addon directory and remove ha_addon directory to avoid conflicts
+RUN mv ha_addon/run.sh /tmp/run.sh && rm -rf ha_addon
 
 # Create a virtual environment and install dependencies
 RUN python3 -m venv /app/venv
@@ -40,7 +39,7 @@ COPY --from=builder /app /app
 
 ENV PATH="/app/venv/bin:$PATH"
 
-COPY run.sh /
+COPY --from=builder /tmp/run.sh /
 RUN chmod a+x /run.sh
 
 CMD [ "/run.sh" ]


### PR DESCRIPTION
Prevents version drift between local development and CI builds by using current source code rather than always cloning latest from repository.