### PR TITLE
Migrate 7 simple powermeters from sync to native asyncio

### DIFF
--- a/src/b2500_meter/powermeter/amisreader.py
+++ b/src/b2500_meter/powermeter/amisreader.py
@@ -19,6 +19,8 @@ class AmisReader(Powermeter):
             self.session = None
 
     async def get_json(self, path):
+        if not self.session:
+            raise RuntimeError("Session not started; call start() first")
         url = f"http://{self.ip}{path}"
         async with self.session.get(url) as resp:
             return await resp.json(content_type=None)

--- a/src/b2500_meter/powermeter/amisreader.py
+++ b/src/b2500_meter/powermeter/amisreader.py
@@ -1,4 +1,4 @@
-import requests
+import aiohttp
 
 from .base import Powermeter
 
@@ -6,12 +6,23 @@ from .base import Powermeter
 class AmisReader(Powermeter):
     def __init__(self, ip: str):
         self.ip = ip
-        self.session = requests.Session()
+        self.session: aiohttp.ClientSession | None = None
 
-    def get_json(self, path):
+    async def start(self) -> None:
+        if self.session:
+            return
+        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+
+    async def stop(self) -> None:
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    async def get_json(self, path):
         url = f"http://{self.ip}{path}"
-        return self.session.get(url, timeout=10).json()
+        async with self.session.get(url) as resp:
+            return await resp.json(content_type=None)
 
-    def get_powermeter_watts(self):
-        response = self.get_json("/rest")
+    async def get_powermeter_watts_async(self) -> list[float]:
+        response = await self.get_json("/rest")
         return [int(response["saldo"])]

--- a/src/b2500_meter/powermeter/amisreader_test.py
+++ b/src/b2500_meter/powermeter/amisreader_test.py
@@ -1,19 +1,12 @@
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from b2500_meter.powermeter import AmisReader
 
 
-class TestAmisreader(unittest.TestCase):
-    @patch("requests.Session.get")
-    def test_amisreader_get_powermeter_watts(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"saldo": 1200}
-        mock_get.return_value = mock_response
-
+async def test_amisreader_get_powermeter_watts(mock_aiohttp_session):
+    mock_aiohttp_session.set_json({"saldo": 1200})
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         amisreader = AmisReader("192.168.1.10")
-        self.assertEqual(amisreader.get_powermeter_watts(), [1200])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        await amisreader.start()
+        assert await amisreader.get_powermeter_watts_async() == [1200]
+        await amisreader.stop()

--- a/src/b2500_meter/powermeter/conftest.py
+++ b/src/b2500_meter/powermeter/conftest.py
@@ -1,0 +1,24 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_aiohttp_session():
+    """Create a mock aiohttp.ClientSession that returns configurable JSON."""
+    json_data = {}
+
+    mock_resp = MagicMock()
+    mock_resp.json = AsyncMock(return_value=json_data)
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+    session = MagicMock()
+    session.get = MagicMock(return_value=mock_resp)
+    session.close = AsyncMock()
+
+    def set_json(data):
+        mock_resp.json.return_value = data
+
+    session.set_json = set_json
+    return session

--- a/src/b2500_meter/powermeter/emlog.py
+++ b/src/b2500_meter/powermeter/emlog.py
@@ -1,4 +1,4 @@
-import requests
+import aiohttp
 
 from .base import Powermeter
 
@@ -8,14 +8,25 @@ class Emlog(Powermeter):
         self.ip = ip
         self.meterindex = meterindex
         self.json_power_calculate = json_power_calculate
-        self.session = requests.Session()
+        self.session: aiohttp.ClientSession | None = None
 
-    def get_json(self, path):
+    async def start(self) -> None:
+        if self.session:
+            return
+        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+
+    async def stop(self) -> None:
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    async def get_json(self, path):
         url = f"http://{self.ip}{path}"
-        return self.session.get(url, timeout=10).json()
+        async with self.session.get(url) as resp:
+            return await resp.json(content_type=None)
 
-    def get_powermeter_watts(self):
-        response = self.get_json(
+    async def get_powermeter_watts_async(self) -> list[float]:
+        response = await self.get_json(
             f"/pages/getinformation.php?heute&meterindex={self.meterindex}"
         )
         if not self.json_power_calculate:

--- a/src/b2500_meter/powermeter/emlog.py
+++ b/src/b2500_meter/powermeter/emlog.py
@@ -21,6 +21,8 @@ class Emlog(Powermeter):
             self.session = None
 
     async def get_json(self, path):
+        if not self.session:
+            raise RuntimeError("Session not started; call start() first")
         url = f"http://{self.ip}{path}"
         async with self.session.get(url) as resp:
             return await resp.json(content_type=None)

--- a/src/b2500_meter/powermeter/emlog_test.py
+++ b/src/b2500_meter/powermeter/emlog_test.py
@@ -1,42 +1,21 @@
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from b2500_meter.powermeter import Emlog
 
 
-class TestEmlog(unittest.TestCase):
-    def setUp(self):
-        self.ip = "127.0.0.1"
-        self.meterindex = "1"
-
-    @patch("requests.Session.get")
-    def test_get_powermeter_watts_no_calculate(self, mock_get):
-        # Prepare the mocked response for no power calculation
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"Leistung170": "200"}
-        mock_get.return_value = mock_response
-
-        # Initialize Emlog with json_power_calculate = False
-        emlog = Emlog(self.ip, self.meterindex, json_power_calculate=False)
-
-        # Call the method and check the result
-        result = emlog.get_powermeter_watts()
-        self.assertEqual(result, [200])
-
-    @patch("requests.Session.get")
-    def test_get_powermeter_watts_with_calculate(self, mock_get):
-        # Prepare the mocked response for power calculation
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"Leistung170": "400", "Leistung270": "150"}
-        mock_get.return_value = mock_response
-
-        # Initialize Emlog with json_power_calculate = True
-        emlog = Emlog(self.ip, self.meterindex, json_power_calculate=True)
-
-        # Call the method and check the result
-        result = emlog.get_powermeter_watts()
-        self.assertEqual(result, [250])
+async def test_get_powermeter_watts_no_calculate(mock_aiohttp_session):
+    mock_aiohttp_session.set_json({"Leistung170": "200"})
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+        emlog = Emlog("127.0.0.1", "1", json_power_calculate=False)
+        await emlog.start()
+        assert await emlog.get_powermeter_watts_async() == [200]
+        await emlog.stop()
 
 
-if __name__ == "__main__":
-    unittest.main()
+async def test_get_powermeter_watts_with_calculate(mock_aiohttp_session):
+    mock_aiohttp_session.set_json({"Leistung170": "400", "Leistung270": "150"})
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+        emlog = Emlog("127.0.0.1", "1", json_power_calculate=True)
+        await emlog.start()
+        assert await emlog.get_powermeter_watts_async() == [250]
+        await emlog.stop()

--- a/src/b2500_meter/powermeter/esphome.py
+++ b/src/b2500_meter/powermeter/esphome.py
@@ -22,6 +22,8 @@ class ESPHome(Powermeter):
             self.session = None
 
     async def get_json(self, path):
+        if not self.session:
+            raise RuntimeError("Session not started; call start() first")
         url = f"http://{self.ip}:{self.port}{path}"
         async with self.session.get(url) as resp:
             return await resp.json(content_type=None)

--- a/src/b2500_meter/powermeter/esphome.py
+++ b/src/b2500_meter/powermeter/esphome.py
@@ -1,4 +1,4 @@
-import requests
+import aiohttp
 
 from .base import Powermeter
 
@@ -9,12 +9,23 @@ class ESPHome(Powermeter):
         self.port = port
         self.domain = domain
         self.id = id
-        self.session = requests.Session()
+        self.session: aiohttp.ClientSession | None = None
 
-    def get_json(self, path):
+    async def start(self) -> None:
+        if self.session:
+            return
+        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+
+    async def stop(self) -> None:
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    async def get_json(self, path):
         url = f"http://{self.ip}:{self.port}{path}"
-        return self.session.get(url, timeout=10).json()
+        async with self.session.get(url) as resp:
+            return await resp.json(content_type=None)
 
-    def get_powermeter_watts(self):
-        ParsedData = self.get_json(f"/{self.domain}/{self.id}")
-        return [int(ParsedData["value"])]
+    async def get_powermeter_watts_async(self) -> list[float]:
+        parsed_data = await self.get_json(f"/{self.domain}/{self.id}")
+        return [int(parsed_data["value"])]

--- a/src/b2500_meter/powermeter/esphome_test.py
+++ b/src/b2500_meter/powermeter/esphome_test.py
@@ -1,19 +1,12 @@
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from b2500_meter.powermeter import ESPHome
 
 
-class TestESPHome(unittest.TestCase):
-    @patch("requests.Session.get")
-    def test_esphome_get_powermeter_watts(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"value": 234}
-        mock_get.return_value = mock_response
-
+async def test_esphome_get_powermeter_watts(mock_aiohttp_session):
+    mock_aiohttp_session.set_json({"value": 234})
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         esphome = ESPHome("192.168.1.4", "80", "sensor", "power")
-        self.assertEqual(esphome.get_powermeter_watts(), [234])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        await esphome.start()
+        assert await esphome.get_powermeter_watts_async() == [234]
+        await esphome.stop()

--- a/src/b2500_meter/powermeter/iobroker.py
+++ b/src/b2500_meter/powermeter/iobroker.py
@@ -32,6 +32,8 @@ class IoBroker(Powermeter):
             self.session = None
 
     async def get_json(self, path):
+        if not self.session:
+            raise RuntimeError("Session not started; call start() first")
         url = f"http://{self.ip}:{self.port}{path}"
         async with self.session.get(url) as resp:
             return await resp.json(content_type=None)

--- a/src/b2500_meter/powermeter/iobroker.py
+++ b/src/b2500_meter/powermeter/iobroker.py
@@ -1,4 +1,4 @@
-import requests
+import aiohttp
 
 from .base import Powermeter
 
@@ -19,20 +19,34 @@ class IoBroker(Powermeter):
         self.power_calculate = power_calculate
         self.power_input_alias = power_input_alias
         self.power_output_alias = power_output_alias
-        self.session = requests.Session()
+        self.session: aiohttp.ClientSession | None = None
 
-    def get_json(self, path):
+    async def start(self) -> None:
+        if self.session:
+            return
+        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+
+    async def stop(self) -> None:
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    async def get_json(self, path):
         url = f"http://{self.ip}:{self.port}{path}"
-        return self.session.get(url, timeout=10).json()
+        async with self.session.get(url) as resp:
+            return await resp.json(content_type=None)
 
-    def get_powermeter_watts(self):
+    async def get_powermeter_watts_async(self) -> list[float]:
         if not self.power_calculate:
-            response = self.get_json(f"/getBulk/{self.current_power_alias}")
+            response = await self.get_json(f"/getBulk/{self.current_power_alias}")
             for item in response:
                 if item["id"] == self.current_power_alias:
                     return [int(item["val"])]
+            raise ValueError(
+                f"Alias {self.current_power_alias!r} not found in response"
+            )
         else:
-            response = self.get_json(
+            response = await self.get_json(
                 f"/getBulk/{self.power_input_alias},{self.power_output_alias}"
             )
             power_in = 0

--- a/src/b2500_meter/powermeter/iobroker_test.py
+++ b/src/b2500_meter/powermeter/iobroker_test.py
@@ -1,62 +1,40 @@
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from b2500_meter.powermeter import IoBroker
 
 
-class TestIoBroker(unittest.TestCase):
-    def setUp(self):
-        self.ip = "127.0.0.1"
-        self.port = "8080"
-        self.current_power_alias = "alias1"
-        self.power_input_alias = "input_alias"
-        self.power_output_alias = "output_alias"
-
-    @patch("requests.Session.get")
-    def test_get_powermeter_watts_no_calculate(self, mock_get):
-        # Prepare the mocked response for no power calculation
-        mock_response = MagicMock()
-        mock_response.json.return_value = [{"id": self.current_power_alias, "val": 100}]
-        mock_get.return_value = mock_response
-
-        # Initialize IoBroker with power_calculate = False
+async def test_get_powermeter_watts_no_calculate(mock_aiohttp_session):
+    mock_aiohttp_session.set_json([{"id": "alias1", "val": 100}])
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         iobroker = IoBroker(
-            self.ip,
-            self.port,
-            self.current_power_alias,
+            "127.0.0.1",
+            "8080",
+            "alias1",
             power_calculate=False,
-            power_input_alias=self.power_input_alias,
-            power_output_alias=self.power_output_alias,
+            power_input_alias="input_alias",
+            power_output_alias="output_alias",
         )
+        await iobroker.start()
+        assert await iobroker.get_powermeter_watts_async() == [100]
+        await iobroker.stop()
 
-        # Call the method and check the result
-        result = iobroker.get_powermeter_watts()
-        self.assertEqual(result, [100])
 
-    @patch("requests.Session.get")
-    def test_get_powermeter_watts_with_calculate(self, mock_get):
-        # Prepare the mocked response for power calculation
-        mock_response = MagicMock()
-        mock_response.json.return_value = [
-            {"id": self.power_input_alias, "val": 300},
-            {"id": self.power_output_alias, "val": 150},
+async def test_get_powermeter_watts_with_calculate(mock_aiohttp_session):
+    mock_aiohttp_session.set_json(
+        [
+            {"id": "input_alias", "val": 300},
+            {"id": "output_alias", "val": 150},
         ]
-        mock_get.return_value = mock_response
-
-        # Initialize IoBroker with power_calculate = True
+    )
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         iobroker = IoBroker(
-            self.ip,
-            self.port,
-            self.current_power_alias,
+            "127.0.0.1",
+            "8080",
+            "alias1",
             power_calculate=True,
-            power_input_alias=self.power_input_alias,
-            power_output_alias=self.power_output_alias,
+            power_input_alias="input_alias",
+            power_output_alias="output_alias",
         )
-
-        # Call the method and check the result
-        result = iobroker.get_powermeter_watts()
-        self.assertEqual(result, [150])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        await iobroker.start()
+        assert await iobroker.get_powermeter_watts_async() == [150]
+        await iobroker.stop()

--- a/src/b2500_meter/powermeter/script.py
+++ b/src/b2500_meter/powermeter/script.py
@@ -20,5 +20,5 @@ class Script(Powermeter):
                 f"Script exited with code {proc.returncode}: {self.script}"
                 + (f"\n{err}" if err else "")
             )
-        power = stdout.decode().strip().split("\n")
-        return [float(p) for p in power]
+        lines = [line for line in stdout.decode().splitlines() if line.strip()]
+        return [float(line) for line in lines]

--- a/src/b2500_meter/powermeter/script.py
+++ b/src/b2500_meter/powermeter/script.py
@@ -1,4 +1,4 @@
-import subprocess
+import asyncio
 
 from .base import Powermeter
 
@@ -7,11 +7,18 @@ class Script(Powermeter):
     def __init__(self, command: str):
         self.script = command
 
-    def get_powermeter_watts(self):
-        power = (
-            subprocess.check_output(self.script, shell=True)
-            .decode()
-            .strip()
-            .split("\n")
+    async def get_powermeter_watts_async(self) -> list[float]:
+        proc = await asyncio.create_subprocess_shell(
+            self.script,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            err = stderr.decode().strip()
+            raise RuntimeError(
+                f"Script exited with code {proc.returncode}: {self.script}"
+                + (f"\n{err}" if err else "")
+            )
+        power = stdout.decode().strip().split("\n")
         return [float(p) for p in power]

--- a/src/b2500_meter/powermeter/script_test.py
+++ b/src/b2500_meter/powermeter/script_test.py
@@ -1,17 +1,11 @@
-import unittest
-
 from .script import Script
 
 
-class TestScript(unittest.TestCase):
-    def test_script_get_powermeter_watts_integer(self):
-        script = Script('echo "456"')
-        self.assertEqual(script.get_powermeter_watts(), [456])
-
-    def test_script_get_powermeter_watts_float(self):
-        script = Script('echo "456.7"')
-        self.assertEqual(script.get_powermeter_watts(), [456.7])
+async def test_script_get_powermeter_watts_integer():
+    script = Script('echo "456"')
+    assert await script.get_powermeter_watts_async() == [456]
 
 
-if __name__ == "__main__":
-    unittest.main()
+async def test_script_get_powermeter_watts_float():
+    script = Script('echo "456.7"')
+    assert await script.get_powermeter_watts_async() == [456.7]

--- a/src/b2500_meter/powermeter/shrdzm.py
+++ b/src/b2500_meter/powermeter/shrdzm.py
@@ -1,4 +1,4 @@
-import requests
+import aiohttp
 
 from .base import Powermeter
 
@@ -8,14 +8,25 @@ class Shrdzm(Powermeter):
         self.ip = ip
         self.user = user
         self.password = password
-        self.session = requests.Session()
+        self.session: aiohttp.ClientSession | None = None
 
-    def get_json(self, path):
+    async def start(self) -> None:
+        if self.session:
+            return
+        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+
+    async def stop(self) -> None:
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    async def get_json(self, path):
         url = f"http://{self.ip}{path}"
-        return self.session.get(url, timeout=10).json()
+        async with self.session.get(url) as resp:
+            return await resp.json(content_type=None)
 
-    def get_powermeter_watts(self):
-        response = self.get_json(
+    async def get_powermeter_watts_async(self) -> list[float]:
+        response = await self.get_json(
             f"/getLastData?user={self.user}&password={self.password}"
         )
         return [int(int(response["1.7.0"]) - int(response["2.7.0"]))]

--- a/src/b2500_meter/powermeter/shrdzm.py
+++ b/src/b2500_meter/powermeter/shrdzm.py
@@ -21,6 +21,8 @@ class Shrdzm(Powermeter):
             self.session = None
 
     async def get_json(self, path):
+        if not self.session:
+            raise RuntimeError("Session not started; call start() first")
         url = f"http://{self.ip}{path}"
         async with self.session.get(url) as resp:
             return await resp.json(content_type=None)

--- a/src/b2500_meter/powermeter/shrdzm_test.py
+++ b/src/b2500_meter/powermeter/shrdzm_test.py
@@ -1,19 +1,12 @@
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from b2500_meter.powermeter import Shrdzm
 
 
-class TestShrdzm(unittest.TestCase):
-    @patch("requests.Session.get")
-    def test_shrdzm_get_powermeter_watts(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"1.7.0": 5000, "2.7.0": 2000}
-        mock_get.return_value = mock_response
-
+async def test_shrdzm_get_powermeter_watts(mock_aiohttp_session):
+    mock_aiohttp_session.set_json({"1.7.0": 5000, "2.7.0": 2000})
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         shrdzm = Shrdzm("192.168.1.5", "user", "pass")
-        self.assertEqual(shrdzm.get_powermeter_watts(), [3000])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        await shrdzm.start()
+        assert await shrdzm.get_powermeter_watts_async() == [3000]
+        await shrdzm.stop()

--- a/src/b2500_meter/powermeter/throttling.py
+++ b/src/b2500_meter/powermeter/throttling.py
@@ -21,14 +21,18 @@ class ThrottledPowermeter(Powermeter):
     def __init__(self, wrapped_powermeter: Powermeter, throttle_interval: float = 0.0):
         self.wrapped_powermeter = wrapped_powermeter
         self.throttle_interval = throttle_interval
+
+        # Sync path state (protected by self.lock).
         self.last_update_time = 0.0
-        self.last_values: list[float] | None = None
+        self._sync_last_values: list[float] | None = None
         self.lock = threading.Lock()
 
-        # Async path: coalescing fetch pattern.  When a fetch is in flight
-        # (including the throttle sleep), concurrent callers await the same
-        # future so every consumer gets fresh data without hammering the source.
+        # Async path state (single-threaded in the event loop).
+        # Coalescing fetch pattern: when a fetch is in flight (including the
+        # throttle sleep), concurrent callers await the same future so every
+        # consumer gets fresh data without hammering the source.
         self._async_last_update_time = 0.0
+        self._async_last_values: list[float] | None = None
         self._pending_fetch: asyncio.Future[list[float]] | None = None
 
     # --- Sync path (unchanged, for non-migrated callers / tests) ---
@@ -42,7 +46,7 @@ class ThrottledPowermeter(Powermeter):
 
             if self.throttle_interval <= 0:
                 values = self.wrapped_powermeter.get_powermeter_watts()
-                self.last_values = values
+                self._sync_last_values = values
                 self.last_update_time = current_time
                 return values
 
@@ -59,7 +63,7 @@ class ThrottledPowermeter(Powermeter):
 
             try:
                 values = self.wrapped_powermeter.get_powermeter_watts()
-                self.last_values = values
+                self._sync_last_values = values
                 prev_update_time = self.last_update_time
                 self.last_update_time = current_time
                 total_interval = current_time - prev_update_time
@@ -70,13 +74,13 @@ class ThrottledPowermeter(Powermeter):
                 )
                 return values
             except Exception as e:
-                if self.last_values is not None:
+                if self._sync_last_values is not None:
                     logger.warning("Throttling: Error getting fresh values: %s", e)
                     logger.debug(
                         "Throttling: Using cached values due to error: %s",
-                        self.last_values,
+                        self._sync_last_values,
                     )
-                    return self.last_values
+                    return self._sync_last_values
                 logger.error("Throttling: Error getting fresh values: %s", e)
                 raise
 
@@ -115,7 +119,7 @@ class ThrottledPowermeter(Powermeter):
                 await asyncio.sleep(remaining)
 
             values = await self.wrapped_powermeter.get_powermeter_watts_async()
-            self.last_values = values
+            self._async_last_values = values
             self._async_last_update_time = time.time()
             logger.debug("Throttling: Fetched fresh values: %s", values)
             self._pending_fetch.set_result(values)
@@ -124,15 +128,15 @@ class ThrottledPowermeter(Powermeter):
             # Update timestamp even on failure so we respect the throttle
             # interval before retrying — avoids hammering a failing source.
             self._async_last_update_time = time.time()
-            if self.last_values is not None and not isinstance(
+            if self._async_last_values is not None and not isinstance(
                 e, (KeyboardInterrupt, SystemExit)
             ):
                 logger.warning("Throttling: Error getting fresh values: %s", e)
                 logger.debug(
                     "Throttling: Using cached values due to error: %s",
-                    self.last_values,
+                    self._async_last_values,
                 )
-                cached = list(self.last_values)
+                cached = list(self._async_last_values)
                 if not self._pending_fetch.done():
                     self._pending_fetch.set_result(cached)
                 return cached

--- a/src/b2500_meter/powermeter/throttling.py
+++ b/src/b2500_meter/powermeter/throttling.py
@@ -115,6 +115,7 @@ class ThrottledPowermeter(Powermeter):
                 await asyncio.sleep(remaining)
 
             values = await self.wrapped_powermeter.get_powermeter_watts_async()
+            self.last_values = values
             self._async_last_update_time = time.time()
             logger.debug("Throttling: Fetched fresh values: %s", values)
             self._pending_fetch.set_result(values)
@@ -123,6 +124,18 @@ class ThrottledPowermeter(Powermeter):
             # Update timestamp even on failure so we respect the throttle
             # interval before retrying — avoids hammering a failing source.
             self._async_last_update_time = time.time()
+            if self.last_values is not None and not isinstance(
+                e, (KeyboardInterrupt, SystemExit)
+            ):
+                logger.warning("Throttling: Error getting fresh values: %s", e)
+                logger.debug(
+                    "Throttling: Using cached values due to error: %s",
+                    self.last_values,
+                )
+                cached = list(self.last_values)
+                if not self._pending_fetch.done():
+                    self._pending_fetch.set_result(cached)
+                return cached
             if not self._pending_fetch.done():
                 self._pending_fetch.set_exception(e)
             raise

--- a/src/b2500_meter/powermeter/throttling_test.py
+++ b/src/b2500_meter/powermeter/throttling_test.py
@@ -1,6 +1,6 @@
 import time
 import unittest
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from .throttling import ThrottledPowermeter
 
@@ -95,6 +95,45 @@ class TestThrottledPowermeter(unittest.TestCase):
         # Next call should wait for interval, then fail and return cached values
         result2 = throttled.get_powermeter_watts()
         self.assertEqual(result2, [100.0, 200.0, 300.0])
+
+
+async def test_async_exception_handling_with_cache():
+    """Test that async path returns cached values on error, matching sync behavior."""
+    mock_pm = Mock()
+    mock_pm.start = AsyncMock()
+    mock_pm.stop = AsyncMock()
+    mock_pm.get_powermeter_watts_async = AsyncMock(return_value=[100.0, 200.0])
+
+    throttled = ThrottledPowermeter(mock_pm, throttle_interval=0.1)
+
+    # First successful call to populate cache
+    result1 = await throttled.get_powermeter_watts_async()
+    assert result1 == [100.0, 200.0]
+
+    # Make the mock raise on next call
+    mock_pm.get_powermeter_watts_async.side_effect = Exception("Network error")
+
+    # Should return cached values instead of raising
+    result2 = await throttled.get_powermeter_watts_async()
+    assert result2 == [100.0, 200.0]
+
+
+async def test_async_exception_raises_without_cache():
+    """Test that async path raises if no cached values exist."""
+    mock_pm = Mock()
+    mock_pm.start = AsyncMock()
+    mock_pm.stop = AsyncMock()
+    mock_pm.get_powermeter_watts_async = AsyncMock(
+        side_effect=Exception("Network error")
+    )
+
+    throttled = ThrottledPowermeter(mock_pm, throttle_interval=0.1)
+
+    # No cached values -- should raise
+    import pytest
+
+    with pytest.raises(Exception, match="Network error"):
+        await throttled.get_powermeter_watts_async()
 
 
 if __name__ == "__main__":

--- a/src/b2500_meter/powermeter/throttling_test.py
+++ b/src/b2500_meter/powermeter/throttling_test.py
@@ -2,6 +2,8 @@ import time
 import unittest
 from unittest.mock import AsyncMock, Mock
 
+import pytest
+
 from .throttling import ThrottledPowermeter
 
 
@@ -130,8 +132,6 @@ async def test_async_exception_raises_without_cache():
     throttled = ThrottledPowermeter(mock_pm, throttle_interval=0.1)
 
     # No cached values -- should raise
-    import pytest
-
     with pytest.raises(Exception, match="Network error"):
         await throttled.get_powermeter_watts_async()
 

--- a/src/b2500_meter/powermeter/vzlogger.py
+++ b/src/b2500_meter/powermeter/vzlogger.py
@@ -1,4 +1,4 @@
-import requests
+import aiohttp
 
 from .base import Powermeter
 
@@ -8,11 +8,22 @@ class VZLogger(Powermeter):
         self.ip = ip
         self.port = port
         self.uuid = uuid
-        self.session = requests.Session()
+        self.session: aiohttp.ClientSession | None = None
 
-    def get_json(self):
+    async def start(self) -> None:
+        if self.session:
+            return
+        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+
+    async def stop(self) -> None:
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    async def get_json(self):
         url = f"http://{self.ip}:{self.port}/{self.uuid}"
-        return self.session.get(url, timeout=10).json()
+        async with self.session.get(url) as resp:
+            return await resp.json(content_type=None)
 
-    def get_powermeter_watts(self):
-        return [int(self.get_json()["data"][0]["tuples"][0][1])]
+    async def get_powermeter_watts_async(self) -> list[float]:
+        return [int((await self.get_json())["data"][0]["tuples"][0][1])]

--- a/src/b2500_meter/powermeter/vzlogger.py
+++ b/src/b2500_meter/powermeter/vzlogger.py
@@ -21,6 +21,8 @@ class VZLogger(Powermeter):
             self.session = None
 
     async def get_json(self):
+        if not self.session:
+            raise RuntimeError("Session not started; call start() first")
         url = f"http://{self.ip}:{self.port}/{self.uuid}"
         async with self.session.get(url) as resp:
             return await resp.json(content_type=None)

--- a/src/b2500_meter/powermeter/vzlogger_test.py
+++ b/src/b2500_meter/powermeter/vzlogger_test.py
@@ -1,19 +1,12 @@
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from b2500_meter.powermeter import VZLogger
 
 
-class TestVZLogger(unittest.TestCase):
-    @patch("requests.Session.get")
-    def test_vzlogger_get_powermeter_watts(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"data": [{"tuples": [[None, 900]]}]}
-        mock_get.return_value = mock_response
-
+async def test_vzlogger_get_powermeter_watts(mock_aiohttp_session):
+    mock_aiohttp_session.set_json({"data": [{"tuples": [[None, 900]]}]})
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         vzlogger = VZLogger("192.168.1.9", "8088", "uuid")
-        self.assertEqual(vzlogger.get_powermeter_watts(), [900])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        await vzlogger.start()
+        assert await vzlogger.get_powermeter_watts_async() == [900]
+        await vzlogger.stop()


### PR DESCRIPTION
Replace requests with aiohttp for AmisReader, ESPHome, VZLogger, Shrdzm, Emlog, and IoBroker. Replace subprocess with asyncio.create_subprocess_shell for Script. Each now overrides get_powermeter_watts_async() directly instead of bridging through asyncio.to_thread().

Also fix ThrottledPowermeter async path to return cached values on transient errors, matching the existing sync behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Converted all power meter readers to use asynchronous HTTP operations for improved responsiveness
  - Added lifecycle methods (start/stop) for proper resource management

* **Bug Fixes**
  - Enhanced error handling in throttled power meter to return cached values on failures when available
  - Improved explicit error messages for misconfigured power meter instances

* **Tests**
  - Modernized entire test suite from synchronous unit tests to asynchronous pytest-based tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->