### PR TITLE
Migrate from threading to asyncio for UDP servers and health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## Next
-- Migrated core application loop, CT002/Shelly device servers, and health service from threads to asyncio; powermeter interface supports gradual async migration via `get_powermeter_watts_async()`
 - Added support for emulating a *CT002/CT003*, which is recommended to steer multiple devices
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))
 - Added SMA Energy Meter / Sunny Home Manager support via Speedwire multicast protocol with auto-detection and per-phase power readings ([#231](https://github.com/tomquist/b2500-meter/pull/252))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Migrated core application loop, CT002/Shelly device servers, and health service from threads to asyncio; powermeter interface supports gradual async migration via `get_powermeter_watts_async()`
 - Added support for emulating a *CT002/CT003*, which is recommended to steer multiple devices
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))
 - Added SMA Energy Meter / Sunny Home Manager support via Speedwire multicast protocol with auto-detection and per-phase power readings ([#231](https://github.com/tomquist/b2500-meter/pull/252))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "GPL-3.0-or-later" }
 dependencies = [
+    "aiohttp>=3.9.0",
     "requests",
     "urllib3",
     "paho-mqtt",
@@ -25,6 +26,7 @@ dev = [
     "ruff>=0.8.0",
     "pytest>=8.0.0",
     "pytest-cov>=5.0.0",
+    "pytest-asyncio>=0.23.0",
     "mypy>=1.13.0",
 ]
 sim = [
@@ -44,6 +46,7 @@ packages = ["src/b2500_meter"]
 testpaths = ["tests", "src"]
 python_files = ["test_*.py", "*_test.py"]
 addopts = "-ra -q"
+asyncio_mode = "auto"
 
 [tool.ruff]
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dev = [
     "mypy>=1.13.0",
 ]
 sim = [
-    "aiohttp>=3.9.0",
     "textual>=1.0.0",
     "textual-plot>=0.10.1",
 ]

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import time
+from collections.abc import Awaitable, Callable
 
 from b2500_meter.config.logger import logger
 
@@ -119,7 +122,7 @@ def parse_request(data):
 
 
 class _CT002Protocol(asyncio.DatagramProtocol):
-    def __init__(self, ct002: "CT002"):
+    def __init__(self, ct002: CT002):
         self.ct002 = ct002
         self._tasks: set[asyncio.Task] = set()
 
@@ -182,7 +185,9 @@ class CT002:
         self.saturation_detection = saturation_detection
         self.saturation_alpha = max(0.01, min(1.0, saturation_alpha))
         self.min_target_for_saturation = max(1, min_target_for_saturation)
-        self.before_send = None
+        self.before_send: (
+            Callable[[tuple, list, str], Awaitable[list[float] | None]] | None
+        ) = None
         self._info_idx_counter = 0
         self._values_by_consumer = {}
         self._reports_by_consumer = {}

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -1,6 +1,5 @@
-import inspect
-import socket
-import threading
+import asyncio
+import contextlib
 import time
 
 from b2500_meter.config.logger import logger
@@ -119,6 +118,22 @@ def parse_request(data):
     return fields, None
 
 
+class _CT002Protocol(asyncio.DatagramProtocol):
+    def __init__(self, ct002: "CT002"):
+        self.ct002 = ct002
+        self._tasks: set[asyncio.Task] = set()
+
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def datagram_received(self, data, addr):
+        task = asyncio.create_task(
+            self.ct002._safe_handle_request(data, addr, self.transport)
+        )
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+
 class CT002:
     def __init__(
         self,
@@ -169,16 +184,18 @@ class CT002:
         self.min_target_for_saturation = max(1, min_target_for_saturation)
         self.before_send = None
         self._info_idx_counter = 0
-        self._stop = False
-        self._udp_thread = None
         self._values_by_consumer = {}
         self._reports_by_consumer = {}
         self._last_target_by_consumer = {}
         self._saturation_by_consumer = {}
-        self._values_lock = threading.Lock()
-        self._last_response_time = {}
+        self._last_response_time: dict[tuple, float] = {}
         self._smoothed_target = None
         self._last_smooth_sample = None
+        self._transport = None
+        self._protocol = None
+        self._cleanup_task = None
+        self._stopped = asyncio.Event()
+        self._request_lock = asyncio.Lock()
 
     def _consumer_key(self, addr, fields):
         battery_mac = fields[1] if len(fields) > 1 else ""
@@ -187,24 +204,20 @@ class CT002:
         return f"{addr[0]}:{addr[1]}"
 
     def set_consumer_value(self, consumer_id, values):
-        with self._values_lock:
-            self._values_by_consumer[consumer_id] = values
+        self._values_by_consumer[consumer_id] = values
 
     def _get_consumer_value(self, consumer_id):
-        with self._values_lock:
-            return self._values_by_consumer.get(consumer_id)
+        return self._values_by_consumer.get(consumer_id)
 
     def _update_consumer_report(self, consumer_id, phase, power):
         normalized_phase = str(phase).upper() if phase else "A"
-        previous_phase = None
-        with self._values_lock:
-            previous = self._reports_by_consumer.get(consumer_id, {})
-            previous_phase = previous.get("phase")
-            self._reports_by_consumer[consumer_id] = {
-                "phase": normalized_phase,
-                "power": parse_int(power, 0),
-                "timestamp": time.time(),
-            }
+        previous = self._reports_by_consumer.get(consumer_id, {})
+        previous_phase = previous.get("phase")
+        self._reports_by_consumer[consumer_id] = {
+            "phase": normalized_phase,
+            "power": parse_int(power, 0),
+            "timestamp": time.time(),
+        }
 
         if normalized_phase in ("A", "B", "C") and previous_phase != normalized_phase:
             if previous_phase in ("A", "B", "C"):
@@ -223,17 +236,16 @@ class CT002:
 
     def _cleanup_consumers(self):
         now = time.time()
-        with self._values_lock:
-            stale = [
-                key
-                for key, report in self._reports_by_consumer.items()
-                if now - report.get("timestamp", 0) > self.consumer_ttl
-            ]
-            for key in stale:
-                self._reports_by_consumer.pop(key, None)
-                self._values_by_consumer.pop(key, None)
-                self._last_target_by_consumer.pop(key, None)
-                self._saturation_by_consumer.pop(key, None)
+        stale = [
+            key
+            for key, report in self._reports_by_consumer.items()
+            if now - report.get("timestamp", 0) > self.consumer_ttl
+        ]
+        for key in stale:
+            self._reports_by_consumer.pop(key, None)
+            self._values_by_consumer.pop(key, None)
+            self._last_target_by_consumer.pop(key, None)
+            self._saturation_by_consumer.pop(key, None)
         stale_addrs = [
             addr
             for addr, ts in self._last_response_time.items()
@@ -257,11 +269,10 @@ class CT002:
         follow_ratio = min(1.0, abs(actual) / target_abs)
         inst_saturation = 1.0 - follow_ratio
         alpha = self.saturation_alpha
-        with self._values_lock:
-            prev = self._saturation_by_consumer.get(consumer_id, 0.0)
-            self._saturation_by_consumer[consumer_id] = (
-                alpha * inst_saturation + (1 - alpha) * prev
-            )
+        prev = self._saturation_by_consumer.get(consumer_id, 0.0)
+        self._saturation_by_consumer[consumer_id] = (
+            alpha * inst_saturation + (1 - alpha) * prev
+        )
 
     def _compute_smooth_target(self, values, consumer_id=None):
         """
@@ -286,15 +297,8 @@ class CT002:
         elif sample_id != self._last_smooth_sample:
             self._last_smooth_sample = sample_id
             if self.deadband > 0 and abs(raw_total) < self.deadband:
-                # Within deadband: decay toward zero to avoid locking in
-                # stale targets (the battery's integral controller would
-                # otherwise keep integrating a non-zero smoothed value
-                # even though the grid is balanced).
                 delta = -alpha * self._smoothed_target
             else:
-                # When meter and smoothed cross zero, catch up faster to
-                # avoid sending wrong-sign target (e.g. 0 when we need
-                # discharge)
                 catchup_alpha = alpha
                 if (raw_total > 0) != (self._smoothed_target > 0):
                     catchup_alpha = min(0.5, alpha * 4)
@@ -305,15 +309,16 @@ class CT002:
                     min(self.max_smooth_step, delta),
                 )
             self._smoothed_target += delta
-        with self._values_lock:
-            reports = dict(self._reports_by_consumer)
-            last_target = self._last_target_by_consumer.get(consumer_id)
-            saturation = dict(self._saturation_by_consumer)
+
+        reports = dict(self._reports_by_consumer)
+        last_target = self._last_target_by_consumer.get(consumer_id)
+        saturation = dict(self._saturation_by_consumer)
+
         if consumer_id and consumer_id in reports:
             actual_self = parse_int(reports.get(consumer_id, {}).get("power", 0))
             self._update_saturation(consumer_id, last_target, actual_self)
-        with self._values_lock:
-            saturation = dict(self._saturation_by_consumer)
+
+        saturation = dict(self._saturation_by_consumer)
         num_consumers = max(1, len(reports))
         eff_part = {cid: max(0.01, 1.0 - saturation.get(cid, 0.0)) for cid in reports}
         total_effective = sum(eff_part.values())
@@ -374,9 +379,9 @@ class CT002:
         # charge during import, worsening overshoot)
         if (raw_total < 0 and target > 0) or (raw_total > 0 and target < 0):
             target = 0
-        with self._values_lock:
-            if consumer_id:
-                self._last_target_by_consumer[consumer_id] = target
+
+        if consumer_id:
+            self._last_target_by_consumer[consumer_id] = target
 
         # Distribute target across phases according to active consumer phase mapping.
         phase_effective = {"A": 0.0, "B": 0.0, "C": 0.0}
@@ -402,8 +407,7 @@ class CT002:
             "B": {"chrg_power": 0, "dchrg_power": 0, "active": False},
             "C": {"chrg_power": 0, "dchrg_power": 0, "active": False},
         }
-        with self._values_lock:
-            reports = list(self._reports_by_consumer.items())
+        reports = list(self._reports_by_consumer.items())
 
         for _consumer_id, report in reports:
             phase = (report.get("phase") or "A").upper()
@@ -433,8 +437,7 @@ class CT002:
         phases = " ".join(f"{p}:{int(v)}W" for p, v in zip("ABC", values, strict=False))
         chrg = " ".join(f"{p}:{phase_values[p]['chrg_power']}" for p in "ABC")
         dchrg = " ".join(f"{p}:{phase_values[p]['dchrg_power']}" for p in "ABC")
-        with self._values_lock:
-            reports = list(self._reports_by_consumer.items())
+        reports = list(self._reports_by_consumer.items())
         consumers = (
             " ".join(
                 f"{cid[:8]}@{r.get('phase', '?')}:{r.get('power', 0)}"
@@ -492,10 +495,6 @@ class CT002:
             "0",  # x/A/B/C/ABC_dchrg_power
         ]
 
-        # Forward A/B/C values across all known consumers, but split per-storage
-        # by sign before aggregation:
-        # negative reports contribute to *_chrg_power,
-        # positive reports contribute to *_dchrg_power.
         phase_values = self._collect_reports_by_phase()
         for phase, idx in (("A", 0), ("B", 1), ("C", 2)):
             if phase_values[phase]["active"]:
@@ -507,20 +506,16 @@ class CT002:
         self._info_idx_counter = (self._info_idx_counter + 1) % 256
         return response_fields
 
-    def _call_before_send(self, addr, fields, consumer_id):
+    async def _call_before_send(self, addr, fields, consumer_id):
         if not self.before_send:
             return None
         try:
-            params = inspect.signature(self.before_send).parameters
-            if len(params) >= 3:
-                return self.before_send(addr, fields, consumer_id)
-            return self.before_send(addr)
+            return await self.before_send(addr, fields, consumer_id)
         except Exception as exc:
             logger.warning("before_send failed for %s: %s", addr, exc)
             return None
 
     def _validate_ct_mac(self, request_fields):
-        # If CT_MAC is not configured, accept all request CT MACs.
         if not self.ct_mac:
             return True
         if len(request_fields) < 4:
@@ -530,139 +525,135 @@ class CT002:
             return False
         return req_ct_mac.lower() == self.ct_mac.lower()
 
-    def _handle_request(self, data, addr):
-        logger.debug("CT002 request from %s: %s", addr, data.hex())
-        fields, error = parse_request(data)
-        if error:
-            logger.debug("Invalid CT002 request from %s: %s", addr, error)
-            return None
-        if len(fields) < 4:
-            logger.debug("CT002 request from %s missing required fields", addr)
-            return None
-        if not self._validate_ct_mac(fields):
+    async def _safe_handle_request(self, data, addr, transport):
+        try:
+            await self._handle_request(data, addr, transport)
+        except Exception:
+            logger.exception("Error handling CT002 request from %s", addr)
+
+    async def _handle_request(self, data, addr, transport):
+        async with self._request_lock:
+            logger.debug("CT002 request from %s: %s", addr, data.hex())
+            fields, error = parse_request(data)
+            if error:
+                logger.debug("Invalid CT002 request from %s: %s", addr, error)
+                return
+            if len(fields) < 4:
+                logger.debug("CT002 request from %s missing required fields", addr)
+                return
+            if not self._validate_ct_mac(fields):
+                logger.debug(
+                    "Ignoring CT002 request from %s due to CT MAC mismatch (req=%s, cfg=%s)",
+                    addr,
+                    fields[3] if len(fields) > 3 else None,
+                    self.ct_mac,
+                )
+                return
+            consumer_id = self._consumer_key(addr, fields)
+            reported_phase = (fields[4] if len(fields) > 4 else "").strip().upper()
+            reported_power = parse_int(fields[5] if len(fields) > 5 else 0)
+
+            if reported_phase not in ("A", "B", "C", "0", ""):
+                logger.debug(
+                    "CT002 request from %s has invalid phase '%s'",
+                    addr,
+                    reported_phase,
+                )
+                return
+
+            in_inspection_mode = reported_phase in ("0", "")
+
             logger.debug(
-                "Ignoring CT002 request from %s due to CT MAC mismatch (req=%s, cfg=%s)",
+                "CT002 parsed fields from %s: meter_dev_type=%s meter_mac=%s ct_type=%s ct_mac=%s phase=%s power=%s consumer_id=%s%s",
                 addr,
+                fields[0] if len(fields) > 0 else None,
+                fields[1] if len(fields) > 1 else None,
+                fields[2] if len(fields) > 2 else None,
                 fields[3] if len(fields) > 3 else None,
-                self.ct_mac,
+                reported_phase or "(inspection)",
+                reported_power,
+                consumer_id,
+                " in inspection mode" if in_inspection_mode else "",
             )
-            return None
-        consumer_id = self._consumer_key(addr, fields)
-        reported_phase = (fields[4] if len(fields) > 4 else "").strip().upper()
-        reported_power = parse_int(fields[5] if len(fields) > 5 else 0)
 
-        if reported_phase not in ("A", "B", "C", "0", ""):
+            # Deduplication check
+            current_time = time.time()
+            last_time = self._last_response_time.get(addr)
+            if last_time and (current_time - last_time) < self.dedupe_time_window:
+                logger.debug("Ignoring request from %s due to dedupe window", addr)
+                return
+
+            if not in_inspection_mode:
+                self._update_consumer_report(
+                    consumer_id, phase=reported_phase, power=reported_power
+                )
+
+            updated = await self._call_before_send(addr, fields, consumer_id)
+            if updated is not None:
+                self.set_consumer_value(consumer_id, updated)
+
+            values = self._get_consumer_value(consumer_id)
+            if values is None:
+                values = [0, 0, 0]
+            meter_value = sum(parse_int(v, 0) for v in values)
+            if self.active_control and not in_inspection_mode:
+                values = self._compute_smooth_target(values, consumer_id)
+            try:
+                response_fields = self._build_response_fields(fields, values)
+                response = build_payload(response_fields)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to build CT002 response for %s (%s): %s",
+                    addr,
+                    fields,
+                    exc,
+                )
+                return
             logger.debug(
-                "CT002 request from %s has invalid phase '%s'", addr, reported_phase
+                "CT002 response to %s: %s (fields=%s)",
+                addr,
+                response.hex(),
+                response_fields,
             )
-            return None
+            if self.debug_status:
+                phase_values = self._collect_reports_by_phase()
+                logger.info(
+                    "CT002 status: %s",
+                    self._format_status(values, phase_values, consumer_id, meter_value),
+                )
+            transport.sendto(response, addr)
+            self._last_response_time[addr] = current_time
 
-        in_inspection_mode = reported_phase in ("0", "")
-
-        logger.debug(
-            "CT002 parsed fields from %s: meter_dev_type=%s meter_mac=%s ct_type=%s ct_mac=%s phase=%s power=%s consumer_id=%s%s",
-            addr,
-            fields[0] if len(fields) > 0 else None,
-            fields[1] if len(fields) > 1 else None,
-            fields[2] if len(fields) > 2 else None,
-            fields[3] if len(fields) > 3 else None,
-            reported_phase or "(inspection)",
-            reported_power,
-            consumer_id,
-            " in inspection mode" if in_inspection_mode else "",
-        )
-        if not in_inspection_mode:
-            self._update_consumer_report(
-                consumer_id, phase=reported_phase, power=reported_power
-            )
-
-        updated = self._call_before_send(addr, fields, consumer_id)
-        if updated is not None:
-            self.set_consumer_value(consumer_id, updated)
-
-        values = self._get_consumer_value(consumer_id)
-        if values is None:
-            values = [0, 0, 0]
-        meter_value = sum(parse_int(v, 0) for v in values)
-        if self.active_control and not in_inspection_mode:
-            values = self._compute_smooth_target(values, consumer_id)
+    async def _cleanup_loop(self):
         try:
-            response_fields = self._build_response_fields(fields, values)
-            response = build_payload(response_fields)
-        except Exception as exc:
-            logger.warning(
-                "Failed to build CT002 response for %s (%s): %s", addr, fields, exc
-            )
-            return None
-        logger.debug(
-            "CT002 response to %s: %s (fields=%s)",
-            addr,
-            response.hex(),
-            response_fields,
-        )
-        if self.debug_status:
-            phase_values = self._collect_reports_by_phase()
-            logger.info(
-                "CT002 status: %s",
-                self._format_status(values, phase_values, consumer_id, meter_value),
-            )
-        return response
+            while True:
+                await asyncio.sleep(CLEANUP_INTERVAL_SECONDS)
+                self._cleanup_consumers()
+        except asyncio.CancelledError:
+            pass
 
-    def udp_server(self):
-        udp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        udp_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        udp_sock.bind(("", self.udp_port))
-        udp_sock.settimeout(1.0)
+    async def start(self):
+        loop = asyncio.get_running_loop()
+        transport, protocol = await loop.create_datagram_endpoint(
+            lambda: _CT002Protocol(self),
+            local_addr=("0.0.0.0", self.udp_port),
+        )
+        self._transport = transport
+        self._protocol = protocol
+        self._stopped.clear()
+        self._cleanup_task = asyncio.create_task(self._cleanup_loop())
         logger.info("CT002 UDP server listening on port %s", self.udp_port)
-        last_cleanup = time.time()
-        try:
-            while not self._stop:
-                now = time.time()
-                if now - last_cleanup >= CLEANUP_INTERVAL_SECONDS:
-                    self._cleanup_consumers()
-                    last_cleanup = now
-                try:
-                    data, addr = udp_sock.recvfrom(1024)
-                except TimeoutError:
-                    continue
-                current_time = time.time()
-                last_time = self._last_response_time.get(addr)
-                if last_time and (current_time - last_time) < self.dedupe_time_window:
-                    logger.debug("Ignoring request from %s due to dedupe window", addr)
-                    continue
-                response = self._handle_request(data, addr)
-                if response:
-                    for attempt in range(3):
-                        try:
-                            udp_sock.sendto(response, addr)
-                            self._last_response_time[addr] = current_time
-                            break
-                        except OSError as e:
-                            if attempt < 2:
-                                time.sleep(0.05 * (attempt + 1))
-                            else:
-                                logger.info(
-                                    "Could not send response to %s after %d attempts: %s",
-                                    addr,
-                                    attempt + 1,
-                                    e,
-                                )
-        finally:
-            udp_sock.close()
 
-    def start(self):
-        if self._udp_thread and self._udp_thread.is_alive():
-            return
-        self._stop = False
-        self._udp_thread = threading.Thread(target=self.udp_server)
-        self._udp_thread.start()
+    async def wait(self):
+        await self._stopped.wait()
 
-    def join(self):
-        if self._udp_thread:
-            self._udp_thread.join()
-
-    def stop(self):
-        self._stop = True
-        if self._udp_thread:
-            self._udp_thread.join()
-        self._udp_thread = None
+    async def stop(self):
+        if self._cleanup_task:
+            self._cleanup_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._cleanup_task
+            self._cleanup_task = None
+        if self._transport:
+            self._transport.close()
+            self._transport = None
+        self._stopped.set()

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -574,12 +574,14 @@ class CT002:
             " in inspection mode" if in_inspection_mode else "",
         )
 
-        # Deduplication check
+        # Deduplication check — stamp immediately (before any await) so a
+        # second rapid packet from the same addr sees the updated time.
         current_time = time.time()
         last_time = self._last_response_time.get(addr)
         if last_time and (current_time - last_time) < self.dedupe_time_window:
             logger.debug("Ignoring request from %s due to dedupe window", addr)
             return
+        self._last_response_time[addr] = current_time
 
         if not in_inspection_mode:
             self._update_consumer_report(
@@ -620,7 +622,6 @@ class CT002:
                 self._format_status(values, phase_values, consumer_id, meter_value),
             )
         transport.sendto(response, addr)
-        self._last_response_time[addr] = current_time
 
     async def _cleanup_loop(self):
         try:

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -652,12 +652,14 @@ class CT002:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._cleanup_task
             self._cleanup_task = None
+        # Close transport first to stop new datagrams from spawning tasks,
+        # then cancel and await any in-flight handler tasks.
+        if self._transport:
+            self._transport.close()
+            self._transport = None
         if self._protocol:
             for task in list(self._protocol._tasks):
                 task.cancel()
             await asyncio.gather(*self._protocol._tasks, return_exceptions=True)
-        if self._transport:
-            self._transport.close()
-            self._transport = None
         self._protocol = None
         self._stopped.set()

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -316,12 +316,12 @@ class CT002:
 
         reports = dict(self._reports_by_consumer)
         last_target = self._last_target_by_consumer.get(consumer_id)
-        saturation = dict(self._saturation_by_consumer)
 
         if consumer_id and consumer_id in reports:
             actual_self = parse_int(reports.get(consumer_id, {}).get("power", 0))
             self._update_saturation(consumer_id, last_target, actual_self)
 
+        # Snapshot after _update_saturation may have modified the dict.
         saturation = dict(self._saturation_by_consumer)
         num_consumers = max(1, len(reports))
         eff_part = {cid: max(0.01, 1.0 - saturation.get(cid, 0.0)) for cid in reports}

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -192,10 +192,9 @@ class CT002:
         self._smoothed_target = None
         self._last_smooth_sample = None
         self._transport = None
-        self._protocol = None
+        self._protocol: _CT002Protocol | None = None
         self._cleanup_task = None
         self._stopped = asyncio.Event()
-        self._request_lock = asyncio.Lock()
 
     def _consumer_key(self, addr, fields):
         battery_mac = fields[1] if len(fields) > 1 else ""
@@ -532,97 +531,96 @@ class CT002:
             logger.exception("Error handling CT002 request from %s", addr)
 
     async def _handle_request(self, data, addr, transport):
-        async with self._request_lock:
-            logger.debug("CT002 request from %s: %s", addr, data.hex())
-            fields, error = parse_request(data)
-            if error:
-                logger.debug("Invalid CT002 request from %s: %s", addr, error)
-                return
-            if len(fields) < 4:
-                logger.debug("CT002 request from %s missing required fields", addr)
-                return
-            if not self._validate_ct_mac(fields):
-                logger.debug(
-                    "Ignoring CT002 request from %s due to CT MAC mismatch (req=%s, cfg=%s)",
-                    addr,
-                    fields[3] if len(fields) > 3 else None,
-                    self.ct_mac,
-                )
-                return
-            consumer_id = self._consumer_key(addr, fields)
-            reported_phase = (fields[4] if len(fields) > 4 else "").strip().upper()
-            reported_power = parse_int(fields[5] if len(fields) > 5 else 0)
-
-            if reported_phase not in ("A", "B", "C", "0", ""):
-                logger.debug(
-                    "CT002 request from %s has invalid phase '%s'",
-                    addr,
-                    reported_phase,
-                )
-                return
-
-            in_inspection_mode = reported_phase in ("0", "")
-
+        logger.debug("CT002 request from %s: %s", addr, data.hex())
+        fields, error = parse_request(data)
+        if error:
+            logger.debug("Invalid CT002 request from %s: %s", addr, error)
+            return
+        if len(fields) < 4:
+            logger.debug("CT002 request from %s missing required fields", addr)
+            return
+        if not self._validate_ct_mac(fields):
             logger.debug(
-                "CT002 parsed fields from %s: meter_dev_type=%s meter_mac=%s ct_type=%s ct_mac=%s phase=%s power=%s consumer_id=%s%s",
+                "Ignoring CT002 request from %s due to CT MAC mismatch (req=%s, cfg=%s)",
                 addr,
-                fields[0] if len(fields) > 0 else None,
-                fields[1] if len(fields) > 1 else None,
-                fields[2] if len(fields) > 2 else None,
                 fields[3] if len(fields) > 3 else None,
-                reported_phase or "(inspection)",
-                reported_power,
-                consumer_id,
-                " in inspection mode" if in_inspection_mode else "",
+                self.ct_mac,
             )
+            return
+        consumer_id = self._consumer_key(addr, fields)
+        reported_phase = (fields[4] if len(fields) > 4 else "").strip().upper()
+        reported_power = parse_int(fields[5] if len(fields) > 5 else 0)
 
-            # Deduplication check
-            current_time = time.time()
-            last_time = self._last_response_time.get(addr)
-            if last_time and (current_time - last_time) < self.dedupe_time_window:
-                logger.debug("Ignoring request from %s due to dedupe window", addr)
-                return
-
-            if not in_inspection_mode:
-                self._update_consumer_report(
-                    consumer_id, phase=reported_phase, power=reported_power
-                )
-
-            updated = await self._call_before_send(addr, fields, consumer_id)
-            if updated is not None:
-                self.set_consumer_value(consumer_id, updated)
-
-            values = self._get_consumer_value(consumer_id)
-            if values is None:
-                values = [0, 0, 0]
-            meter_value = sum(parse_int(v, 0) for v in values)
-            if self.active_control and not in_inspection_mode:
-                values = self._compute_smooth_target(values, consumer_id)
-            try:
-                response_fields = self._build_response_fields(fields, values)
-                response = build_payload(response_fields)
-            except Exception as exc:
-                logger.warning(
-                    "Failed to build CT002 response for %s (%s): %s",
-                    addr,
-                    fields,
-                    exc,
-                )
-                return
+        if reported_phase not in ("A", "B", "C", "0", ""):
             logger.debug(
-                "CT002 response to %s: %s (fields=%s)",
+                "CT002 request from %s has invalid phase '%s'",
                 addr,
-                response.hex(),
-                response_fields,
+                reported_phase,
             )
-            if self.debug_status:
-                phase_values = self._collect_reports_by_phase()
-                logger.info(
-                    "CT002 status: %s",
-                    self._format_status(values, phase_values, consumer_id, meter_value),
-                )
-            transport.sendto(response, addr)
-            self._last_response_time[addr] = current_time
+            return
+
+        in_inspection_mode = reported_phase in ("0", "")
+
+        logger.debug(
+            "CT002 parsed fields from %s: meter_dev_type=%s meter_mac=%s ct_type=%s ct_mac=%s phase=%s power=%s consumer_id=%s%s",
+            addr,
+            fields[0] if len(fields) > 0 else None,
+            fields[1] if len(fields) > 1 else None,
+            fields[2] if len(fields) > 2 else None,
+            fields[3] if len(fields) > 3 else None,
+            reported_phase or "(inspection)",
+            reported_power,
+            consumer_id,
+            " in inspection mode" if in_inspection_mode else "",
+        )
+
+        # Deduplication check
+        current_time = time.time()
+        last_time = self._last_response_time.get(addr)
+        if last_time and (current_time - last_time) < self.dedupe_time_window:
+            logger.debug("Ignoring request from %s due to dedupe window", addr)
+            return
+
+        if not in_inspection_mode:
+            self._update_consumer_report(
+                consumer_id, phase=reported_phase, power=reported_power
+            )
+
+        updated = await self._call_before_send(addr, fields, consumer_id)
+        if updated is not None:
+            self.set_consumer_value(consumer_id, updated)
+
+        values = self._get_consumer_value(consumer_id)
+        if values is None:
+            values = [0, 0, 0]
+        meter_value = sum(parse_int(v, 0) for v in values)
+        if self.active_control and not in_inspection_mode:
+            values = self._compute_smooth_target(values, consumer_id)
+        try:
+            response_fields = self._build_response_fields(fields, values)
+            response = build_payload(response_fields)
+        except Exception as exc:
+            logger.warning(
+                "Failed to build CT002 response for %s (%s): %s",
+                addr,
+                fields,
+                exc,
+            )
+            return
+        logger.debug(
+            "CT002 response to %s: %s (fields=%s)",
+            addr,
+            response.hex(),
+            response_fields,
+        )
+        if self.debug_status:
+            phase_values = self._collect_reports_by_phase()
+            logger.info(
+                "CT002 status: %s",
+                self._format_status(values, phase_values, consumer_id, meter_value),
+            )
+        transport.sendto(response, addr)
+        self._last_response_time[addr] = current_time
 
     async def _cleanup_loop(self):
         try:
@@ -653,7 +651,12 @@ class CT002:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._cleanup_task
             self._cleanup_task = None
+        if self._protocol:
+            for task in list(self._protocol._tasks):
+                task.cancel()
+            await asyncio.gather(*self._protocol._tasks, return_exceptions=True)
         if self._transport:
             self._transport.close()
             self._transport = None
+        self._protocol = None
         self._stopped.set()

--- a/src/b2500_meter/health_service.py
+++ b/src/b2500_meter/health_service.py
@@ -31,9 +31,9 @@ class HealthCheckService:
 
     async def start(self):
         app = web.Application()
+        # aiohttp auto-handles HEAD for GET routes.
         for path in ("/health", "/health/", "/api", "/api/"):
             app.router.add_get(path, self._handle_get)
-            app.router.add_head(path, self._handle_head)
         # Catch-all for unknown paths
         app.router.add_route("*", "/{path:.*}", self._handle_not_found)
 
@@ -72,12 +72,6 @@ class HealthCheckService:
         )
         return web.Response(
             body=_health_json_bytes(),
-            content_type="application/json",
-            headers={"Cache-Control": "no-cache"},
-        )
-
-    async def _handle_head(self, request):
-        return web.Response(
             content_type="application/json",
             headers={"Cache-Control": "no-cache"},
         )

--- a/src/b2500_meter/health_service.py
+++ b/src/b2500_meter/health_service.py
@@ -5,11 +5,9 @@ Provides HTTP health check endpoints for monitoring service health.
 Compatible with both Home Assistant addon watchdog and Docker health checks.
 """
 
-import atexit
 import json
-import threading
-import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from aiohttp import web
 
 from b2500_meter.config.logger import logger
 from b2500_meter.version_info import get_git_commit_sha
@@ -23,188 +21,71 @@ def _health_json_bytes():
     return json.dumps(payload).encode("utf-8")
 
 
-class HealthCheckHandler(BaseHTTPRequestHandler):
-    """HTTP handler for health check endpoints."""
-
-    def do_GET(self):
-        """Handle GET requests to health check endpoints."""
-        # Normalize path to handle trailing slashes
-        normalized_path = self.path.rstrip("/")
-        if normalized_path in ["/health", "/api"]:
-            logger.debug(
-                f"Health check request received from {self.client_address[0]}:{self.client_address[1]}"
-            )
-            self.send_response(200)
-            self.send_header("Content-type", "application/json")
-            self.send_header("Cache-Control", "no-cache")
-            self.end_headers()
-            self.wfile.write(_health_json_bytes())
-        else:
-            logger.debug(
-                f"Invalid request {self.path} from {self.client_address[0]}:{self.client_address[1]}"
-            )
-            self.send_response(404)
-            self.send_header("Content-type", "application/json")
-            self.end_headers()
-            response = b'{"error": "Not Found"}'
-            self.wfile.write(response)
-
-    def do_HEAD(self):
-        """Handle HEAD requests (some health checkers use HEAD)."""
-        # Normalize path to handle trailing slashes
-        normalized_path = self.path.rstrip("/")
-        if normalized_path in ["/health", "/api"]:
-            self.send_response(200)
-            self.send_header("Content-type", "application/json")
-            self.send_header("Cache-Control", "no-cache")
-            self.end_headers()
-        else:
-            self.send_response(404)
-            self.end_headers()
-
-    def log_message(self, format, *args):
-        """Suppress default HTTP server logging to avoid spam."""
-        pass
-
-
 class HealthCheckService:
-    """Health check service manager."""
+    """Async health check service using aiohttp."""
 
     def __init__(self, port=52500, bind_address="0.0.0.0"):
         self.port = port
         self.bind_address = bind_address
-        self.server = None
-        self.server_thread = None
-        self._running = False
+        self._runner = None
 
-    def start(self):
-        """Start the health check HTTP server."""
-        if self._running:
-            logger.warning("Health check service is already running")
-            return False
+    async def start(self):
+        app = web.Application()
+        app.router.add_get("/health", self._handle_get)
+        app.router.add_get("/api", self._handle_get)
+        app.router.add_head("/health", self._handle_head)
+        app.router.add_head("/api", self._handle_head)
+        # Catch-all for unknown paths
+        app.router.add_route("*", "/{path:.*}", self._handle_not_found)
 
+        self._runner = web.AppRunner(app, access_log=None)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.bind_address, self.port)
         try:
-            self.server = HTTPServer((self.bind_address, self.port), HealthCheckHandler)
-            self.server_thread = threading.Thread(
-                target=self._run_server, name="HealthCheckService", daemon=True
-            )
-            self.server_thread.start()
-
-            # Give the server a moment to start and verify it's working
-            time.sleep(0.5)
-            if not self.server_thread.is_alive():
-                logger.error("Health check service thread failed to start")
-                return False
-
-            self._running = True
-            logger.info(
-                f"Health check service started on {self.bind_address}:{self.port}"
-            )
-
-            # Test the endpoint to ensure it's working
-            if self.test_endpoint():
-                logger.debug("Health check endpoint test passed")
-            else:
-                logger.warning(
-                    "Health check endpoint test failed, but service is running"
-                )
-
-            return True
+            await site.start()
         except OSError as e:
-            if e.errno == 98:  # Address already in use
+            if e.errno == 98:
                 logger.error(
                     f"Port {self.port} is already in use. Health check service not started."
                 )
             else:
                 logger.error(f"Failed to bind to {self.bind_address}:{self.port}: {e}")
-            return False
-        except Exception as e:
-            logger.error(f"Failed to start health check service: {e}")
-            return False
-
-    def stop(self):
-        """Stop the health check HTTP server."""
-        if not self._running:
-            return
-
-        try:
-            if self.server:
-                self.server.shutdown()
-                self.server.server_close()
-
-            if self.server_thread and self.server_thread.is_alive():
-                self.server_thread.join(timeout=5.0)
-
-            self._running = False
-            logger.info("Health check service stopped")
-        except Exception as e:
-            logger.error(f"Error stopping health check service: {e}")
-
-    def _run_server(self):
-        """Run the HTTP server (internal method)."""
-        try:
-            self.server.serve_forever()
-        except Exception as e:
-            if self._running:  # Only log if we weren't intentionally shut down
-                logger.error(f"Health check server error: {e}")
-
-    def is_running(self):
-        """Check if the health check service is running."""
-        return self._running and self.server_thread and self.server_thread.is_alive()
-
-    def test_endpoint(self):
-        """Test the health check endpoint (for debugging)."""
-        import urllib.error
-        import urllib.request
-
-        try:
-            url = f"http://{self.bind_address}:{self.port}/health"
-            with urllib.request.urlopen(url, timeout=5) as response:
-                return response.status == 200
-        except Exception as e:
-            logger.debug(f"Health check test failed: {e}")
+            await self._runner.cleanup()
+            self._runner = None
             return False
 
-
-# Global health service instance
-_health_service = None
-
-
-def start_health_service(port=52500, bind_address="0.0.0.0"):
-    """
-    Start the global health check service.
-
-    Args:
-        port (int): Port to bind to (default: 52500)
-        bind_address (str): Address to bind to (default: 'localhost')
-
-    Returns:
-        bool: True if started successfully, False otherwise
-    """
-    global _health_service
-
-    if _health_service and _health_service.is_running():
-        logger.debug("Health service already running")
+        logger.info(f"Health check service started on {self.bind_address}:{self.port}")
         return True
 
-    _health_service = HealthCheckService(port=port, bind_address=bind_address)
-    return _health_service.start()
+    async def stop(self):
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+            logger.info("Health check service stopped")
 
+    def is_running(self):
+        return self._runner is not None
 
-def stop_health_service():
-    """Stop the global health check service."""
-    global _health_service
+    async def _handle_get(self, request):
+        logger.debug(
+            "Health check request received from %s",
+            request.remote,
+        )
+        return web.Response(
+            body=_health_json_bytes(),
+            content_type="application/json",
+            headers={"Cache-Control": "no-cache"},
+        )
 
-    if _health_service:
-        _health_service.stop()
-        _health_service = None
+    async def _handle_head(self, request):
+        return web.Response(
+            content_type="application/json",
+            headers={"Cache-Control": "no-cache"},
+        )
 
-
-def is_health_service_running():
-    """Check if the global health service is running."""
-    global _health_service
-    return _health_service and _health_service.is_running()
-
-
-# Cleanup on module exit
-atexit.register(stop_health_service)
+    async def _handle_not_found(self, request):
+        return web.Response(
+            body=b'{"error": "Not Found"}',
+            status=404,
+            content_type="application/json",
+        )

--- a/src/b2500_meter/health_service.py
+++ b/src/b2500_meter/health_service.py
@@ -31,10 +31,9 @@ class HealthCheckService:
 
     async def start(self):
         app = web.Application()
-        app.router.add_get("/health", self._handle_get)
-        app.router.add_get("/api", self._handle_get)
-        app.router.add_head("/health", self._handle_head)
-        app.router.add_head("/api", self._handle_head)
+        for path in ("/health", "/health/", "/api", "/api/"):
+            app.router.add_get(path, self._handle_get)
+            app.router.add_head(path, self._handle_head)
         # Catch-all for unknown paths
         app.router.add_route("*", "/{path:.*}", self._handle_not_found)
 

--- a/src/b2500_meter/health_service.py
+++ b/src/b2500_meter/health_service.py
@@ -5,6 +5,7 @@ Provides HTTP health check endpoints for monitoring service health.
 Compatible with both Home Assistant addon watchdog and Docker health checks.
 """
 
+import errno
 import json
 
 from aiohttp import web
@@ -43,7 +44,7 @@ class HealthCheckService:
         try:
             await site.start()
         except OSError as e:
-            if e.errno == 98:
+            if e.errno == errno.EADDRINUSE:
                 logger.error(
                     f"Port {self.port} is already in use. Health check service not started."
                 )

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import configparser
 import os
+import signal
 from collections import OrderedDict
 
 from b2500_meter.config.config_loader import ClientFilter, read_all_powermeter_configs
@@ -457,6 +458,10 @@ def main():
                 logger.error("Marstek auto-registration failed: %s", exc)
             except Exception as exc:
                 logger.error("Unexpected Marstek auto-registration error: %s", exc)
+
+    # Map SIGTERM to KeyboardInterrupt so asyncio.run cancels tasks and
+    # runs finally-cleanup the same way it does for SIGINT (Ctrl+C).
+    signal.signal(signal.SIGTERM, signal.default_int_handler)
 
     try:
         asyncio.run(async_main(cfg, args, device_types, device_ids, skip_test))

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -250,10 +250,12 @@ async def async_main(
                 await health.stop()
             health = None
 
-    # Create powermeters
-    powermeters = read_all_powermeter_configs(cfg)
+    powermeters: list[tuple[Powermeter, ClientFilter]] = []
 
     try:
+        # Create powermeters
+        powermeters = read_all_powermeter_configs(cfg)
+
         # Start powermeter lifecycle
         for pm, _ in powermeters:
             await pm.start()

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -208,6 +208,7 @@ async def run_device(
         await device.start()
     except Exception:
         logger.exception("Device %s (%s) failed to start", device_type, device_id)
+        await device.stop()
         return
     try:
         await device.wait()
@@ -277,6 +278,8 @@ async def async_main(
                 await asyncio.wait_for(health.stop(), timeout=5.0)
             except TimeoutError:
                 logger.warning("Health check service stop timed out")
+            except Exception:
+                logger.exception("Error stopping health check service")
 
 
 def main():

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -226,11 +226,17 @@ async def async_main(
     health = None
     if cfg.getboolean("GENERAL", "ENABLE_HEALTH_CHECK", fallback=True):
         logger.info("Starting health check service...")
-        health = HealthCheckService()
-        if await health.start():
-            logger.info("Health check service started successfully")
-        else:
-            logger.error("Failed to start health check service")
+        try:
+            health = HealthCheckService()
+            if await health.start():
+                logger.info("Health check service started successfully")
+            else:
+                logger.error("Failed to start health check service")
+                health = None
+        except Exception:
+            logger.exception("Health check service failed to initialize")
+            if health:
+                await health.stop()
             health = None
 
     # Create powermeters

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -236,15 +236,15 @@ async def async_main(
     # Create powermeters
     powermeters = read_all_powermeter_configs(cfg)
 
-    # Start powermeter lifecycle
-    for pm, _ in powermeters:
-        await pm.start()
-
-    if not skip_test:
-        for powermeter, client_filter in powermeters:
-            await test_powermeter(powermeter, client_filter)
-
     try:
+        # Start powermeter lifecycle
+        for pm, _ in powermeters:
+            await pm.start()
+
+        if not skip_test:
+            for powermeter, client_filter in powermeters:
+                await test_powermeter(powermeter, client_filter)
+
         if not device_types:
             logger.warning("No runnable device types configured after filtering.")
             return
@@ -258,8 +258,13 @@ async def async_main(
             )
         )
     finally:
+        # Best-effort shutdown: each resource gets a stop attempt even if
+        # an earlier one fails.
         for pm, _ in powermeters:
-            await pm.stop()
+            try:
+                await pm.stop()
+            except Exception:
+                logger.exception("Error stopping powermeter %s", pm)
         if health:
             logger.info("Stopping health check service...")
             try:

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -210,12 +210,20 @@ async def run_device(
         # Log but don't re-raise: a single device failing to start (e.g. port
         # conflict) should not take down other healthy devices in the gather.
         logger.exception("Device %s (%s) failed to start", device_type, device_id)
-        await device.stop()
+        try:
+            await device.stop()
+        except Exception:
+            logger.exception(
+                "Device %s (%s) cleanup also failed", device_type, device_id
+            )
         return
     try:
         await device.wait()
     finally:
-        await device.stop()
+        try:
+            await device.stop()
+        except Exception:
+            logger.exception("Device %s (%s) failed to stop", device_type, device_id)
 
 
 async def async_main(

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -204,7 +204,11 @@ async def run_device(
     else:
         raise ValueError(f"Unsupported device type: {device_type}")
 
-    await device.start()
+    try:
+        await device.start()
+    except Exception:
+        logger.exception("Device %s (%s) failed to start", device_type, device_id)
+        return
     try:
         await device.wait()
     finally:
@@ -258,7 +262,10 @@ async def async_main(
             await pm.stop()
         if health:
             logger.info("Stopping health check service...")
-            await asyncio.wait_for(health.stop(), timeout=5.0)
+            try:
+                await asyncio.wait_for(health.stop(), timeout=5.0)
+            except TimeoutError:
+                logger.warning("Health check service stop timed out")
 
 
 def main():

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -460,6 +460,8 @@ def main():
 
     try:
         asyncio.run(async_main(cfg, args, device_types, device_ids, skip_test))
+    except KeyboardInterrupt:
+        pass
     except RuntimeError as exc:
         logger.error("%s", exc)
         exit(1)

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -324,6 +324,7 @@ def main():
             for dt in cfg.get("GENERAL", "DEVICE_TYPE", fallback="shellypro3em").split(
                 ","
             )
+            if dt.strip()
         ]
     )
     skip_test = (

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -207,6 +207,8 @@ async def run_device(
     try:
         await device.start()
     except Exception:
+        # Log but don't re-raise: a single device failing to start (e.g. port
+        # conflict) should not take down other healthy devices in the gather.
         logger.exception("Device %s (%s) failed to start", device_type, device_id)
         await device.stop()
         return

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -1,14 +1,13 @@
 import argparse
+import asyncio
 import configparser
 import os
-import time
 from collections import OrderedDict
-from concurrent.futures import ThreadPoolExecutor
 
 from b2500_meter.config.config_loader import ClientFilter, read_all_powermeter_configs
 from b2500_meter.config.logger import logger, setLogLevel
 from b2500_meter.ct002 import CT002, UDP_PORT
-from b2500_meter.health_service import start_health_service, stop_health_service
+from b2500_meter.health_service import HealthCheckService
 from b2500_meter.marstek_api import (
     MarstekApiError,
     MarstekConfig,
@@ -28,7 +27,7 @@ def get_ct_section(device_type: str, cfg: configparser.ConfigParser) -> str:
     return section
 
 
-def test_powermeter(powermeter: Powermeter, client_filter: ClientFilter):
+async def test_powermeter(powermeter: Powermeter, client_filter: ClientFilter):
     """Test powermeter configuration with minimal retry logic for edge cases."""
     max_retries = 3
     retry_delay = 5  # seconds
@@ -38,10 +37,8 @@ def test_powermeter(powermeter: Powermeter, client_filter: ClientFilter):
             logger.debug(
                 f"Testing powermeter configuration... (attempt {attempt + 1}/{max_retries + 1})"
             )
-            powermeter.wait_for_message(
-                timeout=30
-            )  # Reduced timeout since HA should be ready
-            value = powermeter.get_powermeter_watts()
+            await powermeter.wait_for_message_async(timeout=30)
+            value = await powermeter.get_powermeter_watts_async()
             value_with_units = " | ".join([f"{v}W" for v in value])
             powermeter_name = powermeter.__class__.__name__
             filter_description = ", ".join([str(n) for n in client_filter.netmasks])
@@ -54,7 +51,7 @@ def test_powermeter(powermeter: Powermeter, client_filter: ClientFilter):
 
             if attempt < max_retries:
                 logger.info(f"Retrying powermeter test in {retry_delay} seconds...")
-                time.sleep(retry_delay)
+                await asyncio.sleep(retry_delay)
                 continue
             else:
                 # Last attempt failed
@@ -64,7 +61,7 @@ def test_powermeter(powermeter: Powermeter, client_filter: ClientFilter):
                 exit(1)
 
 
-def run_device(
+async def run_device(
     device_type: str,
     cfg: configparser.ConfigParser,
     args: argparse.Namespace,
@@ -166,7 +163,7 @@ def run_device(
             min_target_for_saturation=min_target_for_saturation,
         )
 
-        def update_readings(addr, _fields=None, _consumer_id=None):
+        async def update_readings(addr, _fields=None, _consumer_id=None):
             powermeter = None
             for pm, client_filter in powermeters:
                 if client_filter.matches(addr[0]):
@@ -175,7 +172,7 @@ def run_device(
             if powermeter is None:
                 logger.debug(f"No powermeter found for client {addr[0]}")
                 return None
-            values = powermeter.get_powermeter_watts()
+            values = await powermeter.get_powermeter_watts_async()
             value1 = values[0] if len(values) > 0 else 0
             value2 = values[1] if len(values) > 1 else 0
             value3 = values[2] if len(values) > 2 else 0
@@ -207,11 +204,61 @@ def run_device(
     else:
         raise ValueError(f"Unsupported device type: {device_type}")
 
+    await device.start()
     try:
-        device.start()
-        device.join()
+        await device.wait()
     finally:
-        device.stop()
+        await device.stop()
+
+
+async def async_main(
+    cfg: configparser.ConfigParser,
+    args: argparse.Namespace,
+    device_types: list[str],
+    device_ids: list[str],
+    skip_test: bool,
+):
+    # Start health check server
+    health = None
+    if cfg.getboolean("GENERAL", "ENABLE_HEALTH_CHECK", fallback=True):
+        logger.info("Starting health check service...")
+        health = HealthCheckService()
+        if await health.start():
+            logger.info("Health check service started successfully")
+        else:
+            logger.error("Failed to start health check service")
+            health = None
+
+    # Create powermeters
+    powermeters = read_all_powermeter_configs(cfg)
+
+    # Start powermeter lifecycle
+    for pm, _ in powermeters:
+        await pm.start()
+
+    if not skip_test:
+        for powermeter, client_filter in powermeters:
+            await test_powermeter(powermeter, client_filter)
+
+    try:
+        if not device_types:
+            logger.warning("No runnable device types configured after filtering.")
+            return
+
+        await asyncio.gather(
+            *(
+                run_device(device_type, cfg, args, powermeters, device_id)
+                for device_type, device_id in zip(
+                    device_types, device_ids, strict=False
+                )
+            )
+        )
+    finally:
+        for pm, _ in powermeters:
+            await pm.stop()
+        if health:
+            logger.info("Stopping health check service...")
+            await asyncio.wait_for(health.stop(), timeout=5.0)
 
 
 def main():
@@ -329,15 +376,7 @@ def main():
             cfg.add_section("GENERAL")
         cfg.set("GENERAL", "THROTTLE_INTERVAL", str(args.throttle_interval))
 
-    # Start health check server for watchdog monitoring
-    if cfg.getboolean("GENERAL", "ENABLE_HEALTH_CHECK", fallback=True):
-        logger.info("Starting health check service...")
-        if start_health_service():
-            logger.info("Health check service started successfully")
-        else:
-            logger.error("Failed to start health check service")
-
-    # Optional Marstek cloud registration for managed fake CT devices
+    # Optional Marstek cloud registration for managed fake CT devices (sync, before event loop)
     marstek_enabled = cfg.getboolean("MARSTEK", "ENABLE", fallback=False)
     if marstek_enabled:
         mailbox = cfg.get("MARSTEK", "MAILBOX", fallback="")
@@ -388,40 +427,7 @@ def main():
             except Exception as exc:
                 logger.error("Unexpected Marstek auto-registration error: %s", exc)
 
-    runtime_device_types = list(device_types)
-    runtime_device_ids = list(device_ids)
-
-    # Create powermeter
-    powermeters = read_all_powermeter_configs(cfg)
-    if not skip_test:
-        for powermeter, client_filter in powermeters:
-            test_powermeter(powermeter, client_filter)
-
-    # Run devices in parallel
-    try:
-        if not runtime_device_types:
-            logger.warning("No runnable device types configured after filtering.")
-            return
-
-        with ThreadPoolExecutor(max_workers=len(runtime_device_types)) as executor:
-            futures = []
-            for device_type, device_id in zip(
-                runtime_device_types, runtime_device_ids, strict=False
-            ):
-                futures.append(
-                    executor.submit(
-                        run_device, device_type, cfg, args, powermeters, device_id
-                    )
-                )
-            # end for
-
-            # Wait for all devices to complete
-            for future in futures:
-                future.result()
-    finally:
-        # Ensure health service is properly stopped on exit
-        logger.info("Stopping health check service...")
-        stop_health_service()
+    asyncio.run(async_main(cfg, args, device_types, device_ids, skip_test))
 
 
 # end main

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -55,10 +55,9 @@ async def test_powermeter(powermeter: Powermeter, client_filter: ClientFilter):
                 continue
             else:
                 # Last attempt failed
-                logger.error(
+                raise RuntimeError(
                     f"Failed to test powermeter after {max_retries + 1} attempts: {e}"
-                )
-                exit(1)
+                ) from e
 
 
 async def run_device(
@@ -459,7 +458,11 @@ def main():
             except Exception as exc:
                 logger.error("Unexpected Marstek auto-registration error: %s", exc)
 
-    asyncio.run(async_main(cfg, args, device_types, device_ids, skip_test))
+    try:
+        asyncio.run(async_main(cfg, args, device_types, device_ids, skip_test))
+    except RuntimeError as exc:
+        logger.error("%s", exc)
+        exit(1)
 
 
 # end main

--- a/src/b2500_meter/powermeter/base.py
+++ b/src/b2500_meter/powermeter/base.py
@@ -1,7 +1,32 @@
+import asyncio
+
+
 # Powermeter classes
 class Powermeter:
+    # --- Sync interface (kept for non-migrated powermeter subclasses) ---
+
+    def get_powermeter_watts(self) -> list[float]:
+        raise NotImplementedError()
+
     def wait_for_message(self, timeout=5):
         pass
 
-    def get_powermeter_watts(self):
-        raise NotImplementedError()
+    # --- Async interface (used by the main application) ---
+    # Default implementations wrap the sync methods via asyncio.to_thread().
+    # Subclasses migrated to native async override these directly.
+    # Once all subclasses are converted, the sync methods and the _async
+    # suffix will be removed.
+
+    async def get_powermeter_watts_async(self) -> list[float]:
+        return await asyncio.to_thread(self.get_powermeter_watts)
+
+    async def wait_for_message_async(self, timeout=5):
+        return await asyncio.to_thread(self.wait_for_message, timeout)
+
+    # --- Lifecycle (no-op by default, override for push-based powermeters) ---
+
+    async def start(self):
+        pass
+
+    async def stop(self):
+        pass

--- a/src/b2500_meter/powermeter/throttling.py
+++ b/src/b2500_meter/powermeter/throttling.py
@@ -25,10 +25,11 @@ class ThrottledPowermeter(Powermeter):
         self.last_values: list[float] | None = None
         self.lock = threading.Lock()
 
-        # Async path has its own state so the two paths are independent.
-        self._async_lock = asyncio.Lock()
+        # Async path: coalescing fetch pattern.  When a fetch is in flight
+        # (including the throttle sleep), concurrent callers await the same
+        # future so every consumer gets fresh data without hammering the source.
         self._async_last_update_time = 0.0
-        self._async_last_values: list[float] | None = None
+        self._pending_fetch: asyncio.Future[list[float]] | None = None
 
     # --- Sync path (unchanged, for non-migrated callers / tests) ---
 
@@ -92,60 +93,35 @@ class ThrottledPowermeter(Powermeter):
 
     async def get_powermeter_watts_async(self) -> list[float]:
         if self.throttle_interval <= 0:
-            async with self._async_lock:
-                values = await self.wrapped_powermeter.get_powermeter_watts_async()
-                self._async_last_values = values
-                self._async_last_update_time = time.time()
-                return values
+            return await self.wrapped_powermeter.get_powermeter_watts_async()
 
-        # Fast path: return cached values if still fresh (no lock needed).
-        current_time = time.time()
-        if (
-            self._async_last_values is not None
-            and (current_time - self._async_last_update_time) < self.throttle_interval
-        ):
-            return self._async_last_values
+        # If a fetch (including its throttle sleep) is already in progress,
+        # coalesce: wait for the same result so every consumer gets fresh
+        # data from the same read.
+        if self._pending_fetch is not None:
+            return list(await asyncio.shield(self._pending_fetch))
 
-        # Slow path: acquire lock, wait for throttle window, fetch fresh values.
-        async with self._async_lock:
-            # Re-check after acquiring lock — another coroutine may have
-            # fetched while we waited.
-            current_time = time.time()
-            time_since_last_update = current_time - self._async_last_update_time
-            if (
-                self._async_last_values is not None
-                and time_since_last_update < self.throttle_interval
-            ):
-                return self._async_last_values
-
-            if time_since_last_update < self.throttle_interval:
-                wait_time = self.throttle_interval - time_since_last_update
+        # We are the leader — other callers that arrive while we sleep or
+        # fetch will coalesce behind our future.
+        self._pending_fetch = asyncio.get_running_loop().create_future()
+        try:
+            now = time.time()
+            remaining = self.throttle_interval - (now - self._async_last_update_time)
+            if remaining > 0:
                 logger.debug(
                     "Throttling: Waiting %.1fs before fetching fresh values...",
-                    wait_time,
+                    remaining,
                 )
-                await asyncio.sleep(wait_time)
-                current_time = time.time()
+                await asyncio.sleep(remaining)
 
-            try:
-                values = await self.wrapped_powermeter.get_powermeter_watts_async()
-                self._async_last_values = values
-                prev_update_time = self._async_last_update_time
-                self._async_last_update_time = current_time
-                total_interval = current_time - prev_update_time
-                logger.debug(
-                    "Throttling: Fetched fresh values after %.1fs interval: %s",
-                    total_interval,
-                    values,
-                )
-                return values
-            except Exception as e:
-                if self._async_last_values is not None:
-                    logger.warning("Throttling: Error getting fresh values: %s", e)
-                    logger.debug(
-                        "Throttling: Using cached values due to error: %s",
-                        self._async_last_values,
-                    )
-                    return self._async_last_values
-                logger.error("Throttling: Error getting fresh values: %s", e)
-                raise
+            values = await self.wrapped_powermeter.get_powermeter_watts_async()
+            self._async_last_update_time = time.time()
+            logger.debug("Throttling: Fetched fresh values: %s", values)
+            self._pending_fetch.set_result(values)
+            return list(values)
+        except BaseException as e:
+            if not self._pending_fetch.done():
+                self._pending_fetch.set_exception(e)
+            raise
+        finally:
+            self._pending_fetch = None

--- a/src/b2500_meter/powermeter/throttling.py
+++ b/src/b2500_meter/powermeter/throttling.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 import time
 
@@ -18,48 +19,43 @@ class ThrottledPowermeter(Powermeter):
     """
 
     def __init__(self, wrapped_powermeter: Powermeter, throttle_interval: float = 0.0):
-        """
-        Initialize throttled powermeter wrapper.
-
-        Args:
-            wrapped_powermeter: The actual powermeter instance to wrap
-            throttle_interval: Minimum time in seconds between value updates (0 = no throttling)
-        """
         self.wrapped_powermeter = wrapped_powermeter
         self.throttle_interval = throttle_interval
         self.last_update_time = 0.0
         self.last_values: list[float] | None = None
         self.lock = threading.Lock()
 
+        # Async path has its own state so the two paths are independent.
+        self._async_lock = asyncio.Lock()
+        self._async_last_update_time = 0.0
+        self._async_last_values: list[float] | None = None
+
+    # --- Sync path (unchanged, for non-migrated callers / tests) ---
+
     def wait_for_message(self, timeout=5):
-        """Pass through to wrapped powermeter."""
         return self.wrapped_powermeter.wait_for_message(timeout)
 
     def get_powermeter_watts(self) -> list[float]:
         with self.lock:
             current_time = time.time()
 
-            # If throttling is disabled, always fetch fresh values
             if self.throttle_interval <= 0:
                 values = self.wrapped_powermeter.get_powermeter_watts()
                 self.last_values = values
                 self.last_update_time = current_time
                 return values
 
-            # Check if enough time has passed since last update
             time_since_last_update = current_time - self.last_update_time
 
             if time_since_last_update < self.throttle_interval:
-                # Not enough time has passed, wait for the remaining time
                 wait_time = self.throttle_interval - time_since_last_update
                 logger.debug(
                     "Throttling: Waiting %.1fs before fetching fresh values...",
                     wait_time,
                 )
                 time.sleep(wait_time)
-                current_time = time.time()  # Update current time after sleep
+                current_time = time.time()
 
-            # Time to get fresh values (either enough time passed or we waited)
             try:
                 values = self.wrapped_powermeter.get_powermeter_watts()
                 self.last_values = values
@@ -73,7 +69,6 @@ class ThrottledPowermeter(Powermeter):
                 )
                 return values
             except Exception as e:
-                # Fall back to cached values if available, otherwise re-raise
                 if self.last_values is not None:
                     logger.warning("Throttling: Error getting fresh values: %s", e)
                     logger.debug(
@@ -81,5 +76,60 @@ class ThrottledPowermeter(Powermeter):
                         self.last_values,
                     )
                     return self.last_values
+                logger.error("Throttling: Error getting fresh values: %s", e)
+                raise
+
+    # --- Async path (used by the main application) ---
+
+    async def wait_for_message_async(self, timeout=5):
+        return await self.wrapped_powermeter.wait_for_message_async(timeout)
+
+    async def start(self):
+        await self.wrapped_powermeter.start()
+
+    async def stop(self):
+        await self.wrapped_powermeter.stop()
+
+    async def get_powermeter_watts_async(self) -> list[float]:
+        async with self._async_lock:
+            current_time = time.time()
+
+            if self.throttle_interval <= 0:
+                values = await self.wrapped_powermeter.get_powermeter_watts_async()
+                self._async_last_values = values
+                self._async_last_update_time = current_time
+                return values
+
+            time_since_last_update = current_time - self._async_last_update_time
+
+            if time_since_last_update < self.throttle_interval:
+                wait_time = self.throttle_interval - time_since_last_update
+                logger.debug(
+                    "Throttling: Waiting %.1fs before fetching fresh values...",
+                    wait_time,
+                )
+                await asyncio.sleep(wait_time)
+                current_time = time.time()
+
+            try:
+                values = await self.wrapped_powermeter.get_powermeter_watts_async()
+                self._async_last_values = values
+                prev_update_time = self._async_last_update_time
+                self._async_last_update_time = current_time
+                total_interval = current_time - prev_update_time
+                logger.debug(
+                    "Throttling: Fetched fresh values after %.1fs interval: %s",
+                    total_interval,
+                    values,
+                )
+                return values
+            except Exception as e:
+                if self._async_last_values is not None:
+                    logger.warning("Throttling: Error getting fresh values: %s", e)
+                    logger.debug(
+                        "Throttling: Using cached values due to error: %s",
+                        self._async_last_values,
+                    )
+                    return self._async_last_values
                 logger.error("Throttling: Error getting fresh values: %s", e)
                 raise

--- a/src/b2500_meter/powermeter/throttling.py
+++ b/src/b2500_meter/powermeter/throttling.py
@@ -120,6 +120,9 @@ class ThrottledPowermeter(Powermeter):
             self._pending_fetch.set_result(values)
             return list(values)
         except BaseException as e:
+            # Update timestamp even on failure so we respect the throttle
+            # interval before retrying — avoids hammering a failing source.
+            self._async_last_update_time = time.time()
             if not self._pending_fetch.done():
                 self._pending_fetch.set_exception(e)
             raise

--- a/src/b2500_meter/powermeter/throttling.py
+++ b/src/b2500_meter/powermeter/throttling.py
@@ -91,16 +91,32 @@ class ThrottledPowermeter(Powermeter):
         await self.wrapped_powermeter.stop()
 
     async def get_powermeter_watts_async(self) -> list[float]:
-        async with self._async_lock:
-            current_time = time.time()
-
-            if self.throttle_interval <= 0:
+        if self.throttle_interval <= 0:
+            async with self._async_lock:
                 values = await self.wrapped_powermeter.get_powermeter_watts_async()
                 self._async_last_values = values
-                self._async_last_update_time = current_time
+                self._async_last_update_time = time.time()
                 return values
 
+        # Fast path: return cached values if still fresh (no lock needed).
+        current_time = time.time()
+        if (
+            self._async_last_values is not None
+            and (current_time - self._async_last_update_time) < self.throttle_interval
+        ):
+            return self._async_last_values
+
+        # Slow path: acquire lock, wait for throttle window, fetch fresh values.
+        async with self._async_lock:
+            # Re-check after acquiring lock — another coroutine may have
+            # fetched while we waited.
+            current_time = time.time()
             time_since_last_update = current_time - self._async_last_update_time
+            if (
+                self._async_last_values is not None
+                and time_since_last_update < self.throttle_interval
+            ):
+                return self._async_last_values
 
             if time_since_last_update < self.throttle_interval:
                 wait_time = self.throttle_interval - time_since_last_update

--- a/src/b2500_meter/powermeter/transform.py
+++ b/src/b2500_meter/powermeter/transform.py
@@ -34,8 +34,16 @@ class TransformedPowermeter(Powermeter):
     def wait_for_message(self, timeout=5):
         return self.wrapped_powermeter.wait_for_message(timeout)
 
-    def get_powermeter_watts(self) -> list[float]:
-        values = self.wrapped_powermeter.get_powermeter_watts()
+    async def wait_for_message_async(self, timeout=5):
+        return await self.wrapped_powermeter.wait_for_message_async(timeout)
+
+    async def start(self):
+        await self.wrapped_powermeter.start()
+
+    async def stop(self):
+        await self.wrapped_powermeter.stop()
+
+    def _apply_transform(self, values: list[float]) -> list[float]:
         result = []
         for i, value in enumerate(values):
             multiplier = self.multipliers[i % len(self.multipliers)]
@@ -65,3 +73,11 @@ class TransformedPowermeter(Powermeter):
             self._multipliers_mismatch_warned = False
 
         return result
+
+    def get_powermeter_watts(self) -> list[float]:
+        values = self.wrapped_powermeter.get_powermeter_watts()
+        return self._apply_transform(values)
+
+    async def get_powermeter_watts_async(self) -> list[float]:
+        values = await self.wrapped_powermeter.get_powermeter_watts_async()
+        return self._apply_transform(values)

--- a/src/b2500_meter/shelly/shelly.py
+++ b/src/b2500_meter/shelly/shelly.py
@@ -181,8 +181,8 @@ class Shelly:
                 transport.sendto(response_data, addr)
         except json.JSONDecodeError:
             logger.error("Error: Invalid JSON")
-        except Exception as e:
-            logger.error(f"Error processing message: {e}")
+        except Exception:
+            logger.exception("Error processing message")
 
     async def _inactive_check_loop(self):
         try:

--- a/src/b2500_meter/shelly/shelly.py
+++ b/src/b2500_meter/shelly/shelly.py
@@ -148,8 +148,14 @@ class Shelly:
             logger.exception("Error handling Shelly request from %s", addr)
 
     async def _handle_request(self, transport, data, addr):
-        request_str = data.decode()
         self._track_battery_seen(addr)
+
+        try:
+            request_str = data.decode()
+        except UnicodeDecodeError:
+            logger.debug("Ignoring non-UTF-8 datagram from %s:%s", addr[0], addr[1])
+            return
+
         logger.debug(f"Received UDP message: {request_str}")
         logger.debug(f"From: {addr[0]}:{addr[1]}")
 
@@ -202,7 +208,14 @@ class Shelly:
         self._protocol = protocol
         self._stopped.clear()
         self._inactive_check_task = asyncio.create_task(self._inactive_check_loop())
+        bound = self._transport.get_extra_info("sockname")
+        if bound:
+            self._udp_port = bound[1]
         logger.info(f"Shelly emulator listening on UDP port {self._udp_port}...")
+
+    @property
+    def udp_port(self) -> int:
+        return self._udp_port
 
     async def wait(self):
         await self._stopped.wait()

--- a/src/b2500_meter/shelly/shelly.py
+++ b/src/b2500_meter/shelly/shelly.py
@@ -226,12 +226,14 @@ class Shelly:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._inactive_check_task
             self._inactive_check_task = None
+        # Close transport first to stop new datagrams from spawning tasks,
+        # then cancel and await any in-flight handler tasks.
+        if self._transport:
+            self._transport.close()
+            self._transport = None
         if self._protocol:
             for task in list(self._protocol._tasks):
                 task.cancel()
             await asyncio.gather(*self._protocol._tasks, return_exceptions=True)
-        if self._transport:
-            self._transport.close()
-            self._transport = None
         self._protocol = None
         self._stopped.set()

--- a/src/b2500_meter/shelly/shelly.py
+++ b/src/b2500_meter/shelly/shelly.py
@@ -1,14 +1,29 @@
+import asyncio
+import contextlib
 import json
-import socket
-import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
 
 from b2500_meter.config import ClientFilter
 from b2500_meter.config.logger import logger
 from b2500_meter.powermeter import Powermeter
 
 BATTERY_INACTIVE_TIMEOUT_SECONDS = 120
+
+
+class _ShellyProtocol(asyncio.DatagramProtocol):
+    def __init__(self, shelly: "Shelly"):
+        self.shelly = shelly
+        self._tasks: set[asyncio.Task] = set()
+
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def datagram_received(self, data, addr):
+        task = asyncio.create_task(
+            self.shelly._safe_handle_request(self.transport, data, addr)
+        )
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
 
 
 class Shelly:
@@ -21,14 +36,12 @@ class Shelly:
         self._udp_port = udp_port
         self._device_id = device_id
         self._powermeters = powermeters
-        self._udp_thread: threading.Thread | None = None
-        self._stop = False
-        self._value_mutex = threading.Lock()
-        self._executor = ThreadPoolExecutor(max_workers=5)
-        self._send_lock = threading.Lock()
-        self._battery_state_lock = threading.Lock()
+        self._transport = None
+        self._protocol = None
         self._battery_last_seen: dict[str, float] = {}
         self._inactive_batteries: set[str] = set()
+        self._stopped = asyncio.Event()
+        self._inactive_check_task = None
 
     def _calculate_derived_values(self, power):
         decimal_point_enforcer = 0.001
@@ -89,12 +102,11 @@ class Shelly:
         battery_ip = addr[0]
         now = time.time()
 
-        with self._battery_state_lock:
-            first_seen = battery_ip not in self._battery_last_seen
-            was_inactive = battery_ip in self._inactive_batteries
-            self._battery_last_seen[battery_ip] = now
-            if was_inactive:
-                self._inactive_batteries.remove(battery_ip)
+        first_seen = battery_ip not in self._battery_last_seen
+        was_inactive = battery_ip in self._inactive_batteries
+        self._battery_last_seen[battery_ip] = now
+        if was_inactive:
+            self._inactive_batteries.remove(battery_ip)
 
         if first_seen:
             logger.info(
@@ -113,14 +125,13 @@ class Shelly:
         now = time.time()
         newly_inactive_batteries = []
 
-        with self._battery_state_lock:
-            for battery_ip, last_seen in self._battery_last_seen.items():
-                if (
-                    now - last_seen >= BATTERY_INACTIVE_TIMEOUT_SECONDS
-                    and battery_ip not in self._inactive_batteries
-                ):
-                    self._inactive_batteries.add(battery_ip)
-                    newly_inactive_batteries.append(battery_ip)
+        for battery_ip, last_seen in self._battery_last_seen.items():
+            if (
+                now - last_seen >= BATTERY_INACTIVE_TIMEOUT_SECONDS
+                and battery_ip not in self._inactive_batteries
+            ):
+                self._inactive_batteries.add(battery_ip)
+                newly_inactive_batteries.append(battery_ip)
 
         for battery_ip in newly_inactive_batteries:
             logger.info(
@@ -130,7 +141,13 @@ class Shelly:
                 battery_ip,
             )
 
-    def _handle_request(self, sock, data, addr):
+    async def _safe_handle_request(self, transport, data, addr):
+        try:
+            await self._handle_request(transport, data, addr)
+        except Exception:
+            logger.exception("Error handling Shelly request from %s", addr)
+
+    async def _handle_request(self, transport, data, addr):
         request_str = data.decode()
         self._track_battery_seen(addr)
         logger.debug(f"Received UDP message: {request_str}")
@@ -149,7 +166,7 @@ class Shelly:
                     logger.warning(f"No powermeter found for client {addr[0]}")
                     return
 
-                powers = powermeter.get_powermeter_watts()
+                powers = await powermeter.get_powermeter_watts_async()
 
                 if request.get("method") == "EM.GetStatus":
                     response = self._create_em_response(request["id"], powers)
@@ -161,47 +178,42 @@ class Shelly:
                 response_json = json.dumps(response, separators=(",", ":"))
                 logger.debug(f"Sending response: {response_json}")
                 response_data = response_json.encode()
-                with self._send_lock:
-                    sock.sendto(response_data, addr)
+                transport.sendto(response_data, addr)
         except json.JSONDecodeError:
             logger.error("Error: Invalid JSON")
         except Exception as e:
             logger.error(f"Error processing message: {e}")
 
-    def udp_server(self):
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        sock.settimeout(1.0)
-        sock.bind(("", self._udp_port))
+    async def _inactive_check_loop(self):
+        try:
+            while True:
+                await asyncio.sleep(1.0)
+                self._log_inactive_batteries()
+        except asyncio.CancelledError:
+            pass
+
+    async def start(self):
+        loop = asyncio.get_running_loop()
+        transport, protocol = await loop.create_datagram_endpoint(
+            lambda: _ShellyProtocol(self),
+            local_addr=("0.0.0.0", self._udp_port),
+        )
+        self._transport = transport
+        self._protocol = protocol
+        self._stopped.clear()
+        self._inactive_check_task = asyncio.create_task(self._inactive_check_loop())
         logger.info(f"Shelly emulator listening on UDP port {self._udp_port}...")
 
-        try:
-            while not self._stop:
-                try:
-                    data, addr = sock.recvfrom(1024)
-                except TimeoutError:
-                    self._log_inactive_batteries()
-                    continue
+    async def wait(self):
+        await self._stopped.wait()
 
-                self._executor.submit(self._handle_request, sock, data, addr)
-                self._log_inactive_batteries()
-
-        finally:
-            sock.close()
-
-    def start(self):
-        if self._udp_thread:
-            return
-        self._stop = False
-        self._udp_thread = threading.Thread(target=self.udp_server)
-        self._udp_thread.start()
-
-    def join(self):
-        if self._udp_thread:
-            self._udp_thread.join()
-
-    def stop(self):
-        self._stop = True
-        if self._udp_thread:
-            self._udp_thread.join()
-            self._udp_thread = None
-        self._executor.shutdown(wait=True)
+    async def stop(self):
+        if self._inactive_check_task:
+            self._inactive_check_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._inactive_check_task
+            self._inactive_check_task = None
+        if self._transport:
+            self._transport.close()
+            self._transport = None
+        self._stopped.set()

--- a/src/b2500_meter/shelly/shelly.py
+++ b/src/b2500_meter/shelly/shelly.py
@@ -37,7 +37,7 @@ class Shelly:
         self._device_id = device_id
         self._powermeters = powermeters
         self._transport = None
-        self._protocol = None
+        self._protocol: _ShellyProtocol | None = None
         self._battery_last_seen: dict[str, float] = {}
         self._inactive_batteries: set[str] = set()
         self._stopped = asyncio.Event()
@@ -213,7 +213,12 @@ class Shelly:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._inactive_check_task
             self._inactive_check_task = None
+        if self._protocol:
+            for task in list(self._protocol._tasks):
+                task.cancel()
+            await asyncio.gather(*self._protocol._tasks, return_exceptions=True)
         if self._transport:
             self._transport.close()
             self._transport = None
+        self._protocol = None
         self._stopped.set()

--- a/src/b2500_meter/shelly/shelly_udp_test.py
+++ b/src/b2500_meter/shelly/shelly_udp_test.py
@@ -62,8 +62,7 @@ async def test_multiple_requests_with_throttling():
 
 class _ClientProtocol(asyncio.DatagramProtocol):
     def __init__(self):
-        self._loop = asyncio.get_event_loop()
-        self.received: asyncio.Future = self._loop.create_future()
+        self.received: asyncio.Future = asyncio.get_running_loop().create_future()
 
     def datagram_received(self, data, addr):
         if not self.received.done():

--- a/src/b2500_meter/shelly/shelly_udp_test.py
+++ b/src/b2500_meter/shelly/shelly_udp_test.py
@@ -1,8 +1,6 @@
+import asyncio
 import json
 import socket
-import threading
-import time
-import unittest
 from ipaddress import IPv4Network
 
 from b2500_meter.config import ClientFilter
@@ -15,65 +13,62 @@ class DummyPowermeter(Powermeter):
         return [1.0]
 
 
-class TestShellyUDP(unittest.TestCase):
-    def test_multiple_requests_with_throttling(self):
-        pm = ThrottledPowermeter(DummyPowermeter(), throttle_interval=0.2)
-        cf = ClientFilter([IPv4Network("127.0.0.1/32")])
+async def test_multiple_requests_with_throttling():
+    pm = ThrottledPowermeter(DummyPowermeter(), throttle_interval=0.2)
+    cf = ClientFilter([IPv4Network("127.0.0.1/32")])
 
-        tmp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        tmp.bind(("", 0))
-        port = tmp.getsockname()[1]
-        tmp.close()
+    # Find a free port
+    tmp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    tmp.bind(("", 0))
+    port = tmp.getsockname()[1]
+    tmp.close()
 
-        shelly = Shelly([(pm, cf)], udp_port=port, device_id="test")
-        shelly.start()
-        try:
-            # Give the UDP server thread a brief moment to bind before sending requests.
-            # Without this, first packets can be dropped and recvfrom() may block forever.
-            time.sleep(0.05)
+    shelly = Shelly([(pm, cf)], udp_port=port, device_id="test")
+    await shelly.start()
+    try:
+        responses = []
+        errors = []
 
-            responses = []
-            errors = []
-            responses_lock = threading.Lock()
+        async def send_req(i):
+            req = {
+                "id": i,
+                "src": "cli",
+                "method": "EM.GetStatus",
+                "params": {"id": 0},
+            }
+            loop = asyncio.get_running_loop()
+            transport, protocol = await loop.create_datagram_endpoint(
+                lambda: _ClientProtocol(),
+                local_addr=("127.0.0.1", 0),
+                family=socket.AF_INET,
+            )
+            try:
+                transport.sendto(json.dumps(req).encode(), ("127.0.0.1", port))
+                data = await asyncio.wait_for(protocol.received, timeout=2.0)
+                resp = json.loads(data.decode())
+                responses.append(resp["id"])
+            except TimeoutError:
+                errors.append(f"timeout for request id={i}")
+            finally:
+                transport.close()
 
-            def send_req(i):
-                req = {
-                    "id": i,
-                    "src": "cli",
-                    "method": "EM.GetStatus",
-                    "params": {"id": 0},
-                }
+        await asyncio.gather(*(send_req(i) for i in range(3)))
 
-                client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                client.settimeout(1.0)
-                try:
-                    client.sendto(json.dumps(req).encode(), ("127.0.0.1", port))
-                    data, _ = client.recvfrom(1024)
-                    with responses_lock:
-                        responses.append(json.loads(data.decode())["id"])
-                except TimeoutError:
-                    with responses_lock:
-                        errors.append(f"timeout for request id={i}")
-                finally:
-                    client.close()
-
-            threads = []
-            start = time.time()
-            for i in range(3):
-                t = threading.Thread(target=send_req, args=(i,))
-                t.start()
-                threads.append(t)
-            for t in threads:
-                t.join(timeout=2.0)
-                self.assertFalse(t.is_alive(), "request thread did not finish")
-
-            duration = time.time() - start
-            self.assertEqual(errors, [])
-            self.assertEqual(sorted(responses), [0, 1, 2])
-            self.assertLess(duration, 0.6)
-        finally:
-            shelly.stop()
+        assert errors == []
+        assert sorted(responses) == [0, 1, 2]
+    finally:
+        await shelly.stop()
 
 
-if __name__ == "__main__":
-    unittest.main()
+class _ClientProtocol(asyncio.DatagramProtocol):
+    def __init__(self):
+        self._loop = asyncio.get_event_loop()
+        self.received: asyncio.Future = self._loop.create_future()
+
+    def datagram_received(self, data, addr):
+        if not self.received.done():
+            self.received.set_result(data)
+
+    def error_received(self, exc):
+        if not self.received.done():
+            self.received.set_exception(exc)

--- a/src/b2500_meter/shelly/shelly_udp_test.py
+++ b/src/b2500_meter/shelly/shelly_udp_test.py
@@ -9,55 +9,72 @@ from b2500_meter.shelly.shelly import Shelly
 
 
 class DummyPowermeter(Powermeter):
+    def __init__(self):
+        self.call_count = 0
+
     def get_powermeter_watts(self):
+        self.call_count += 1
         return [1.0]
 
 
 async def test_multiple_requests_with_throttling():
-    pm = ThrottledPowermeter(DummyPowermeter(), throttle_interval=0.2)
+    dummy = DummyPowermeter()
+    pm = ThrottledPowermeter(dummy, throttle_interval=0.2)
     cf = ClientFilter([IPv4Network("127.0.0.1/32")])
 
-    # Find a free port
-    tmp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    tmp.bind(("", 0))
-    port = tmp.getsockname()[1]
-    tmp.close()
-
-    shelly = Shelly([(pm, cf)], udp_port=port, device_id="test")
+    shelly = Shelly([(pm, cf)], udp_port=0, device_id="test")
     await shelly.start()
+    port = shelly.udp_port
+    assert port != 0, "Shelly should have bound to an actual port"
     try:
+        # Prime the throttle with an initial fetch so subsequent
+        # concurrent requests coalesce on the same reading.
+        resp = await _send_req(port, 99)
+        assert resp == 99
+        initial_calls = dummy.call_count
+
         responses = []
         errors = []
 
         async def send_req(i):
-            req = {
-                "id": i,
-                "src": "cli",
-                "method": "EM.GetStatus",
-                "params": {"id": 0},
-            }
-            loop = asyncio.get_running_loop()
-            transport, protocol = await loop.create_datagram_endpoint(
-                lambda: _ClientProtocol(),
-                local_addr=("127.0.0.1", 0),
-                family=socket.AF_INET,
-            )
             try:
-                transport.sendto(json.dumps(req).encode(), ("127.0.0.1", port))
-                data = await asyncio.wait_for(protocol.received, timeout=2.0)
-                resp = json.loads(data.decode())
-                responses.append(resp["id"])
+                resp_id = await _send_req(port, i)
+                responses.append(resp_id)
             except TimeoutError:
                 errors.append(f"timeout for request id={i}")
-            finally:
-                transport.close()
 
         await asyncio.gather(*(send_req(i) for i in range(3)))
 
         assert errors == []
         assert sorted(responses) == [0, 1, 2]
+        # All 3 concurrent requests should coalesce into a single fetch.
+        assert dummy.call_count - initial_calls <= 1, (
+            f"Expected at most 1 powermeter fetch for 3 concurrent requests, "
+            f"got {dummy.call_count - initial_calls}"
+        )
     finally:
         await shelly.stop()
+
+
+async def _send_req(port, request_id):
+    loop = asyncio.get_running_loop()
+    transport, protocol = await loop.create_datagram_endpoint(
+        lambda: _ClientProtocol(),
+        local_addr=("127.0.0.1", 0),
+        family=socket.AF_INET,
+    )
+    try:
+        req = {
+            "id": request_id,
+            "src": "cli",
+            "method": "EM.GetStatus",
+            "params": {"id": 0},
+        }
+        transport.sendto(json.dumps(req).encode(), ("127.0.0.1", port))
+        data = await asyncio.wait_for(protocol.received, timeout=2.0)
+        return json.loads(data.decode())["id"]
+    finally:
+        transport.close()
 
 
 class _ClientProtocol(asyncio.DatagramProtocol):

--- a/tests/test_ct002_mac_policy.py
+++ b/tests/test_ct002_mac_policy.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 from b2500_meter.ct002.ct002 import CT002, build_payload
 
 
@@ -6,19 +8,28 @@ def make_request(ct_mac):
     return build_payload(fields)
 
 
-def test_ct002_accepts_any_when_no_mac():
+async def test_ct002_accepts_any_when_no_mac():
     device = CT002(ct_mac="")
-    response = device._handle_request(make_request("DEADBEEF0001"), ("1.1.1.1", 12345))
-    assert response is not None
+    transport = MagicMock()
+    await device._handle_request(
+        make_request("DEADBEEF0001"), ("1.1.1.1", 12345), transport
+    )
+    transport.sendto.assert_called_once()
 
 
-def test_ct002_configured_mac_rejects_mismatch():
+async def test_ct002_configured_mac_rejects_mismatch():
     device = CT002(ct_mac="AABBCCDDEEFF")
-    response = device._handle_request(make_request("DEADBEEF0001"), ("1.1.1.1", 12345))
-    assert response is None
+    transport = MagicMock()
+    await device._handle_request(
+        make_request("DEADBEEF0001"), ("1.1.1.1", 12345), transport
+    )
+    transport.sendto.assert_not_called()
 
 
-def test_ct002_configured_mac_accepts_match():
+async def test_ct002_configured_mac_accepts_match():
     device = CT002(ct_mac="AABBCCDDEEFF")
-    response = device._handle_request(make_request("AABBCCDDEEFF"), ("1.1.1.1", 12345))
-    assert response is not None
+    transport = MagicMock()
+    await device._handle_request(
+        make_request("AABBCCDDEEFF"), ("1.1.1.1", 12345), transport
+    )
+    transport.sendto.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -191,7 +191,6 @@ dev = [
     { name = "ruff" },
 ]
 sim = [
-    { name = "aiohttp" },
     { name = "textual" },
     { name = "textual-plot" },
 ]
@@ -199,7 +198,6 @@ sim = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "aiohttp", marker = "extra == 'sim'", specifier = ">=3.9.0" },
     { name = "jsonpath-ng" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "paho-mqtt" },

--- a/uv.lock
+++ b/uv.lock
@@ -171,6 +171,7 @@ name = "b2500-meter"
 version = "1.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiohttp" },
     { name = "jsonpath-ng" },
     { name = "paho-mqtt" },
     { name = "pymodbus" },
@@ -185,6 +186,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
@@ -196,6 +198,7 @@ sim = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "aiohttp", marker = "extra == 'sim'", specifier = ">=3.9.0" },
     { name = "jsonpath-ng" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
@@ -203,6 +206,7 @@ requires-dist = [
     { name = "pymodbus", specifier = "==3.6.5" },
     { name = "pyserial" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "requests" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
@@ -213,6 +217,15 @@ requires-dist = [
     { name = "websocket-client", specifier = "==1.8.0" },
 ]
 provides-extras = ["dev", "sim"]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
 
 [[package]]
 name = "certifi"
@@ -1292,6 +1305,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR migrates the codebase from thread-based synchronous I/O to async/await patterns using asyncio. The main changes involve converting UDP server implementations (CT002, Shelly) and the health check service from threading to asyncio-based event loops, along with corresponding updates to the powermeter interface and main application flow.

## Key Changes

### UDP Server Migrations
- **CT002 and Shelly**: Replaced `threading.Thread` + blocking socket operations with `asyncio.DatagramProtocol` for non-blocking UDP handling
  - Removed `_stop` flag and thread management in favor of asyncio task lifecycle
  - Converted request handlers to async methods (`_handle_request`, `_safe_handle_request`)
  - Implemented task tracking in protocol classes to manage concurrent request processing
  - Removed socket-level locks (`_values_lock`, `_send_lock`, `_battery_state_lock`) as asyncio provides implicit serialization within a single event loop

### Health Check Service
- Replaced `HTTPServer` + `threading.Thread` with `aiohttp.web.Application`
- Converted to async request handlers (`_handle_get`, `_handle_not_found`)
- Simplified lifecycle management with `AppRunner` and `TCPSite`
- Removed manual thread lifecycle management and test endpoint polling

### Powermeter Interface
- Added async variants to base `Powermeter` class:
  - `get_powermeter_watts_async()` - async version of `get_powermeter_watts()`
  - `wait_for_message_async()` - async version of `wait_for_message()`
  - `start()` and `stop()` lifecycle methods
- Default implementations use `asyncio.to_thread()` to wrap sync methods for backward compatibility
- Updated `ThrottledPowermeter` with async path using coalescing fetch pattern to avoid hammering source during throttle window

### Main Application Flow
- Converted `main()` to `async_main()` with proper async lifecycle management
- Updated device startup/shutdown to use async methods (`await device.start()`, `await device.stop()`)
- Implemented concurrent device execution via `asyncio.gather()`
- Proper cleanup of powermeters and health service in finally block with timeout handling

### Test Updates
- Converted `shelly_udp_test.py` from `unittest` to async test functions
- Implemented `_ClientProtocol` for async UDP client testing
- Removed thread-based synchronization in favor of asyncio primitives

## Implementation Details
- Removed unused imports: `inspect`, `socket`, `threading`, `concurrent.futures.ThreadPoolExecutor`, `atexit`
- Added `asyncio` and `contextlib` imports where needed
- Removed all explicit lock objects (`threading.Lock()`) as they're no longer needed with single-threaded async execution
- Maintained backward compatibility for sync powermeter implementations via `asyncio.to_thread()` wrapper
- Added `_stopped` asyncio.Event() for graceful shutdown signaling
- Deduplication logic in CT002 now stamps immediately before any await to prevent race conditions

https://claude.ai/code/session_01UVW3sDxcjkjaMpi96bsM6P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added aiohttp as a runtime dependency, added pytest-asyncio to dev extras, and enabled asyncio test mode.

* **Refactor**
  * Large migration to async: networking, health endpoints, powermeter/device flows, lifecycle/start-stop APIs, and dedup/inactivity logic now use asyncio with cancellable tasks instead of threads/locks.
  * Powermeter APIs and throttling now support async reads and coalesced concurrent fetches.

* **Tests**
  * Converted tests and helpers to async patterns and updated assertions to validate network/send behavior and request coalescing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->