### PR TITLE
Enhancement for vzlogger meter, change logging in throttling.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,12 @@ POWER_OUTPUT_ALIAS = sensor.power_out_1,sensor.power_out_2,sensor.power_out_3
 [VZLOGGER]
 IP = 192.168.1.106
 PORT = 8080
+# Use if vzlogger powermeter provides a single saldo power value
 UUID = your-uuid
+# Set to True if vzlogger meter provides separate power values for input/output
+POWER_CALCULATE = ""|True|False
+POWER_INPUT_UUID = grid-import-uuid
+POWER_OUTPUT_UUID = grid-export-uuid
 ```
 
 ### ESPHome

--- a/config.ini.example
+++ b/config.ini.example
@@ -89,6 +89,8 @@ THROTTLE_INTERVAL = 0
 #IP = 192.168.1.106
 #PORT = 8080
 #UUID = your-uuid
+
+## For vzlogger meters providing seperate input/output power values
 #POWER_CALCULATE = True
 #POWER_INPUT_UUID = grid-import-uuid
 #POWER_OUTPUT_UUID = grid-export-uuid


### PR DESCRIPTION
The NetzOÖ Smartmeter Siemens TD-3511 does not provide a 'saldo' for grid export/import so is has to be calculated.

Messages in throttling.py floods the container logs and causes a constant increase of container memory.
Only print the messages when container starts with '--loglevel debug'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added power calculation capability for VZLogger meters using separate input and output power values
  * New configuration options to toggle power calculation mode and specify input/output identifiers

* **Documentation**
  * Updated configuration example and README with new VZLogger power settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->