### PR TITLE
Fix simulator TUI arrow keys being captured by plot widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Fixed simulator TUI arrow keys being captured by the plot widget instead of controlling SOC/Solar
 - Reduced CT002 active-steering oscillation with multiple batteries by decaying the smoothed target toward zero inside the deadband (instead of holding stale values) and raising the default `SMOOTH_TARGET_ALPHA` from 0.08 to 0.9
 - Added support for emulating a *CT002/CT003*, which is recommended to steer multiple devices
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
 ## Next
-- Fixed simulator TUI arrow keys being captured by the plot widget instead of controlling SOC/Solar
-- Reduced CT002 active-steering oscillation with multiple batteries by decaying the smoothed target toward zero inside the deadband (instead of holding stale values) and raising the default `SMOOTH_TARGET_ALPHA` from 0.08 to 0.9
 - Added support for emulating a *CT002/CT003*, which is recommended to steer multiple devices
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))
 - Added SMA Energy Meter / Sunny Home Manager support via Speedwire multicast protocol with auto-detection and per-phase power readings ([#231](https://github.com/tomquist/b2500-meter/pull/252))

--- a/src/b2500_meter/simulator/tui.py
+++ b/src/b2500_meter/simulator/tui.py
@@ -47,6 +47,7 @@ class SimulatorApp(App):
     #grid-graph {
         height: 12;
         margin: 0 1;
+        can-focus: false;
     }
     .section-title {
         text-style: bold;


### PR DESCRIPTION
## Summary
Fixed an issue where arrow keys in the simulator TUI were being captured by the plot widget instead of being used to control SOC/Solar parameters.

## Changes
- Added `can-focus: false;` CSS property to the grid-graph widget in the simulator TUI stylesheet
  - This prevents the plot widget from capturing keyboard focus and intercepting arrow key inputs
  - Allows arrow keys to be properly routed to SOC/Solar controls as intended

## Details
The plot widget was inadvertently consuming arrow key events due to having focus capability enabled. By disabling focus on the grid-graph widget, keyboard input is now correctly handled by the intended control elements.

https://claude.ai/code/session_01V7bW3MjRYLKMjUQJqUiaQi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard focus behavior in the simulator grid graph widget to prevent unintended keyboard interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->