### PR TITLE
Add LOG_LEVEL environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,8 @@ EXPOSE 52500/tcp
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD curl -f http://localhost:52500/health || exit 1
 
+# Default log level for container startup
+ENV LOG_LEVEL=info
+
 # Run the SmartMeter script when the container starts
-CMD ["pipenv", "run", "python", "main.py", "--loglevel", "info"]
+CMD ["pipenv", "run", "python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ The B2500 Meter project can be installed and run in several ways depending on yo
    ```bash
    docker-compose up -d
    ```
+   You can control the verbosity by setting the `LOG_LEVEL` environment
+   variable (for example `-e LOG_LEVEL=debug`). If not set the container
+   defaults to `info`.
 Note: Host network mode is required because the B2500 device uses UDP broadcasts for device discovery. Without host networking, the container won't be able to receive these broadcasts properly.
 
 ### Direct Installation

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import configparser
 import argparse
 import logging
+import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, List, Tuple
@@ -162,8 +163,8 @@ def main():
     parser.add_argument(
         "-log",
         "--loglevel",
-        default="warning",
-        help="Provide logging level. Example --loglevel debug, default=warning",
+        default=os.environ.get("LOG_LEVEL", "warning"),
+        help="Provide logging level. Example --loglevel debug. Can also be set via LOG_LEVEL env var",
     )
 
     # B2500-specific arguments


### PR DESCRIPTION
## Summary
- support `LOG_LEVEL` env var in main.py
- use `LOG_LEVEL` env var in Dockerfile
- document `LOG_LEVEL` usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b56b4b308832ebfdd3106f2f3f485