### PR TITLE
Improve HomeAssistant powermeter missing sensor error

### DIFF
--- a/powermeter/homeassistant.py
+++ b/powermeter/homeassistant.py
@@ -55,37 +55,69 @@ class HomeAssistant(Powermeter):
 
         try:
             response = self.session.get(url, headers=headers, timeout=10)
-            response.raise_for_status()  # Raise an exception for bad status codes
+            response.raise_for_status()
             return response.json()
         except json.JSONDecodeError as e:
             logger.error(f"Failed to decode JSON response from Home Assistant API: {e}")
             logger.error(
                 f"Response content: {response.text[:200]}..."
             )  # Log first 200 chars
-            raise ValueError(f"Home Assistant API returned invalid JSON: {e}")
+            raise ValueError(
+                f"Home Assistant API returned invalid JSON: {e}"
+            ) from e
+        except requests.exceptions.HTTPError:
+            # Propagate HTTP errors for caller-specific handling
+            raise
         except requests.exceptions.RequestException as e:
             logger.error(f"Failed to connect to Home Assistant API: {e}")
-            raise ValueError(f"Home Assistant API connection error: {e}")
+            raise ValueError(
+                f"Home Assistant API connection error: {e}"
+            ) from e
         except Exception as e:
             logger.error(f"Unexpected error calling Home Assistant API: {e}")
+            raise ValueError(f"Home Assistant API error: {e}") from e
+
+    def get_sensor_value(self, entity: str) -> float:
+        path = f"/api/states/{entity}"
+        try:
+            response = self.get_json(path)
+            try:
+                val = response["state"]
+            except KeyError as e:
+                msg = f"Home Assistant sensor {entity} has no state"
+                logger.error(msg)
+                raise ValueError(msg) from e
+            if val in ("unknown", "unavailable", None):
+                msg = (
+                    f"Home Assistant sensor {entity} state '{val}' is not numeric"
+                )
+                logger.error(msg)
+                raise ValueError(msg)
+            try:
+                return float(val)
+            except (TypeError, ValueError) as e:
+                msg = (
+                    f"Home Assistant sensor {entity} state '{val}' is not numeric"
+                )
+                logger.error(msg)
+                raise ValueError(msg) from e
+        except requests.exceptions.HTTPError as e:
+            if e.response is not None and e.response.status_code == 404:
+                msg = f"Home Assistant sensor {entity} does not exist"
+                logger.error(msg)
+                raise ValueError(msg)
+            logger.error(f"Failed to fetch Home Assistant sensor {entity}: {e}")
             raise ValueError(f"Home Assistant API error: {e}")
 
     def get_powermeter_watts(self):
         if not self.power_calculate:
-            results = []
-            for entity in self.current_power_entity:
-                path = f"/api/states/{entity}"
-                response = self.get_json(path)
-                results.append(float(response["state"]))
-            return results
+            return [self.get_sensor_value(entity) for entity in self.current_power_entity]
         else:
             results = []
             for in_entity, out_entity in zip(
                 self.power_input_alias, self.power_output_alias
             ):
-                response = self.get_json(f"/api/states/{in_entity}")
-                power_in = float(response["state"])
-                response = self.get_json(f"/api/states/{out_entity}")
-                power_out = float(response["state"])
+                power_in = self.get_sensor_value(in_entity)
+                power_out = self.get_sensor_value(out_entity)
                 results.append(power_in - power_out)
             return results

--- a/powermeter/homeassistant_test.py
+++ b/powermeter/homeassistant_test.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import patch, MagicMock
+import requests
 from powermeter import HomeAssistant
 
 
@@ -23,6 +24,87 @@ class TestPowermeters(unittest.TestCase):
             None,
         )
         self.assertEqual(homeassistant.get_powermeter_watts(), [800])
+
+    @patch("requests.Session.get")
+    def test_homeassistant_sensor_not_found(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            response=mock_response
+        )
+        mock_get.return_value = mock_response
+
+        homeassistant = HomeAssistant(
+            "192.168.1.8",
+            "8123",
+            False,
+            "token",
+            "sensor.current_power",
+            False,
+            "",
+            "",
+            None,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            homeassistant.get_powermeter_watts()
+
+        self.assertEqual(
+            str(context.exception),
+            "Home Assistant sensor sensor.current_power does not exist",
+        )
+
+    @patch("requests.Session.get")
+    def test_homeassistant_sensor_has_no_state(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_get.return_value = mock_response
+
+        homeassistant = HomeAssistant(
+            "192.168.1.8",
+            "8123",
+            False,
+            "token",
+            "sensor.current_power",
+            False,
+            "",
+            "",
+            None,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            homeassistant.get_powermeter_watts()
+
+        self.assertEqual(
+            str(context.exception),
+            "Home Assistant sensor sensor.current_power has no state",
+        )
+
+    @patch("requests.Session.get")
+    def test_homeassistant_sensor_state_not_numeric(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"state": "unavailable"}
+        mock_get.return_value = mock_response
+
+        homeassistant = HomeAssistant(
+            "192.168.1.8",
+            "8123",
+            False,
+            "token",
+            "sensor.current_power",
+            False,
+            "",
+            "",
+            None,
+        )
+
+        with self.assertRaises(ValueError) as context:
+            homeassistant.get_powermeter_watts()
+
+        self.assertEqual(
+            str(context.exception),
+            "Home Assistant sensor sensor.current_power state 'unavailable' is not numeric",
+        )
 
     @patch("requests.Session.get")
     def test_homeassistant_path_prefix(self, mock_get):


### PR DESCRIPTION
## Summary
- Chain exceptions for Home Assistant API errors to preserve original context
- Validate sensor state presence and numeric value with explicit error messages
- Extend tests for missing state and non-numeric sensor values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b00a8eadb0832eb783e2954daea17e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More precise error handling when sensors are missing, lack a state, or report non-numeric values, with clear messages to aid troubleshooting.
* **Refactor**
  * Centralized sensor value retrieval and validation to ensure consistent behavior across power readings and calculations.
* **Tests**
  * Added tests covering missing sensors, empty states, and non-numeric states to prevent regressions and verify improved error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->