### PR TITLE
Add SMA Energy Meter powermeter via Speedwire multicast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,15 @@ pipenv run python3 -m pytest
 ```
 
 CI runs the same `flake8 --select BLK` and `pytest` steps; `black .` keeps formatting aligned so BLK passes.
+
+## Changelog
+
+On every user-facing change, add a bullet under **`## Next`** in `CHANGELOG.md`. Skip when nothing users would notice changes (refactors, tests-only, etc.).
+
+## Adding a powermeter
+
+1. **Implementation** — Add `powermeter/<module>.py` with a class subclassing `Powermeter`; implement `get_powermeter_watts()` (and `wait_for_message()` only if the base default is wrong for your source).
+2. **Exports** — Import and re-export the class from `powermeter/__init__.py`.
+3. **Config** — In `config/config_loader.py`: import the class, define a `*_SECTION` string, add a `section.startswith(...)` branch in `create_powermeter()`, and a `create_*_powermeter()` factory that reads options from the section. `POWER_OFFSET` / `POWER_MULTIPLIER`, `THROTTLE_INTERVAL`, and `NETMASK` are handled globally for any section that returns a powermeter — no extra wiring unless you need something custom.
+4. **Examples, docs & changelog** — Add a commented example to `config.ini.example`, a subsection under **Configuration** in `README.md`, and a bullet under **`## Next`** in `CHANGELOG.md`.
+5. **Tests** — Add `powermeter/<module>_test.py` (or extend existing tests) and run the commands above before finishing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))
+- Added SMA Energy Meter / Sunny Home Manager support via Speedwire multicast protocol with auto-detection and per-phase power readings ([#231](https://github.com/tomquist/b2500-meter/pull/252))
 - Switched the Home Assistant powermeter integration from REST polling to the WebSocket API and improved missing/non-numeric sensor state handling ([#232](https://github.com/tomquist/b2500-meter/pull/232), [#193](https://github.com/tomquist/b2500-meter/pull/193))
 - Added optional Marstek cloud auto-registration for managed fake `ct002` and `ct003` devices at startup ([#237](https://github.com/tomquist/b2500-meter/pull/237))
 - Added battery activity info logs for Shelly emulation to report detection, inactivity, and reconnection events ([#241](https://github.com/tomquist/b2500-meter/pull/241))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Clarified README: emulated device types (CT001/Shelly) are listed separately from powermeter data sources such as SMA Energy Meter / Sunny Home Manager
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))
 - Added SMA Energy Meter / Sunny Home Manager support via Speedwire multicast protocol with auto-detection and per-phase power readings ([#231](https://github.com/tomquist/b2500-meter/pull/252))
 - Switched the Home Assistant powermeter integration from REST polling to the WebSocket API and improved missing/non-numeric sensor state handling ([#232](https://github.com/tomquist/b2500-meter/pull/232), [#193](https://github.com/tomquist/b2500-meter/pull/193))

--- a/README.md
+++ b/README.md
@@ -463,6 +463,19 @@ SERIAL = your_device_serial
 # THROTTLE_INTERVAL = 0
 ```
 
+### SMA Energy Meter
+
+Reads an [SMA Energy Meter](https://www.sma.de/) (EM 1.0/2.0) or Sunny Home Manager via the **Speedwire** multicast protocol (UDP). The listener joins the default multicast group and reports per-phase active power (L1, L2, L3). Use `SERIAL_NUMBER = 0` to auto-detect the first meter seen on the network, or set the device serial to pin a specific unit. Like other UDP-based features, this requires the host to receive multicast traffic (use Docker host networking or equivalent).
+
+```ini
+[SMA_ENERGY_METER]
+MULTICAST_GROUP = 239.12.255.254
+PORT = 9522
+SERIAL_NUMBER = 0
+# INTERFACE = 192.168.1.10
+# THROTTLE_INTERVAL = 0
+```
+
 ### Modbus
 
 ```ini

--- a/config.ini.example
+++ b/config.ini.example
@@ -166,6 +166,18 @@ THROTTLE_INTERVAL = 0
 ## Per-powermeter throttling override (optional)
 #THROTTLE_INTERVAL = 0
 
+#[SMA_ENERGY_METER]
+## SMA Energy Meter / Sunny Home Manager via Speedwire multicast
+## Listens for UDP multicast broadcasts and reports per-phase power (L1, L2, L3)
+#MULTICAST_GROUP = 239.12.255.254
+#PORT = 9522
+## Serial number of the meter (0 = auto-detect first meter found)
+#SERIAL_NUMBER = 0
+## Network interface IP to bind to (optional, leave empty for all interfaces)
+#INTERFACE =
+## Per-powermeter throttling override (optional)
+#THROTTLE_INTERVAL = 0
+
 #[SCRIPT]
 #COMMAND = /path/to/your/script.sh
 ## Per-powermeter throttling override (optional)

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -24,6 +24,7 @@ from powermeter import (
     JsonHttpPowermeter,
     TQEnergyManager,
     HomeWizardPowermeter,
+    SmaEnergyMeter,
     ThrottledPowermeter,
     TransformedPowermeter,
 )
@@ -42,6 +43,7 @@ MODBUS_SECTION = "MODBUS"
 JSON_HTTP_SECTION = "JSON_HTTP"
 TQ_EM_SECTION = "TQ_EM"
 HOMEWIZARD_SECTION = "HOMEWIZARD"
+SMA_ENERGY_METER_SECTION = "SMA_ENERGY_METER"
 
 
 class ClientFilter:
@@ -165,6 +167,8 @@ def create_powermeter(
         return create_json_http_powermeter(section, config)
     elif section.startswith(HOMEWIZARD_SECTION):
         return create_homewizard_powermeter(section, config)
+    elif section.startswith(SMA_ENERGY_METER_SECTION):
+        return create_sma_energy_meter_powermeter(section, config)
     elif section.startswith("MQTT"):
         return create_mqtt_powermeter(section, config)
     else:
@@ -384,4 +388,15 @@ def create_homewizard_powermeter(
         config.get(section, "TOKEN", fallback=""),
         config.get(section, "SERIAL", fallback=""),
         verify_ssl=config.getboolean(section, "VERIFY_SSL", fallback=True),
+    )
+
+
+def create_sma_energy_meter_powermeter(
+    section: str, config: configparser.ConfigParser
+) -> Powermeter:
+    return SmaEnergyMeter(
+        config.get(section, "MULTICAST_GROUP", fallback="239.12.255.254"),
+        config.getint(section, "PORT", fallback=9522),
+        config.getint(section, "SERIAL_NUMBER", fallback=0),
+        config.get(section, "INTERFACE", fallback=""),
     )

--- a/powermeter/__init__.py
+++ b/powermeter/__init__.py
@@ -16,3 +16,4 @@ from .throttling import ThrottledPowermeter
 from .transform import TransformedPowermeter
 from .tq_em import TQEnergyManager
 from .homewizard import HomeWizardPowermeter
+from .sma_energy_meter import SmaEnergyMeter

--- a/powermeter/sma_energy_meter.py
+++ b/powermeter/sma_energy_meter.py
@@ -1,7 +1,6 @@
 import socket
 import struct
 import threading
-import time
 
 from .base import Powermeter
 from config.logger import logger
@@ -70,6 +69,7 @@ class SmaEnergyMeter(Powermeter):
         self.interface = interface
         self.values = None
         self._lock = threading.Lock()
+        self._message_event = threading.Event()
         self._detected_serial = None
 
         thread = threading.Thread(target=self._listen, daemon=True)
@@ -99,7 +99,7 @@ class SmaEnergyMeter(Powermeter):
             )
 
             while True:
-                data, addr = sock.recvfrom(1024)
+                data, _addr = sock.recvfrom(1024)
                 try:
                     self._handle_packet(data)
                 except Exception as e:
@@ -133,17 +133,18 @@ class SmaEnergyMeter(Powermeter):
             if serial != self.serial_number:
                 return
         else:
-            if self._detected_serial is None:
-                device_name = SMA_SUSY_IDS.get(susy_id)
-                if device_name is None:
+            with self._lock:
+                if self._detected_serial is None:
+                    device_name = SMA_SUSY_IDS.get(susy_id)
+                    if device_name is None:
+                        return
+                    self._detected_serial = serial
+                    logger.info(
+                        f"SMA Energy Meter: auto-detected {device_name} "
+                        f"with serial {serial}"
+                    )
+                elif serial != self._detected_serial:
                     return
-                self._detected_serial = serial
-                logger.info(
-                    f"SMA Energy Meter: auto-detected {device_name} "
-                    f"with serial {serial}"
-                )
-            elif serial != self._detected_serial:
-                return
 
         self._parse_channels(data)
 
@@ -203,6 +204,7 @@ class SmaEnergyMeter(Powermeter):
 
         with self._lock:
             self.values = values
+            self._message_event.set()
 
     def get_powermeter_watts(self):
         with self._lock:
@@ -211,11 +213,5 @@ class SmaEnergyMeter(Powermeter):
         raise ValueError("No value received from SMA Energy Meter")
 
     def wait_for_message(self, timeout=5):
-        start_time = time.time()
-        while True:
-            with self._lock:
-                if self.values is not None:
-                    return
-            if time.time() - start_time > timeout:
-                raise TimeoutError("Timeout waiting for SMA Energy Meter data")
-            time.sleep(1)
+        if not self._message_event.wait(timeout):
+            raise TimeoutError("Timeout waiting for SMA Energy Meter data")

--- a/powermeter/sma_energy_meter.py
+++ b/powermeter/sma_energy_meter.py
@@ -77,9 +77,7 @@ class SmaEnergyMeter(Powermeter):
 
     def _listen(self):
         try:
-            sock = socket.socket(
-                socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP
-            )
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             if hasattr(socket, "SO_REUSEPORT"):
                 try:
@@ -191,15 +189,9 @@ class SmaEnergyMeter(Powermeter):
             pos += 4 + channel_len
 
         if has_phase_data:
-            l1 = raw.get(CHANNEL_L1_POWER_PLUS, 0) - raw.get(
-                CHANNEL_L1_POWER_MINUS, 0
-            )
-            l2 = raw.get(CHANNEL_L2_POWER_PLUS, 0) - raw.get(
-                CHANNEL_L2_POWER_MINUS, 0
-            )
-            l3 = raw.get(CHANNEL_L3_POWER_PLUS, 0) - raw.get(
-                CHANNEL_L3_POWER_MINUS, 0
-            )
+            l1 = raw.get(CHANNEL_L1_POWER_PLUS, 0) - raw.get(CHANNEL_L1_POWER_MINUS, 0)
+            l2 = raw.get(CHANNEL_L2_POWER_PLUS, 0) - raw.get(CHANNEL_L2_POWER_MINUS, 0)
+            l3 = raw.get(CHANNEL_L3_POWER_PLUS, 0) - raw.get(CHANNEL_L3_POWER_MINUS, 0)
             values = [l1, l2, l3]
         elif CHANNEL_TOTAL_POWER_PLUS in raw or CHANNEL_TOTAL_POWER_MINUS in raw:
             total = raw.get(CHANNEL_TOTAL_POWER_PLUS, 0) - raw.get(

--- a/powermeter/sma_energy_meter.py
+++ b/powermeter/sma_energy_meter.py
@@ -1,0 +1,229 @@
+import socket
+import struct
+import threading
+import time
+
+from .base import Powermeter
+from config.logger import logger
+
+# SMA Speedwire multicast defaults
+DEFAULT_MULTICAST_GROUP = "239.12.255.254"
+DEFAULT_PORT = 9522
+
+# SMA device SUSY IDs
+SMA_SUSY_IDS = {
+    270: "SMA Energy Meter 1.0",
+    349: "SMA Energy Meter 2.0",
+    372: "Sunny Home Manager 2.0",
+    501: "Sunny Home Manager 2.0",
+}
+
+# OBIS channel identifiers for active power (4 bytes each, raw value / 10 = watts)
+CHANNEL_TOTAL_POWER_PLUS = 0x00010400
+CHANNEL_TOTAL_POWER_MINUS = 0x00020400
+CHANNEL_L1_POWER_PLUS = 0x00150400
+CHANNEL_L1_POWER_MINUS = 0x00160400
+CHANNEL_L2_POWER_PLUS = 0x00290400
+CHANNEL_L2_POWER_MINUS = 0x002A0400
+CHANNEL_L3_POWER_PLUS = 0x003D0400
+CHANNEL_L3_POWER_MINUS = 0x003E0400
+
+POWER_DIVISOR = 10.0
+
+# End-of-data marker
+CHANNEL_END = 0x00000000
+
+# Software version channel
+CHANNEL_SOFTWARE_VERSION = 0x90000000
+
+
+def _get_channel_data_length(identifier):
+    """Determine data length for an OBIS channel identifier.
+
+    The second byte of the identifier encodes the measurement type:
+    - 0x04: instantaneous value (4 bytes)
+    - 0x08: counter/meter value (8 bytes)
+    """
+    if identifier == CHANNEL_END:
+        return 0
+    type_byte = (identifier >> 8) & 0xFF
+    if type_byte == 0x04:
+        return 4
+    elif type_byte == 0x08:
+        return 8
+    elif identifier == CHANNEL_SOFTWARE_VERSION:
+        return 4
+    return 4
+
+
+class SmaEnergyMeter(Powermeter):
+    def __init__(
+        self,
+        multicast_group=DEFAULT_MULTICAST_GROUP,
+        port=DEFAULT_PORT,
+        serial_number=0,
+        interface="",
+    ):
+        self.multicast_group = multicast_group
+        self.port = port
+        self.serial_number = serial_number
+        self.interface = interface
+        self.values = None
+        self._lock = threading.Lock()
+        self._detected_serial = None
+
+        thread = threading.Thread(target=self._listen, daemon=True)
+        thread.start()
+
+    def _listen(self):
+        try:
+            sock = socket.socket(
+                socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP
+            )
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            if hasattr(socket, "SO_REUSEPORT"):
+                try:
+                    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+                except OSError:
+                    pass
+            sock.bind(("", self.port))
+
+            interface_ip = self.interface if self.interface else "0.0.0.0"
+            mreq = struct.pack(
+                "4s4s",
+                socket.inet_aton(self.multicast_group),
+                socket.inet_aton(interface_ip),
+            )
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+
+            logger.info(
+                f"SMA Energy Meter: listening on {self.multicast_group}:{self.port}"
+            )
+
+            while True:
+                data, addr = sock.recvfrom(1024)
+                try:
+                    self._handle_packet(data)
+                except Exception as e:
+                    logger.debug(f"SMA Energy Meter: dropping invalid packet: {e}")
+        except Exception as e:
+            logger.error(f"SMA Energy Meter: listener failed: {e}")
+
+    def _handle_packet(self, data):
+        if len(data) < 28:
+            return
+
+        # Validate magic constant "SMA\0"
+        if data[0:4] != b"SMA\x00":
+            return
+
+        # Validate tag42
+        if data[5] != 0x04 or data[6] != 0x02:
+            return
+
+        # Validate protocol ID (0x6069 = energy meter)
+        protocol_id = struct.unpack_from(">H", data, 16)[0]
+        if protocol_id != 0x6069:
+            return
+
+        # Extract device identifiers
+        susy_id = struct.unpack_from(">H", data, 18)[0]
+        serial = struct.unpack_from(">I", data, 20)[0]
+
+        # Filter by serial number
+        if self.serial_number != 0:
+            if serial != self.serial_number:
+                return
+        else:
+            if self._detected_serial is None:
+                device_name = SMA_SUSY_IDS.get(susy_id)
+                if device_name is None:
+                    return
+                self._detected_serial = serial
+                logger.info(
+                    f"SMA Energy Meter: auto-detected {device_name} "
+                    f"with serial {serial}"
+                )
+            elif serial != self._detected_serial:
+                return
+
+        self._parse_channels(data)
+
+    def _parse_channels(self, data):
+        raw = {}
+        pos = 28
+        data_len = len(data)
+        has_phase_data = False
+
+        while pos + 4 <= data_len:
+            identifier = struct.unpack_from(">I", data, pos)[0]
+
+            if identifier == CHANNEL_END:
+                break
+
+            channel_len = _get_channel_data_length(identifier)
+
+            if pos + 4 + channel_len > data_len:
+                break
+
+            if identifier in (
+                CHANNEL_TOTAL_POWER_PLUS,
+                CHANNEL_TOTAL_POWER_MINUS,
+                CHANNEL_L1_POWER_PLUS,
+                CHANNEL_L1_POWER_MINUS,
+                CHANNEL_L2_POWER_PLUS,
+                CHANNEL_L2_POWER_MINUS,
+                CHANNEL_L3_POWER_PLUS,
+                CHANNEL_L3_POWER_MINUS,
+            ):
+                value = struct.unpack_from(">I", data, pos + 4)[0]
+                raw[identifier] = value / POWER_DIVISOR
+                if identifier in (
+                    CHANNEL_L1_POWER_PLUS,
+                    CHANNEL_L1_POWER_MINUS,
+                    CHANNEL_L2_POWER_PLUS,
+                    CHANNEL_L2_POWER_MINUS,
+                    CHANNEL_L3_POWER_PLUS,
+                    CHANNEL_L3_POWER_MINUS,
+                ):
+                    has_phase_data = True
+
+            pos += 4 + channel_len
+
+        if has_phase_data:
+            l1 = raw.get(CHANNEL_L1_POWER_PLUS, 0) - raw.get(
+                CHANNEL_L1_POWER_MINUS, 0
+            )
+            l2 = raw.get(CHANNEL_L2_POWER_PLUS, 0) - raw.get(
+                CHANNEL_L2_POWER_MINUS, 0
+            )
+            l3 = raw.get(CHANNEL_L3_POWER_PLUS, 0) - raw.get(
+                CHANNEL_L3_POWER_MINUS, 0
+            )
+            values = [l1, l2, l3]
+        elif CHANNEL_TOTAL_POWER_PLUS in raw or CHANNEL_TOTAL_POWER_MINUS in raw:
+            total = raw.get(CHANNEL_TOTAL_POWER_PLUS, 0) - raw.get(
+                CHANNEL_TOTAL_POWER_MINUS, 0
+            )
+            values = [total]
+        else:
+            return
+
+        with self._lock:
+            self.values = values
+
+    def get_powermeter_watts(self):
+        with self._lock:
+            if self.values is not None:
+                return list(self.values)
+        raise ValueError("No value received from SMA Energy Meter")
+
+    def wait_for_message(self, timeout=5):
+        start_time = time.time()
+        while True:
+            with self._lock:
+                if self.values is not None:
+                    return
+            if time.time() - start_time > timeout:
+                raise TimeoutError("Timeout waiting for SMA Energy Meter data")
+            time.sleep(1)

--- a/powermeter/sma_energy_meter_test.py
+++ b/powermeter/sma_energy_meter_test.py
@@ -104,27 +104,31 @@ class TestGetChannelDataLength(unittest.TestCase):
 class TestHandlePacket(unittest.TestCase):
     def test_three_phase_consumption(self):
         meter = _create_meter()
-        packet = _build_packet([
-            _build_channel(CHANNEL_L1_POWER_PLUS, 1000),  # 100.0 W
-            _build_channel(CHANNEL_L1_POWER_MINUS, 0),
-            _build_channel(CHANNEL_L2_POWER_PLUS, 2000),  # 200.0 W
-            _build_channel(CHANNEL_L2_POWER_MINUS, 0),
-            _build_channel(CHANNEL_L3_POWER_PLUS, 3000),  # 300.0 W
-            _build_channel(CHANNEL_L3_POWER_MINUS, 0),
-        ])
+        packet = _build_packet(
+            [
+                _build_channel(CHANNEL_L1_POWER_PLUS, 1000),  # 100.0 W
+                _build_channel(CHANNEL_L1_POWER_MINUS, 0),
+                _build_channel(CHANNEL_L2_POWER_PLUS, 2000),  # 200.0 W
+                _build_channel(CHANNEL_L2_POWER_MINUS, 0),
+                _build_channel(CHANNEL_L3_POWER_PLUS, 3000),  # 300.0 W
+                _build_channel(CHANNEL_L3_POWER_MINUS, 0),
+            ]
+        )
         meter._handle_packet(packet)
         self.assertEqual(meter.get_powermeter_watts(), [100.0, 200.0, 300.0])
 
     def test_three_phase_net_power(self):
         meter = _create_meter()
-        packet = _build_packet([
-            _build_channel(CHANNEL_L1_POWER_PLUS, 1500),   # 150.0 W
-            _build_channel(CHANNEL_L1_POWER_MINUS, 500),   #  50.0 W
-            _build_channel(CHANNEL_L2_POWER_PLUS, 0),
-            _build_channel(CHANNEL_L2_POWER_MINUS, 2000),  # -200.0 W
-            _build_channel(CHANNEL_L3_POWER_PLUS, 1000),
-            _build_channel(CHANNEL_L3_POWER_MINUS, 1000),  # 0.0 W
-        ])
+        packet = _build_packet(
+            [
+                _build_channel(CHANNEL_L1_POWER_PLUS, 1500),  # 150.0 W
+                _build_channel(CHANNEL_L1_POWER_MINUS, 500),  #  50.0 W
+                _build_channel(CHANNEL_L2_POWER_PLUS, 0),
+                _build_channel(CHANNEL_L2_POWER_MINUS, 2000),  # -200.0 W
+                _build_channel(CHANNEL_L3_POWER_PLUS, 1000),
+                _build_channel(CHANNEL_L3_POWER_MINUS, 1000),  # 0.0 W
+            ]
+        )
         meter._handle_packet(packet)
         result = meter.get_powermeter_watts()
         self.assertAlmostEqual(result[0], 100.0)
@@ -133,19 +137,23 @@ class TestHandlePacket(unittest.TestCase):
 
     def test_total_only_fallback(self):
         meter = _create_meter()
-        packet = _build_packet([
-            _build_channel(CHANNEL_TOTAL_POWER_PLUS, 5000),   # 500.0 W
-            _build_channel(CHANNEL_TOTAL_POWER_MINUS, 0),
-        ])
+        packet = _build_packet(
+            [
+                _build_channel(CHANNEL_TOTAL_POWER_PLUS, 5000),  # 500.0 W
+                _build_channel(CHANNEL_TOTAL_POWER_MINUS, 0),
+            ]
+        )
         meter._handle_packet(packet)
         self.assertEqual(meter.get_powermeter_watts(), [500.0])
 
     def test_total_net_production(self):
         meter = _create_meter()
-        packet = _build_packet([
-            _build_channel(CHANNEL_TOTAL_POWER_PLUS, 100),
-            _build_channel(CHANNEL_TOTAL_POWER_MINUS, 3000),
-        ])
+        packet = _build_packet(
+            [
+                _build_channel(CHANNEL_TOTAL_POWER_PLUS, 100),
+                _build_channel(CHANNEL_TOTAL_POWER_MINUS, 3000),
+            ]
+        )
         meter._handle_packet(packet)
         result = meter.get_powermeter_watts()
         self.assertAlmostEqual(result[0], -290.0)
@@ -202,7 +210,8 @@ class TestHandlePacket(unittest.TestCase):
         # First packet from meter with serial 11111
         packet1 = _build_packet(
             [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000)],
-            serial=11111, susy_id=349,
+            serial=11111,
+            susy_id=349,
         )
         meter._handle_packet(packet1)
         self.assertEqual(meter._detected_serial, 11111)
@@ -211,7 +220,8 @@ class TestHandlePacket(unittest.TestCase):
         # Second packet from different serial should be ignored
         packet2 = _build_packet(
             [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 9999)],
-            serial=22222, susy_id=349,
+            serial=22222,
+            susy_id=349,
         )
         meter._handle_packet(packet2)
         # Should still have old value
@@ -221,7 +231,8 @@ class TestHandlePacket(unittest.TestCase):
         meter = _create_meter()
         packet = _build_packet(
             [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000)],
-            serial=11111, susy_id=999,
+            serial=11111,
+            susy_id=999,
         )
         meter._handle_packet(packet)
         self.assertIsNone(meter._detected_serial)
@@ -230,33 +241,37 @@ class TestHandlePacket(unittest.TestCase):
     def test_energy_channels_skipped_correctly(self):
         """8-byte energy channels should be skipped without breaking power parsing."""
         meter = _create_meter()
-        packet = _build_packet([
-            _build_channel(CHANNEL_L1_POWER_PLUS, 1000),
-            _build_channel(CHANNEL_L1_POWER_MINUS, 0),
-            # 8-byte energy counter interspersed
-            _build_channel(CHANNEL_TOTAL_ENERGY_PLUS, 123456789, length=8),
-            _build_channel(CHANNEL_L2_POWER_PLUS, 2000),
-            _build_channel(CHANNEL_L2_POWER_MINUS, 0),
-            _build_channel(CHANNEL_L1_ENERGY_PLUS, 987654321, length=8),
-            _build_channel(CHANNEL_L3_POWER_PLUS, 3000),
-            _build_channel(CHANNEL_L3_POWER_MINUS, 0),
-        ])
+        packet = _build_packet(
+            [
+                _build_channel(CHANNEL_L1_POWER_PLUS, 1000),
+                _build_channel(CHANNEL_L1_POWER_MINUS, 0),
+                # 8-byte energy counter interspersed
+                _build_channel(CHANNEL_TOTAL_ENERGY_PLUS, 123456789, length=8),
+                _build_channel(CHANNEL_L2_POWER_PLUS, 2000),
+                _build_channel(CHANNEL_L2_POWER_MINUS, 0),
+                _build_channel(CHANNEL_L1_ENERGY_PLUS, 987654321, length=8),
+                _build_channel(CHANNEL_L3_POWER_PLUS, 3000),
+                _build_channel(CHANNEL_L3_POWER_MINUS, 0),
+            ]
+        )
         meter._handle_packet(packet)
         self.assertEqual(meter.get_powermeter_watts(), [100.0, 200.0, 300.0])
 
     def test_phase_data_preferred_over_total(self):
         """When both phase and total data present, phase data is used."""
         meter = _create_meter()
-        packet = _build_packet([
-            _build_channel(CHANNEL_TOTAL_POWER_PLUS, 6000),
-            _build_channel(CHANNEL_TOTAL_POWER_MINUS, 0),
-            _build_channel(CHANNEL_L1_POWER_PLUS, 1000),
-            _build_channel(CHANNEL_L1_POWER_MINUS, 0),
-            _build_channel(CHANNEL_L2_POWER_PLUS, 2000),
-            _build_channel(CHANNEL_L2_POWER_MINUS, 0),
-            _build_channel(CHANNEL_L3_POWER_PLUS, 3000),
-            _build_channel(CHANNEL_L3_POWER_MINUS, 0),
-        ])
+        packet = _build_packet(
+            [
+                _build_channel(CHANNEL_TOTAL_POWER_PLUS, 6000),
+                _build_channel(CHANNEL_TOTAL_POWER_MINUS, 0),
+                _build_channel(CHANNEL_L1_POWER_PLUS, 1000),
+                _build_channel(CHANNEL_L1_POWER_MINUS, 0),
+                _build_channel(CHANNEL_L2_POWER_PLUS, 2000),
+                _build_channel(CHANNEL_L2_POWER_MINUS, 0),
+                _build_channel(CHANNEL_L3_POWER_PLUS, 3000),
+                _build_channel(CHANNEL_L3_POWER_MINUS, 0),
+            ]
+        )
         meter._handle_packet(packet)
         result = meter.get_powermeter_watts()
         self.assertEqual(len(result), 3)
@@ -264,11 +279,13 @@ class TestHandlePacket(unittest.TestCase):
 
     def test_software_version_channel_skipped(self):
         meter = _create_meter()
-        packet = _build_packet([
-            _build_channel(CHANNEL_SOFTWARE_VERSION, 0x01020304),
-            _build_channel(CHANNEL_TOTAL_POWER_PLUS, 5000),
-            _build_channel(CHANNEL_TOTAL_POWER_MINUS, 0),
-        ])
+        packet = _build_packet(
+            [
+                _build_channel(CHANNEL_SOFTWARE_VERSION, 0x01020304),
+                _build_channel(CHANNEL_TOTAL_POWER_PLUS, 5000),
+                _build_channel(CHANNEL_TOTAL_POWER_MINUS, 0),
+            ]
+        )
         meter._handle_packet(packet)
         self.assertEqual(meter.get_powermeter_watts(), [500.0])
 

--- a/powermeter/sma_energy_meter_test.py
+++ b/powermeter/sma_energy_meter_test.py
@@ -1,0 +1,314 @@
+import struct
+import sys
+import types
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Avoid circular import by pre-populating config.logger if needed
+if "config" not in sys.modules:
+    config_mod = types.ModuleType("config")
+    config_mod.logger = types.ModuleType("config.logger")
+    config_mod.logger.logger = MagicMock()
+    sys.modules["config"] = config_mod
+    sys.modules["config.logger"] = config_mod.logger
+
+from powermeter.sma_energy_meter import (
+    SmaEnergyMeter,
+    _get_channel_data_length,
+    CHANNEL_TOTAL_POWER_PLUS,
+    CHANNEL_TOTAL_POWER_MINUS,
+    CHANNEL_L1_POWER_PLUS,
+    CHANNEL_L1_POWER_MINUS,
+    CHANNEL_L2_POWER_PLUS,
+    CHANNEL_L2_POWER_MINUS,
+    CHANNEL_L3_POWER_PLUS,
+    CHANNEL_L3_POWER_MINUS,
+    CHANNEL_END,
+    CHANNEL_SOFTWARE_VERSION,
+    SMA_SUSY_IDS,
+)
+
+# Energy counter channels (8 bytes)
+CHANNEL_TOTAL_ENERGY_PLUS = 0x00010800
+CHANNEL_L1_ENERGY_PLUS = 0x00150800
+
+
+def _build_header(susy_id=349, serial=3000012345, protocol_id=0x6069):
+    """Build a valid SMA Speedwire header (28 bytes)."""
+    header = bytearray(28)
+    # Magic "SMA\0"
+    header[0:4] = b"SMA\x00"
+    # Tag42: length word with bytes[5]=0x04, bytes[6]=0x02
+    header[4] = 0x00
+    header[5] = 0x04
+    header[6] = 0x02
+    header[7] = 0x00
+    # Default channel (bytes 8-11)
+    struct.pack_into(">I", header, 8, 1)
+    # Padding (bytes 12-15)
+    # Protocol ID (bytes 16-17)
+    struct.pack_into(">H", header, 16, protocol_id)
+    # SUSY ID (bytes 18-19)
+    struct.pack_into(">H", header, 18, susy_id)
+    # Serial number (bytes 20-23)
+    struct.pack_into(">I", header, 20, serial)
+    # Measuring time (bytes 24-27)
+    struct.pack_into(">I", header, 24, 0)
+    return bytes(header)
+
+
+def _build_channel(identifier, value, length=4):
+    """Build an OBIS channel entry (4-byte identifier + value)."""
+    data = struct.pack(">I", identifier)
+    if length == 4:
+        data += struct.pack(">I", value)
+    elif length == 8:
+        data += struct.pack(">Q", value)
+    return data
+
+
+def _build_end_marker():
+    return struct.pack(">I", CHANNEL_END)
+
+
+def _build_packet(channels, susy_id=349, serial=3000012345, protocol_id=0x6069):
+    """Build a complete SMA Speedwire packet."""
+    header = _build_header(susy_id=susy_id, serial=serial, protocol_id=protocol_id)
+    body = b""
+    for ch in channels:
+        body += ch
+    body += _build_end_marker()
+    return header + body
+
+
+def _create_meter(**kwargs):
+    """Create an SmaEnergyMeter without starting the listener thread."""
+    with patch("powermeter.sma_energy_meter.threading.Thread"):
+        return SmaEnergyMeter(**kwargs)
+
+
+class TestGetChannelDataLength(unittest.TestCase):
+    def test_type_04_returns_4(self):
+        self.assertEqual(_get_channel_data_length(0x00010400), 4)
+
+    def test_type_08_returns_8(self):
+        self.assertEqual(_get_channel_data_length(0x00010800), 8)
+
+    def test_end_marker_returns_0(self):
+        self.assertEqual(_get_channel_data_length(CHANNEL_END), 0)
+
+    def test_software_version_returns_4(self):
+        self.assertEqual(_get_channel_data_length(CHANNEL_SOFTWARE_VERSION), 4)
+
+
+class TestHandlePacket(unittest.TestCase):
+    def test_three_phase_consumption(self):
+        meter = _create_meter()
+        packet = _build_packet([
+            _build_channel(CHANNEL_L1_POWER_PLUS, 1000),  # 100.0 W
+            _build_channel(CHANNEL_L1_POWER_MINUS, 0),
+            _build_channel(CHANNEL_L2_POWER_PLUS, 2000),  # 200.0 W
+            _build_channel(CHANNEL_L2_POWER_MINUS, 0),
+            _build_channel(CHANNEL_L3_POWER_PLUS, 3000),  # 300.0 W
+            _build_channel(CHANNEL_L3_POWER_MINUS, 0),
+        ])
+        meter._handle_packet(packet)
+        self.assertEqual(meter.get_powermeter_watts(), [100.0, 200.0, 300.0])
+
+    def test_three_phase_net_power(self):
+        meter = _create_meter()
+        packet = _build_packet([
+            _build_channel(CHANNEL_L1_POWER_PLUS, 1500),   # 150.0 W
+            _build_channel(CHANNEL_L1_POWER_MINUS, 500),   #  50.0 W
+            _build_channel(CHANNEL_L2_POWER_PLUS, 0),
+            _build_channel(CHANNEL_L2_POWER_MINUS, 2000),  # -200.0 W
+            _build_channel(CHANNEL_L3_POWER_PLUS, 1000),
+            _build_channel(CHANNEL_L3_POWER_MINUS, 1000),  # 0.0 W
+        ])
+        meter._handle_packet(packet)
+        result = meter.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 100.0)
+        self.assertAlmostEqual(result[1], -200.0)
+        self.assertAlmostEqual(result[2], 0.0)
+
+    def test_total_only_fallback(self):
+        meter = _create_meter()
+        packet = _build_packet([
+            _build_channel(CHANNEL_TOTAL_POWER_PLUS, 5000),   # 500.0 W
+            _build_channel(CHANNEL_TOTAL_POWER_MINUS, 0),
+        ])
+        meter._handle_packet(packet)
+        self.assertEqual(meter.get_powermeter_watts(), [500.0])
+
+    def test_total_net_production(self):
+        meter = _create_meter()
+        packet = _build_packet([
+            _build_channel(CHANNEL_TOTAL_POWER_PLUS, 100),
+            _build_channel(CHANNEL_TOTAL_POWER_MINUS, 3000),
+        ])
+        meter._handle_packet(packet)
+        result = meter.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], -290.0)
+
+    def test_invalid_magic_ignored(self):
+        meter = _create_meter()
+        packet = b"XYZ\x00" + b"\x00" * 24
+        meter._handle_packet(packet)
+        self.assertIsNone(meter.values)
+
+    def test_invalid_tag42_ignored(self):
+        meter = _create_meter()
+        packet = bytearray(_build_header())
+        packet[5] = 0x00
+        packet[6] = 0x00
+        packet += _build_end_marker()
+        meter._handle_packet(bytes(packet))
+        self.assertIsNone(meter.values)
+
+    def test_wrong_protocol_id_ignored(self):
+        meter = _create_meter()
+        packet = _build_packet(
+            [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000)],
+            protocol_id=0x6065,  # inverter, not energy meter
+        )
+        meter._handle_packet(packet)
+        self.assertIsNone(meter.values)
+
+    def test_too_short_packet_ignored(self):
+        meter = _create_meter()
+        meter._handle_packet(b"SMA\x00" + b"\x00" * 10)
+        self.assertIsNone(meter.values)
+
+    def test_serial_filter_match(self):
+        meter = _create_meter(serial_number=12345)
+        packet = _build_packet(
+            [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000)],
+            serial=12345,
+        )
+        meter._handle_packet(packet)
+        self.assertEqual(meter.get_powermeter_watts(), [100.0])
+
+    def test_serial_filter_mismatch(self):
+        meter = _create_meter(serial_number=12345)
+        packet = _build_packet(
+            [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000)],
+            serial=99999,
+        )
+        meter._handle_packet(packet)
+        self.assertIsNone(meter.values)
+
+    def test_auto_detect_locks_serial(self):
+        meter = _create_meter()
+        # First packet from meter with serial 11111
+        packet1 = _build_packet(
+            [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000)],
+            serial=11111, susy_id=349,
+        )
+        meter._handle_packet(packet1)
+        self.assertEqual(meter._detected_serial, 11111)
+        self.assertEqual(meter.get_powermeter_watts(), [100.0])
+
+        # Second packet from different serial should be ignored
+        packet2 = _build_packet(
+            [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 9999)],
+            serial=22222, susy_id=349,
+        )
+        meter._handle_packet(packet2)
+        # Should still have old value
+        self.assertEqual(meter.get_powermeter_watts(), [100.0])
+
+    def test_auto_detect_rejects_unknown_susy_id(self):
+        meter = _create_meter()
+        packet = _build_packet(
+            [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000)],
+            serial=11111, susy_id=999,
+        )
+        meter._handle_packet(packet)
+        self.assertIsNone(meter._detected_serial)
+        self.assertIsNone(meter.values)
+
+    def test_energy_channels_skipped_correctly(self):
+        """8-byte energy channels should be skipped without breaking power parsing."""
+        meter = _create_meter()
+        packet = _build_packet([
+            _build_channel(CHANNEL_L1_POWER_PLUS, 1000),
+            _build_channel(CHANNEL_L1_POWER_MINUS, 0),
+            # 8-byte energy counter interspersed
+            _build_channel(CHANNEL_TOTAL_ENERGY_PLUS, 123456789, length=8),
+            _build_channel(CHANNEL_L2_POWER_PLUS, 2000),
+            _build_channel(CHANNEL_L2_POWER_MINUS, 0),
+            _build_channel(CHANNEL_L1_ENERGY_PLUS, 987654321, length=8),
+            _build_channel(CHANNEL_L3_POWER_PLUS, 3000),
+            _build_channel(CHANNEL_L3_POWER_MINUS, 0),
+        ])
+        meter._handle_packet(packet)
+        self.assertEqual(meter.get_powermeter_watts(), [100.0, 200.0, 300.0])
+
+    def test_phase_data_preferred_over_total(self):
+        """When both phase and total data present, phase data is used."""
+        meter = _create_meter()
+        packet = _build_packet([
+            _build_channel(CHANNEL_TOTAL_POWER_PLUS, 6000),
+            _build_channel(CHANNEL_TOTAL_POWER_MINUS, 0),
+            _build_channel(CHANNEL_L1_POWER_PLUS, 1000),
+            _build_channel(CHANNEL_L1_POWER_MINUS, 0),
+            _build_channel(CHANNEL_L2_POWER_PLUS, 2000),
+            _build_channel(CHANNEL_L2_POWER_MINUS, 0),
+            _build_channel(CHANNEL_L3_POWER_PLUS, 3000),
+            _build_channel(CHANNEL_L3_POWER_MINUS, 0),
+        ])
+        meter._handle_packet(packet)
+        result = meter.get_powermeter_watts()
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result, [100.0, 200.0, 300.0])
+
+    def test_software_version_channel_skipped(self):
+        meter = _create_meter()
+        packet = _build_packet([
+            _build_channel(CHANNEL_SOFTWARE_VERSION, 0x01020304),
+            _build_channel(CHANNEL_TOTAL_POWER_PLUS, 5000),
+            _build_channel(CHANNEL_TOTAL_POWER_MINUS, 0),
+        ])
+        meter._handle_packet(packet)
+        self.assertEqual(meter.get_powermeter_watts(), [500.0])
+
+
+class TestGetPowermeterWatts(unittest.TestCase):
+    def test_no_data_raises(self):
+        meter = _create_meter()
+        with self.assertRaises(ValueError):
+            meter.get_powermeter_watts()
+
+    def test_returns_copy(self):
+        meter = _create_meter()
+        meter.values = [100.0, 200.0, 300.0]
+        result = meter.get_powermeter_watts()
+        result[0] = 999
+        self.assertEqual(meter.values[0], 100.0)
+
+
+class TestWaitForMessage(unittest.TestCase):
+    def test_timeout_raises(self):
+        meter = _create_meter()
+        with self.assertRaises(TimeoutError):
+            meter.wait_for_message(timeout=0)
+
+    def test_returns_when_data_available(self):
+        meter = _create_meter()
+        meter.values = [100.0]
+        meter.wait_for_message(timeout=1)
+
+
+class TestDeviceNames(unittest.TestCase):
+    def test_known_susy_ids(self):
+        self.assertEqual(SMA_SUSY_IDS[270], "SMA Energy Meter 1.0")
+        self.assertEqual(SMA_SUSY_IDS[349], "SMA Energy Meter 2.0")
+        self.assertEqual(SMA_SUSY_IDS[372], "Sunny Home Manager 2.0")
+        self.assertEqual(SMA_SUSY_IDS[501], "Sunny Home Manager 2.0")
+
+    def test_unknown_susy_id(self):
+        self.assertNotIn(999, SMA_SUSY_IDS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/powermeter/sma_energy_meter_test.py
+++ b/powermeter/sma_energy_meter_test.py
@@ -313,6 +313,7 @@ class TestWaitForMessage(unittest.TestCase):
     def test_returns_when_data_available(self):
         meter = _create_meter()
         meter.values = [100.0]
+        meter._message_event.set()
         meter.wait_for_message(timeout=1)
 
 


### PR DESCRIPTION
## Summary

- Adds `SmaEnergyMeter` powermeter that listens for SMA Speedwire UDP multicast broadcasts (`239.12.255.254:9522`) and parses the binary OBIS protocol to extract per-phase active power
- Supports auto-detection of SMA Energy Meter 1.0/2.0 and Sunny Home Manager 2.0 by SUSY ID, with optional serial number filtering
- Returns 3-phase power `[L1, L2, L3]` when per-phase data is available, falls back to `[total]`
- No external dependencies — uses only Python stdlib (`socket`, `struct`, `threading`)

## Configuration

```ini
[SMA_ENERGY_METER]
MULTICAST_GROUP = 239.12.255.254
PORT = 9522
SERIAL_NUMBER = 0
INTERFACE =
```

## Test plan

- [x] 25 unit tests covering packet parsing, serial filtering, auto-detection, edge cases
- [x] All existing tests pass (no regressions)
- [ ] Manual test with real SMA Energy Meter hardware

https://claude.ai/code/session_0199nFJ7dSNQ9edQ5cvv25LV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SMA Energy Meter / Sunny Home Manager via Speedwire UDP multicast with configurable multicast group, UDP port, interface binding, and optional serial-number selection (auto-detect when unset).
  * Per-meter throttle-interval override supported.
* **Tests**
  * Added unit tests covering packet parsing, serial auto-detection/latching, filtering, and public APIs.
* **Documentation**
  * Updated example configuration and changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->