### PR TITLE
Add timestamps to log lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed Modbus `UNIT_ID` handling and clarified Home Assistant entity ID configuration in the docs ([#191](https://github.com/tomquist/b2500-meter/pull/191), [#195](https://github.com/tomquist/b2500-meter/pull/195))
 - CI-built container images embed **`GIT_COMMIT_SHA`**; startup logs the git commit and `/health` JSON includes **`git_commit`** when set
 - **Developer tooling:** Python **3.10+**; **uv** + **pyproject.toml** replace Pipenv; application code lives under **src/b2500_meter/**; **ruff**, **mypy**, and **pytest** (see [CONTRIBUTING.md](CONTRIBUTING.md)); CLI entry point **`b2500-meter`**; Docker and Home Assistant add-on images install the wheel and use the same command instead of `python main.py`.
+- Added timestamps to application log lines and aligned the logger regression test with the current `logging.basicConfig` setup ([#260](https://github.com/tomquist/b2500-meter/pull/260))
 
 ### Breaking
 - The Home Assistant add-on no longer publishes images for 32-bit ARM (`armhf` / `armv7`). Installations must use a 64-bit Home Assistant OS or supervisor environment (`amd64` or `aarch64`), consistent with Home Assistant dropping 32-bit support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fixed Modbus `UNIT_ID` handling and clarified Home Assistant entity ID configuration in the docs ([#191](https://github.com/tomquist/b2500-meter/pull/191), [#195](https://github.com/tomquist/b2500-meter/pull/195))
 - CI-built container images embed **`GIT_COMMIT_SHA`**; startup logs the git commit and `/health` JSON includes **`git_commit`** when set
 - **Developer tooling:** Python **3.10+**; **uv** + **pyproject.toml** replace Pipenv; application code lives under **src/b2500_meter/**; **ruff**, **mypy**, and **pytest** (see [CONTRIBUTING.md](CONTRIBUTING.md)); CLI entry point **`b2500-meter`**; Docker and Home Assistant add-on images install the wheel and use the same command instead of `python main.py`.
-- Added timestamps to application log lines and aligned the logger regression test with the current `logging.basicConfig` setup ([#260](https://github.com/tomquist/b2500-meter/pull/260))
+- Added timestamps to application log lines ([#260](https://github.com/tomquist/b2500-meter/pull/260))
 
 ### Breaking
 - The Home Assistant add-on no longer publishes images for 32-bit ARM (`armhf` / `armv7`). Installations must use a 64-bit Home Assistant OS or supervisor environment (`amd64` or `aarch64`), consistent with Home Assistant dropping 32-bit support.

--- a/src/b2500_meter/config/logger.py
+++ b/src/b2500_meter/config/logger.py
@@ -5,7 +5,12 @@ def setLogLevel(inLevel: str):
     level = levels.get(inLevel.lower())
     if level is None:
         level = logging.WARNING
-    logging.basicConfig(level=level)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        force=True,
+    )
 
 
 levels = {

--- a/src/b2500_meter/config/logger_test.py
+++ b/src/b2500_meter/config/logger_test.py
@@ -1,0 +1,16 @@
+import logging
+
+from b2500_meter.config.logger import setLogLevel
+
+
+def test_set_log_level_uses_timestamped_format():
+    setLogLevel("info")
+
+    root = logging.getLogger()
+    assert root.level == logging.INFO
+    assert root.handlers
+
+    formatter = root.handlers[0].formatter
+    assert formatter is not None
+    assert formatter._fmt == "%(asctime)s %(levelname)s:%(name)s:%(message)s"
+    assert formatter.datefmt == "%Y-%m-%d %H:%M:%S"

--- a/src/b2500_meter/config/logger_test.py
+++ b/src/b2500_meter/config/logger_test.py
@@ -1,20 +1,49 @@
 import importlib
 import logging
+import re
 from unittest.mock import patch
+
+import pytest
 
 from b2500_meter.config.logger import setLogLevel
 
 logger_module = importlib.import_module("b2500_meter.config.logger")
 
 
-def test_set_log_level_uses_timestamped_format():
+@pytest.mark.parametrize(
+    ("level_name", "expected_level"),
+    [("info", logging.INFO), ("debug", logging.DEBUG), ("invalid", logging.WARNING)],
+)
+def test_set_log_level_configures_expected_level(level_name, expected_level):
+    with patch.object(logger_module.logging, "basicConfig") as basic_config:
+        setLogLevel(level_name)
+
+    basic_config.assert_called_once()
+    assert basic_config.call_args.kwargs["level"] == expected_level
+
+
+def test_set_log_level_configures_timestamped_log_output():
     with patch.object(logger_module.logging, "basicConfig") as basic_config:
         setLogLevel("info")
 
     basic_config.assert_called_once()
-    assert basic_config.call_args.kwargs == {
-        "level": logging.INFO,
-        "format": "%(asctime)s %(levelname)s:%(name)s:%(message)s",
-        "datefmt": "%Y-%m-%d %H:%M:%S",
-        "force": True,
-    }
+    kwargs = basic_config.call_args.kwargs
+
+    formatter = logging.Formatter(kwargs["format"], kwargs["datefmt"])
+    record = logging.LogRecord(
+        name="b2500-meter",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=(),
+        exc_info=None,
+    )
+    record.created = 0
+
+    formatted = formatter.format(record)
+    assert re.fullmatch(
+        r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} INFO:b2500-meter:hello",
+        formatted,
+    )
+    assert kwargs["force"] is True

--- a/src/b2500_meter/config/logger_test.py
+++ b/src/b2500_meter/config/logger_test.py
@@ -1,16 +1,16 @@
 import logging
+from unittest.mock import patch
 
 from b2500_meter.config.logger import setLogLevel
 
 
 def test_set_log_level_uses_timestamped_format():
-    setLogLevel("info")
+    with patch("logging.basicConfig") as basic_config:
+        setLogLevel("info")
 
-    root = logging.getLogger()
-    assert root.level == logging.INFO
-    assert root.handlers
-
-    formatter = root.handlers[0].formatter
-    assert formatter is not None
-    assert formatter._fmt == "%(asctime)s %(levelname)s:%(name)s:%(message)s"
-    assert formatter.datefmt == "%Y-%m-%d %H:%M:%S"
+    basic_config.assert_called_once_with(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        force=True,
+    )

--- a/src/b2500_meter/config/logger_test.py
+++ b/src/b2500_meter/config/logger_test.py
@@ -4,13 +4,14 @@ from unittest.mock import patch
 from b2500_meter.config.logger import setLogLevel
 
 
-def test_set_log_level_uses_timestamped_format():
-    with patch("logging.basicConfig") as basic_config:
-        setLogLevel("info")
+@patch("b2500_meter.config.logger.logging.basicConfig")
+def test_set_log_level_uses_timestamped_format(basic_config):
+    setLogLevel("info")
 
-    basic_config.assert_called_once_with(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-        force=True,
-    )
+    basic_config.assert_called_once()
+    assert basic_config.call_args.kwargs == {
+        "level": logging.INFO,
+        "format": "%(asctime)s %(levelname)s:%(name)s:%(message)s",
+        "datefmt": "%Y-%m-%d %H:%M:%S",
+        "force": True,
+    }

--- a/src/b2500_meter/config/logger_test.py
+++ b/src/b2500_meter/config/logger_test.py
@@ -1,12 +1,15 @@
+import importlib
 import logging
 from unittest.mock import patch
 
 from b2500_meter.config.logger import setLogLevel
 
+logger_module = importlib.import_module("b2500_meter.config.logger")
 
-@patch("b2500_meter.config.logger.logging.basicConfig")
-def test_set_log_level_uses_timestamped_format(basic_config):
-    setLogLevel("info")
+
+def test_set_log_level_uses_timestamped_format():
+    with patch.object(logger_module.logging, "basicConfig") as basic_config:
+        setLogLevel("info")
 
     basic_config.assert_called_once()
     assert basic_config.call_args.kwargs == {


### PR DESCRIPTION
## Summary
- add timestamps to application log lines
- keep existing log level behavior intact
- add a regression test for the logger format and date format

## Testing
- uv run pytest -q src/b2500_meter/config/logger_test.py src/b2500_meter/config/config_loader_test.py

Fixes #247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced logging configuration to include structured message formatting with timestamps, log level indicators, logger names, and complete message details. Logging now includes explicit time format (YYYY-MM-DD HH:MM:SS) and enforces overrides of any existing logging settings.

* **Tests**
  * Added unit test coverage for logging configuration to validate proper initialization, format specification, and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->