### PR TITLE
Update health check port to 52500

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ RUN rm -rf /app/ha_addon
 # Expose the ports your application will be listening on
 EXPOSE 12345/tcp
 EXPOSE 12345/udp
-EXPOSE 8124/tcp
+EXPOSE 52500/tcp
 
 # Add health check that uses the same endpoint as HA addon
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-  CMD curl -f http://localhost:8124/health || exit 1
+  CMD curl -f http://localhost:52500/health || exit 1
 
 # Run the SmartMeter script when the container starts
 CMD ["pipenv", "run", "python", "main.py", "--loglevel", "info"]

--- a/health_service.py
+++ b/health_service.py
@@ -156,7 +156,7 @@ def start_health_service(port=52500, bind_address='0.0.0.0'):
     Start the global health check service.
     
     Args:
-        port (int): Port to bind to (default: 8124)
+        port (int): Port to bind to (default: 52500)
         bind_address (str): Address to bind to (default: 'localhost')
     
     Returns:


### PR DESCRIPTION
## Summary
- change exposed health port in Dockerfile
- update health check command to use new port
- fix default port docstring in health service

## Testing
- `pipenv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859201f9238832e875c01c92cf93da3