### PR TITLE
Improve HomeAssistant powermeter missing sensor error

### DIFF
--- a/powermeter/homeassistant.py
+++ b/powermeter/homeassistant.py
@@ -81,15 +81,29 @@ class HomeAssistant(Powermeter):
         path = f"/api/states/{entity}"
         try:
             response = self.get_json(path)
+
+            if not isinstance(response, dict):
+                msg = (
+                    f"Home Assistant sensor {entity} returned non-object JSON"
+                )
+                logger.error(msg)
+                raise ValueError(msg)
+
             try:
                 val = response["state"]
             except KeyError as e:
                 msg = f"Home Assistant sensor {entity} has no state"
                 logger.error(msg)
                 raise ValueError(msg) from e
+
+            if val is None:
+                msg = f"Home Assistant sensor {entity} has no state"
+                logger.error(msg)
+                raise ValueError(msg)
+
             try:
                 return float(val)
-            except ValueError as e:
+            except (ValueError, TypeError) as e:
                 msg = (
                     f"Home Assistant sensor {entity} state '{val}' is not numeric"
                 )
@@ -107,6 +121,13 @@ class HomeAssistant(Powermeter):
         if not self.power_calculate:
             return [self.get_sensor_value(entity) for entity in self.current_power_entity]
         else:
+            if len(self.power_input_alias) != len(self.power_output_alias):
+                msg = (
+                    "Home Assistant power_input_alias and power_output_alias lengths differ"
+                )
+                logger.error(msg)
+                raise ValueError(msg)
+
             results = []
             for in_entity, out_entity in zip(
                 self.power_input_alias, self.power_output_alias

--- a/powermeter/homeassistant_test.py
+++ b/powermeter/homeassistant_test.py
@@ -81,6 +81,32 @@ class TestPowermeters(unittest.TestCase):
         )
 
     @patch("requests.Session.get")
+    def test_homeassistant_sensor_state_none(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"state": None}
+        mock_get.return_value = mock_response
+
+        homeassistant = HomeAssistant(
+            "192.168.1.8",
+            "8123",
+            False,
+            "token",
+            "sensor.current_power",
+            False,
+            "",
+            "",
+            None,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            homeassistant.get_powermeter_watts()
+
+        self.assertEqual(
+            str(context.exception),
+            "Home Assistant sensor sensor.current_power has no state",
+        )
+
+    @patch("requests.Session.get")
     def test_homeassistant_sensor_state_not_numeric(self, mock_get):
         mock_response = MagicMock()
         mock_response.json.return_value = {"state": "unavailable"}
@@ -104,6 +130,32 @@ class TestPowermeters(unittest.TestCase):
         self.assertEqual(
             str(context.exception),
             "Home Assistant sensor sensor.current_power state 'unavailable' is not numeric",
+        )
+
+    @patch("requests.Session.get")
+    def test_homeassistant_sensor_response_not_dict(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        homeassistant = HomeAssistant(
+            "192.168.1.8",
+            "8123",
+            False,
+            "token",
+            "sensor.current_power",
+            False,
+            "",
+            "",
+            None,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            homeassistant.get_powermeter_watts()
+
+        self.assertEqual(
+            str(context.exception),
+            "Home Assistant sensor sensor.current_power returned non-object JSON",
         )
 
     @patch("requests.Session.get")
@@ -181,6 +233,27 @@ class TestPowermeters(unittest.TestCase):
             None,
         )
         self.assertEqual(homeassistant.get_powermeter_watts(), [800.0, 1700.0, 2600.0])
+
+    def test_homeassistant_power_alias_length_mismatch(self):
+        homeassistant = HomeAssistant(
+            "192.168.1.8",
+            "8123",
+            False,
+            "token",
+            "",
+            True,
+            ["sensor.power_in_1", "sensor.power_in_2"],
+            ["sensor.power_out_1"],
+            None,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            homeassistant.get_powermeter_watts()
+
+        self.assertEqual(
+            str(context.exception),
+            "Home Assistant power_input_alias and power_output_alias lengths differ",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Abstract fetching Home Assistant sensor values into its own helper that surfaces a clear error when a sensor is missing
- Use the new helper inside powermeter logic and keep the generic JSON fetcher free of endpoint-specific behavior
- Extend tests to mock HTTP errors for missing sensors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b00a8eadb0832eb783e2954daea17e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Clear, user-friendly errors for sensor not found (404), missing state, non-numeric state, and non-object JSON responses.
  - HTTP errors from the Home Assistant API now surface to callers instead of being suppressed.

- Refactor
  - Centralized sensor-value retrieval used for power calculations, simplifying logic and validation (including alias length checks for calculated power).

- Tests
  - Added unit tests covering not-found, missing-state, non-numeric-state, non-object JSON, and alias-length-mismatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->