### PR TITLE
Migrate Shelly powermeters to async with aiohttp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Migrated the Shelly powermeters to native asyncio using `aiohttp` (with `DigestAuthMiddleware` for Gen2+ devices), eliminating the thread-pool overhead of the previous `requests`-based implementation
 - Added support for emulating a *CT002/CT003*, which is recommended to steer multiple devices
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))
 - Added SMA Energy Meter / Sunny Home Manager support via Speedwire multicast protocol with auto-detection and per-phase power readings ([#231](https://github.com/tomquist/b2500-meter/pull/252))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## Next
-- Migrated the Shelly powermeters to native asyncio using `aiohttp` (with `DigestAuthMiddleware` for Gen2+ devices), eliminating the thread-pool overhead of the previous `requests`-based implementation
 - Added support for emulating a *CT002/CT003*, which is recommended to steer multiple devices
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))
 - Added SMA Energy Meter / Sunny Home Manager support via Speedwire multicast protocol with auto-detection and per-phase power readings ([#231](https://github.com/tomquist/b2500-meter/pull/252))

--- a/src/b2500_meter/powermeter/shelly.py
+++ b/src/b2500_meter/powermeter/shelly.py
@@ -1,5 +1,5 @@
-import requests
-from requests.auth import HTTPDigestAuth
+import aiohttp
+from aiohttp import BasicAuth, ClientTimeout, DigestAuthMiddleware
 
 from .base import Powermeter
 
@@ -10,60 +10,77 @@ class Shelly(Powermeter):
         self.user = user
         self.password = password
         self.emeterindex = emeterindex
-        self.session = requests.Session()
+        self._session: aiohttp.ClientSession | None = None
+        self._rpc_session: aiohttp.ClientSession | None = None
 
-    def get_json(self, path):
+    async def start(self) -> None:
+        timeout = ClientTimeout(total=10)
+        auth = BasicAuth(self.user, self.password) if self.user else None
+        self._session = aiohttp.ClientSession(auth=auth, timeout=timeout)
+        self._rpc_session = aiohttp.ClientSession(
+            timeout=timeout,
+            middlewares=[DigestAuthMiddleware(self.user, self.password)],
+        )
+
+    async def stop(self) -> None:
+        if self._session:
+            await self._session.close()
+            self._session = None
+        if self._rpc_session:
+            await self._rpc_session.close()
+            self._rpc_session = None
+
+    async def _get_json(self, path: str) -> dict:
+        assert self._session is not None
         url = f"http://{self.ip}{path}"
-        headers = {"content-type": "application/json"}
-        return self.session.get(
-            url, headers=headers, auth=(self.user, self.password), timeout=10
-        ).json()
+        async with self._session.get(url) as resp:
+            resp.raise_for_status()
+            return await resp.json(content_type=None)
 
-    def get_rpc_json(self, path):
+    async def _get_rpc_json(self, path: str) -> dict:
+        assert self._rpc_session is not None
         url = f"http://{self.ip}/rpc{path}"
-        headers = {"content-type": "application/json"}
-        return self.session.get(
-            url,
-            headers=headers,
-            auth=HTTPDigestAuth(self.user, self.password),
-            timeout=10,
-        ).json()
+        async with self._rpc_session.get(url) as resp:
+            resp.raise_for_status()
+            return await resp.json(content_type=None)
 
-    def get_powermeter_watts(self):
+    async def get_powermeter_watts_async(self) -> list[float]:
         raise NotImplementedError()
 
 
 class Shelly1PM(Shelly):
-    def get_powermeter_watts(self):
-        status = self.get_json("/status")
+    async def get_powermeter_watts_async(self) -> list[float]:
+        status = await self._get_json("/status")
         if self.emeterindex:
-            return [int(self.get_json(f"/meter/{self.emeterindex}")["power"])]
+            meter = await self._get_json(f"/meter/{self.emeterindex}")
+            return [int(meter["power"])]
         else:
             return [int(meter["power"]) for meter in status["meters"]]
 
 
 class ShellyPlus1PM(Shelly):
-    def get_powermeter_watts(self):
-        return [int(self.get_rpc_json("/Switch.GetStatus?id=0")["apower"])]
+    async def get_powermeter_watts_async(self) -> list[float]:
+        response = await self._get_rpc_json("/Switch.GetStatus?id=0")
+        return [int(response["apower"])]
 
 
 class ShellyEM(Shelly):
-    def get_powermeter_watts(self):
+    async def get_powermeter_watts_async(self) -> list[float]:
         if self.emeterindex:
-            return [int(self.get_json(f"/emeter/{self.emeterindex}")["power"])]
+            emeter = await self._get_json(f"/emeter/{self.emeterindex}")
+            return [int(emeter["power"])]
         else:
-            status = self.get_json("/status")
+            status = await self._get_json("/status")
             return [int(emeter["power"]) for emeter in status["emeters"]]
 
 
 class Shelly3EM(Shelly):
-    def get_powermeter_watts(self):
-        status = self.get_json("/status")
-        # Return an array of all power values
+    async def get_powermeter_watts_async(self) -> list[float]:
+        status = await self._get_json("/status")
         return [int(emeter["power"]) for emeter in status["emeters"]]
 
 
 class Shelly3EMPro(Shelly):
-    def get_powermeter_watts(self):
-        response = self.get_rpc_json("/EM.GetStatus?id=0")
+    async def get_powermeter_watts_async(self) -> list[float]:
+        response = await self._get_rpc_json("/EM.GetStatus?id=0")
         return [int(response["total_act_power"])]

--- a/src/b2500_meter/powermeter/shelly.py
+++ b/src/b2500_meter/powermeter/shelly.py
@@ -50,11 +50,11 @@ class Shelly(Powermeter):
 
 class Shelly1PM(Shelly):
     async def get_powermeter_watts_async(self) -> list[float]:
-        status = await self._get_json("/status")
         if self.emeterindex:
             meter = await self._get_json(f"/meter/{self.emeterindex}")
             return [int(meter["power"])]
         else:
+            status = await self._get_json("/status")
             return [int(meter["power"]) for meter in status["meters"]]
 
 

--- a/src/b2500_meter/powermeter/shelly_test.py
+++ b/src/b2500_meter/powermeter/shelly_test.py
@@ -1,5 +1,4 @@
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from b2500_meter.powermeter import (
     Shelly1PM,
@@ -10,56 +9,55 @@ from b2500_meter.powermeter import (
 )
 
 
-class TestShelly(unittest.TestCase):
-    @patch("requests.Session.get")
-    def test_shelly1pm_get_powermeter_watts(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"meters": [{"power": 456}]}
-        mock_get.return_value = mock_response
+def _mock_session(json_data: dict) -> MagicMock:
+    """Create a mock aiohttp.ClientSession whose .get() returns *json_data*."""
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = AsyncMock(return_value=json_data)
 
-        shelly1pm = Shelly1PM("192.168.1.2", "user", "pass", "")
-        self.assertEqual(shelly1pm.get_powermeter_watts(), [456])
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=mock_response)
+    ctx.__aexit__ = AsyncMock(return_value=False)
 
-    @patch("requests.Session.get")
-    def test_shellyem_get_powermeter_watts(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "emeters": [{"power": 789}, {"power": 1011}, {"power": 1213}]
-        }
-        mock_get.return_value = mock_response
-
-        shellyem = ShellyEM("192.168.1.3", "user", "pass", "")
-        self.assertEqual(shellyem.get_powermeter_watts(), [789, 1011, 1213])
-
-    @patch("requests.Session.get")
-    def test_shellyplus1pm_get_powermeter_watts(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"apower": 150}
-        mock_get.return_value = mock_response
-
-        shellyplus1pm = ShellyPlus1PM("192.168.1.11", "user", "pass", "")
-        self.assertEqual(shellyplus1pm.get_powermeter_watts(), [150])
-
-    @patch("requests.Session.get")
-    def test_shelly3em_get_powermeter_watts(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "emeters": [{"power": 100}, {"power": 200}, {"power": 300}]
-        }
-        mock_get.return_value = mock_response
-
-        shellyem = Shelly3EM("192.168.1.12", "user", "pass", "")
-        self.assertEqual(shellyem.get_powermeter_watts(), [100, 200, 300])
-
-    @patch("requests.Session.get")
-    def test_shelly3empro_get_powermeter_watts(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"total_act_power": 450}
-        mock_get.return_value = mock_response
-
-        shelly3empro = Shelly3EMPro("192.168.1.13", "user", "pass", "")
-        self.assertEqual(shelly3empro.get_powermeter_watts(), [450])
+    session = MagicMock()
+    session.get.return_value = ctx
+    return session
 
 
-if __name__ == "__main__":
-    unittest.main()
+async def test_shelly1pm_get_powermeter_watts() -> None:
+    shelly = Shelly1PM("192.168.1.2", "user", "pass", "")
+    shelly._session = _mock_session({"meters": [{"power": 456}]})
+
+    assert await shelly.get_powermeter_watts_async() == [456]
+
+
+async def test_shellyem_get_powermeter_watts() -> None:
+    shelly = ShellyEM("192.168.1.3", "user", "pass", "")
+    shelly._session = _mock_session(
+        {"emeters": [{"power": 789}, {"power": 1011}, {"power": 1213}]}
+    )
+
+    assert await shelly.get_powermeter_watts_async() == [789, 1011, 1213]
+
+
+async def test_shellyplus1pm_get_powermeter_watts() -> None:
+    shelly = ShellyPlus1PM("192.168.1.11", "user", "pass", "")
+    shelly._rpc_session = _mock_session({"apower": 150})
+
+    assert await shelly.get_powermeter_watts_async() == [150]
+
+
+async def test_shelly3em_get_powermeter_watts() -> None:
+    shelly = Shelly3EM("192.168.1.12", "user", "pass", "")
+    shelly._session = _mock_session(
+        {"emeters": [{"power": 100}, {"power": 200}, {"power": 300}]}
+    )
+
+    assert await shelly.get_powermeter_watts_async() == [100, 200, 300]
+
+
+async def test_shelly3empro_get_powermeter_watts() -> None:
+    shelly = Shelly3EMPro("192.168.1.13", "user", "pass", "")
+    shelly._rpc_session = _mock_session({"total_act_power": 450})
+
+    assert await shelly.get_powermeter_watts_async() == [450]

--- a/src/b2500_meter/powermeter/shelly_test.py
+++ b/src/b2500_meter/powermeter/shelly_test.py
@@ -56,6 +56,20 @@ async def test_shelly3em_get_powermeter_watts() -> None:
     assert await shelly.get_powermeter_watts_async() == [100, 200, 300]
 
 
+async def test_shelly1pm_get_powermeter_watts_indexed() -> None:
+    shelly = Shelly1PM("192.168.1.2", "user", "pass", "0")
+    shelly._session = _mock_session({"power": 789})
+
+    assert await shelly.get_powermeter_watts_async() == [789]
+
+
+async def test_shellyem_get_powermeter_watts_indexed() -> None:
+    shelly = ShellyEM("192.168.1.3", "user", "pass", "1")
+    shelly._session = _mock_session({"power": 555})
+
+    assert await shelly.get_powermeter_watts_async() == [555]
+
+
 async def test_shelly3empro_get_powermeter_watts() -> None:
     shelly = Shelly3EMPro("192.168.1.13", "user", "pass", "")
     shelly._rpc_session = _mock_session({"total_act_power": 450})


### PR DESCRIPTION
## Summary
Migrated the Shelly powermeter implementations from synchronous `requests`-based HTTP calls to asynchronous `aiohttp`-based calls, eliminating thread-pool overhead and enabling better concurrency.

## Key Changes
- **HTTP Client Migration**: Replaced `requests.Session` with `aiohttp.ClientSession` for all HTTP operations
- **Authentication Updates**: 
  - Switched from `HTTPDigestAuth` to `DigestAuthMiddleware` for Gen2+ devices (RPC endpoints)
  - Simplified basic auth using `aiohttp.BasicAuth`
- **API Conversion**: Converted all `get_powermeter_watts()` methods to async `get_powermeter_watts_async()` methods
- **Session Management**: Added `start()` and `stop()` lifecycle methods to properly initialize and clean up aiohttp sessions with configurable timeouts (10s)
- **Test Refactoring**: 
  - Converted from `unittest.TestCase` to pytest-style async test functions
  - Updated mocks to use `AsyncMock` for async operations
  - Created `_mock_session()` helper to properly mock aiohttp context managers

## Implementation Details
- Separate session instances for standard REST endpoints (`_session`) and RPC endpoints (`_rpc_session`) to support different authentication methods
- All HTTP methods now use async context managers (`async with`) for proper resource handling
- Added `content_type=None` parameter to `json()` calls to handle responses without explicit content-type headers
- Maintained backward compatibility with the `emeterindex` parameter for device-specific meter queries

https://claude.ai/code/session_01VfLxERFcpudacLE6PYLBxL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Shelly power-meter integration refactored with improved performance and enhanced authentication support for Gen2+ devices. Connection lifecycle management is now explicit and more efficient, benefiting resource handling across all supported Shelly power-meter models.

* **Tests**
  * Updated test suite for Shelly power-meter device validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->