### PR TITLE
Migrate powermeters to async with aiohttp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Migrated powermeters to native asyncio, replacing blocking `requests`/threading with `aiohttp` and async lifecycle management for improved concurrency
 - Added support for emulating a *CT002/CT003*, which is recommended to steer multiple devices
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))
 - Added SMA Energy Meter / Sunny Home Manager support via Speedwire multicast protocol with auto-detection and per-phase power readings ([#231](https://github.com/tomquist/b2500-meter/pull/252))

--- a/src/b2500_meter/powermeter/conftest.py
+++ b/src/b2500_meter/powermeter/conftest.py
@@ -10,15 +10,31 @@ def mock_aiohttp_session():
 
     mock_resp = MagicMock()
     mock_resp.json = AsyncMock(return_value=json_data)
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.status = 200
     mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
     mock_resp.__aexit__ = AsyncMock(return_value=False)
 
+    post_json_data = {}
+
+    mock_post_resp = MagicMock()
+    mock_post_resp.json = AsyncMock(return_value=post_json_data)
+    mock_post_resp.raise_for_status = MagicMock()
+    mock_post_resp.status = 200
+    mock_post_resp.__aenter__ = AsyncMock(return_value=mock_post_resp)
+    mock_post_resp.__aexit__ = AsyncMock(return_value=False)
+
     session = MagicMock()
     session.get = MagicMock(return_value=mock_resp)
+    session.post = MagicMock(return_value=mock_post_resp)
     session.close = AsyncMock()
 
     def set_json(data):
         mock_resp.json.return_value = data
 
+    def set_post_json(data):
+        mock_post_resp.json.return_value = data
+
     session.set_json = set_json
+    session.set_post_json = set_post_json
     return session

--- a/src/b2500_meter/powermeter/json_http.py
+++ b/src/b2500_meter/powermeter/json_http.py
@@ -1,8 +1,8 @@
 import json
 
-import requests
+import aiohttp
+from aiohttp import BasicAuth, ClientTimeout
 from jsonpath_ng import parse
-from requests.auth import HTTPBasicAuth
 
 from b2500_meter.config.logger import logger
 
@@ -29,27 +29,42 @@ class JsonHttpPowermeter(Powermeter):
     ):
         self.url = url
         self.json_paths = [json_path] if isinstance(json_path, str) else list(json_path)
-        self.auth = HTTPBasicAuth(username, password) if username or password else None
+        self.auth = (
+            BasicAuth(username or "", password or "") if username or password else None
+        )
         self.headers = headers or {}
-        self.session = requests.Session()
+        self.session: aiohttp.ClientSession | None = None
 
-    def get_json(self):
+    async def start(self) -> None:
+        if self.session:
+            return
+        self.session = aiohttp.ClientSession(
+            auth=self.auth,
+            headers=self.headers,
+            timeout=ClientTimeout(total=10),
+        )
+
+    async def stop(self) -> None:
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    async def get_json(self):
+        if not self.session:
+            raise RuntimeError("Session not started; call start() first")
         try:
-            response = self.session.get(
-                self.url, headers=self.headers, auth=self.auth, timeout=10
-            )
-            response.raise_for_status()
-            return response.json()
+            async with self.session.get(self.url) as resp:
+                resp.raise_for_status()
+                return await resp.json(content_type=None)
         except json.JSONDecodeError as e:
             logger.error(f"Failed to decode JSON: {e}")
-            logger.error(f"Response content: {response.text[:200]}...")
             raise ValueError(f"Invalid JSON response: {e}") from e
-        except requests.exceptions.RequestException as e:
+        except aiohttp.ClientError as e:
             logger.error(f"HTTP request error: {e}")
             raise ValueError(f"HTTP request error: {e}") from e
 
-    def get_powermeter_watts(self) -> list[float]:
-        data = self.get_json()
+    async def get_powermeter_watts_async(self) -> list[float]:
+        data = await self.get_json()
         values = []
         for path in self.json_paths:
             values.append(extract_json_value(data, path))

--- a/src/b2500_meter/powermeter/json_http_test.py
+++ b/src/b2500_meter/powermeter/json_http_test.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from aiohttp import BasicAuth
+from aiohttp import BasicAuth, ClientTimeout
 
 from b2500_meter.powermeter import JsonHttpPowermeter
 
@@ -25,7 +25,7 @@ async def test_three_phase(mock_aiohttp_session):
 
 async def test_headers_and_auth(mock_aiohttp_session):
     mock_aiohttp_session.set_json({"power": 50})
-    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session) as mock_cls:
         meter = JsonHttpPowermeter(
             "http://localhost",
             "$.power",
@@ -34,8 +34,11 @@ async def test_headers_and_auth(mock_aiohttp_session):
             headers={"X-Test": "1"},
         )
         await meter.start()
+        mock_cls.assert_called_once_with(
+            auth=BasicAuth("user", "pass"),
+            headers={"X-Test": "1"},
+            timeout=ClientTimeout(total=10),
+        )
         await meter.get_powermeter_watts_async()
         mock_aiohttp_session.get.assert_called_with("http://localhost")
-        assert meter.auth == BasicAuth("user", "pass")
-        assert meter.headers == {"X-Test": "1"}
         await meter.stop()

--- a/src/b2500_meter/powermeter/json_http_test.py
+++ b/src/b2500_meter/powermeter/json_http_test.py
@@ -1,43 +1,31 @@
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from requests.auth import HTTPBasicAuth
+from aiohttp import BasicAuth
 
 from b2500_meter.powermeter import JsonHttpPowermeter
 
 
-class TestJsonHttpPowermeter(unittest.TestCase):
-    @patch("requests.Session.get")
-    def test_single_phase(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"power": 100}
-        mock_get.return_value = mock_response
-
+async def test_single_phase(mock_aiohttp_session):
+    mock_aiohttp_session.set_json({"power": 100})
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         meter = JsonHttpPowermeter("http://localhost", "$.power")
-        self.assertEqual(meter.get_powermeter_watts(), [100.0])
+        await meter.start()
+        assert await meter.get_powermeter_watts_async() == [100.0]
+        await meter.stop()
 
-    @patch("requests.Session.get")
-    def test_three_phase(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {
-            "p1": 100,
-            "p2": 200,
-            "p3": 300,
-        }
-        mock_get.return_value = mock_response
 
-        meter = JsonHttpPowermeter(
-            "http://localhost",
-            ["$.p1", "$.p2", "$.p3"],
-        )
-        self.assertEqual(meter.get_powermeter_watts(), [100.0, 200.0, 300.0])
+async def test_three_phase(mock_aiohttp_session):
+    mock_aiohttp_session.set_json({"p1": 100, "p2": 200, "p3": 300})
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+        meter = JsonHttpPowermeter("http://localhost", ["$.p1", "$.p2", "$.p3"])
+        await meter.start()
+        assert await meter.get_powermeter_watts_async() == [100.0, 200.0, 300.0]
+        await meter.stop()
 
-    @patch("requests.Session.get")
-    def test_headers_and_auth(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"power": 50}
-        mock_get.return_value = mock_response
 
+async def test_headers_and_auth(mock_aiohttp_session):
+    mock_aiohttp_session.set_json({"power": 50})
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         meter = JsonHttpPowermeter(
             "http://localhost",
             "$.power",
@@ -45,14 +33,9 @@ class TestJsonHttpPowermeter(unittest.TestCase):
             password="pass",
             headers={"X-Test": "1"},
         )
-        meter.get_powermeter_watts()
-        mock_get.assert_called_with(
-            "http://localhost",
-            headers={"X-Test": "1"},
-            auth=HTTPBasicAuth("user", "pass"),
-            timeout=10,
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
+        await meter.start()
+        await meter.get_powermeter_watts_async()
+        mock_aiohttp_session.get.assert_called_with("http://localhost")
+        assert meter.auth == BasicAuth("user", "pass")
+        assert meter.headers == {"X-Test": "1"}
+        await meter.stop()

--- a/src/b2500_meter/powermeter/json_http_test.py
+++ b/src/b2500_meter/powermeter/json_http_test.py
@@ -39,6 +39,7 @@ async def test_headers_and_auth(mock_aiohttp_session):
             headers={"X-Test": "1"},
             timeout=ClientTimeout(total=10),
         )
-        await meter.get_powermeter_watts_async()
-        mock_aiohttp_session.get.assert_called_with("http://localhost")
+        result = await meter.get_powermeter_watts_async()
+        assert result == [50.0]
+        mock_aiohttp_session.get.assert_called_once_with("http://localhost")
         await meter.stop()

--- a/src/b2500_meter/powermeter/tasmota.py
+++ b/src/b2500_meter/powermeter/tasmota.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlencode
 
-import requests
+import aiohttp
+from aiohttp import ClientTimeout
 
 from .base import Powermeter
 
@@ -27,20 +28,33 @@ class Tasmota(Powermeter):
         self.json_power_input_mqtt_label = json_power_input_mqtt_label
         self.json_power_output_mqtt_label = json_power_output_mqtt_label
         self.json_power_calculate = json_power_calculate
-        self.session = requests.Session()
+        self.session: aiohttp.ClientSession | None = None
 
-    def get_json(self, path):
+    async def start(self) -> None:
+        if self.session:
+            return
+        self.session = aiohttp.ClientSession(timeout=ClientTimeout(total=10))
+
+    async def stop(self) -> None:
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    async def get_json(self, path):
+        if not self.session:
+            raise RuntimeError("Session not started; call start() first")
         url = f"http://{self.ip}{path}"
-        return self.session.get(url, timeout=10).json()
+        async with self.session.get(url) as resp:
+            return await resp.json(content_type=None)
 
-    def get_powermeter_watts(self):
+    async def get_powermeter_watts_async(self) -> list[float]:
         if not self.user:
-            response = self.get_json("/cm?cmnd=status%2010")
+            response = await self.get_json("/cm?cmnd=status%2010")
         else:
             qs = urlencode(
                 {"user": self.user, "password": self.password, "cmnd": "status 10"}
             )
-            response = self.get_json(f"/cm?{qs}")
+            response = await self.get_json(f"/cm?{qs}")
         value = response[self.json_status][self.json_payload_mqtt_prefix]
         if not self.json_power_calculate:
             return [int(value[self.json_power_mqtt_label])]

--- a/src/b2500_meter/powermeter/tasmota.py
+++ b/src/b2500_meter/powermeter/tasmota.py
@@ -45,6 +45,7 @@ class Tasmota(Powermeter):
             raise RuntimeError("Session not started; call start() first")
         url = f"http://{self.ip}{path}"
         async with self.session.get(url) as resp:
+            resp.raise_for_status()
             return await resp.json(content_type=None)
 
     async def get_powermeter_watts_async(self) -> list[float]:

--- a/src/b2500_meter/powermeter/tasmota_test.py
+++ b/src/b2500_meter/powermeter/tasmota_test.py
@@ -1,23 +1,22 @@
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from b2500_meter.powermeter import (
-    Tasmota,
-)
+from b2500_meter.powermeter import Tasmota
 
 
-class TestTasmota(unittest.TestCase):
-    @patch("requests.Session.get")
-    def test_tasmota_get_powermeter_watts(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"StatusSNS": {"ENERGY": {"Power": 123}}}
-        mock_get.return_value = mock_response
-
+async def test_tasmota_get_powermeter_watts(mock_aiohttp_session):
+    mock_aiohttp_session.set_json({"StatusSNS": {"ENERGY": {"Power": 123}}})
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         tasmota = Tasmota(
-            "192.168.1.1", "user", "pass", "StatusSNS", "ENERGY", "Power", "", "", False
+            "192.168.1.1",
+            "user",
+            "pass",
+            "StatusSNS",
+            "ENERGY",
+            "Power",
+            "",
+            "",
+            False,
         )
-        self.assertEqual(tasmota.get_powermeter_watts(), [123])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        await tasmota.start()
+        assert await tasmota.get_powermeter_watts_async() == [123]
+        await tasmota.stop()

--- a/src/b2500_meter/powermeter/tasmota_test.py
+++ b/src/b2500_meter/powermeter/tasmota_test.py
@@ -20,3 +20,25 @@ async def test_tasmota_get_powermeter_watts(mock_aiohttp_session):
         await tasmota.start()
         assert await tasmota.get_powermeter_watts_async() == [123]
         await tasmota.stop()
+
+
+async def test_tasmota_unauthenticated(mock_aiohttp_session):
+    mock_aiohttp_session.set_json({"StatusSNS": {"ENERGY": {"Power": 123}}})
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+        tasmota = Tasmota(
+            "192.168.1.1",
+            "",
+            "",
+            "StatusSNS",
+            "ENERGY",
+            "Power",
+            "",
+            "",
+            False,
+        )
+        await tasmota.start()
+        assert await tasmota.get_powermeter_watts_async() == [123]
+        mock_aiohttp_session.get.assert_called_with(
+            "http://192.168.1.1/cm?cmnd=status%2010"
+        )
+        await tasmota.stop()

--- a/src/b2500_meter/powermeter/tasmota_test.py
+++ b/src/b2500_meter/powermeter/tasmota_test.py
@@ -19,6 +19,9 @@ async def test_tasmota_get_powermeter_watts(mock_aiohttp_session):
         )
         await tasmota.start()
         assert await tasmota.get_powermeter_watts_async() == [123]
+        mock_aiohttp_session.get.assert_called_with(
+            "http://192.168.1.1/cm?user=user&password=pass&cmnd=status+10"
+        )
         await tasmota.stop()
 
 

--- a/src/b2500_meter/powermeter/tq_em.py
+++ b/src/b2500_meter/powermeter/tq_em.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 import aiohttp
@@ -39,6 +40,7 @@ class TQEnergyManager(Powermeter):
         self._sess: aiohttp.ClientSession | None = None
         self._serial: str | None = None
         self._last_use = 0.0
+        self._auth_lock = asyncio.Lock()
 
     async def start(self) -> None:
         if self._sess:
@@ -58,13 +60,14 @@ class TQEnergyManager(Powermeter):
     async def get_powermeter_watts_async(self) -> list[float]:
         if not self._sess:
             raise RuntimeError("Session not started; call start() first")
-        await self._ensure_session()
+        async with self._auth_lock:
+            await self._ensure_session()
 
-        try:
-            data = await self._read_live_json()
-        except _SessionExpired:
-            await self._login()
-            data = await self._read_live_json()
+            try:
+                data = await self._read_live_json()
+            except _SessionExpired:
+                await self._login()
+                data = await self._read_live_json()
 
         if any(k in data for k in self._PHASE_KEYS):
             return [

--- a/src/b2500_meter/powermeter/tq_em.py
+++ b/src/b2500_meter/powermeter/tq_em.py
@@ -88,7 +88,8 @@ class TQEnergyManager(Powermeter):
     # INTERNALS                                                          #
     # ------------------------------------------------------------------ #
     async def _ensure_session(self) -> None:
-        assert self._sess is not None
+        if self._sess is None:
+            raise RuntimeError("Session not started; call start() first")
         now = time.time()
         if self._serial is None or (now - self._last_use) > self._MAX_IDLE:
             await self._login()
@@ -96,7 +97,8 @@ class TQEnergyManager(Powermeter):
 
     async def _login(self) -> None:
         """Authenticate lazily with the device."""
-        assert self._sess is not None
+        if self._sess is None:
+            raise RuntimeError("Session not started; call start() first")
         async with self._sess.get(f"http://{self._host}/start.php") as r1:
             r1.raise_for_status()
             j1 = await r1.json(content_type=None)
@@ -121,7 +123,8 @@ class TQEnergyManager(Powermeter):
                 raise RuntimeError("Authentication failed")
 
     async def _read_live_json(self) -> dict:
-        assert self._sess is not None
+        if self._sess is None:
+            raise RuntimeError("Session not started; call start() first")
         async with self._sess.get(f"http://{self._host}/mum-webservice/data.php") as r:
             if r.status in (401, 403):
                 raise _SessionExpired

--- a/src/b2500_meter/powermeter/tq_em.py
+++ b/src/b2500_meter/powermeter/tq_em.py
@@ -1,6 +1,7 @@
 import time
 
-import requests
+import aiohttp
+from aiohttp import ClientTimeout
 
 from .base import Powermeter
 
@@ -35,21 +36,35 @@ class TQEnergyManager(Powermeter):
 
     def __init__(self, host: str, password: str = "", *, timeout: float = 5.0) -> None:
         self._host, self._pw, self._timeout = host.rstrip("/"), password, timeout
-        self._sess = requests.Session()
+        self._sess: aiohttp.ClientSession | None = None
         self._serial: str | None = None
         self._last_use = 0.0
+
+    async def start(self) -> None:
+        if self._sess:
+            return
+        self._sess = aiohttp.ClientSession(
+            timeout=ClientTimeout(total=self._timeout),
+        )
+
+    async def stop(self) -> None:
+        if self._sess:
+            await self._sess.close()
+            self._sess = None
 
     # ------------------------------------------------------------------ #
     # PUBLIC                                                             #
     # ------------------------------------------------------------------ #
-    def get_powermeter_watts(self) -> list[float]:
-        self._ensure_session()
+    async def get_powermeter_watts_async(self) -> list[float]:
+        if not self._sess:
+            raise RuntimeError("Session not started; call start() first")
+        await self._ensure_session()
 
         try:
-            data = self._read_live_json()
+            data = await self._read_live_json()
         except _SessionExpired:
-            self._login()
-            data = self._read_live_json()
+            await self._login()
+            data = await self._read_live_json()
 
         if any(k in data for k in self._PHASE_KEYS):
             return [
@@ -72,17 +87,19 @@ class TQEnergyManager(Powermeter):
     # ------------------------------------------------------------------ #
     # INTERNALS                                                          #
     # ------------------------------------------------------------------ #
-    def _ensure_session(self) -> None:
+    async def _ensure_session(self) -> None:
+        assert self._sess is not None
         now = time.time()
         if self._serial is None or (now - self._last_use) > self._MAX_IDLE:
-            self._login()
+            await self._login()
         self._last_use = now
 
-    def _login(self) -> None:
+    async def _login(self) -> None:
         """Authenticate lazily with the device."""
-        r1 = self._sess.get(f"http://{self._host}/start.php", timeout=self._timeout)
-        r1.raise_for_status()
-        j1 = r1.json()
+        assert self._sess is not None
+        async with self._sess.get(f"http://{self._host}/start.php") as r1:
+            r1.raise_for_status()
+            j1 = await r1.json(content_type=None)
 
         self._serial = j1.get("serial") or j1.get("ieq_serial")
         if not self._serial:
@@ -95,25 +112,25 @@ class TQEnergyManager(Powermeter):
         if self._pw:
             payload["password"] = self._pw
 
-        r2 = self._sess.post(
-            f"http://{self._host}/start.php", data=payload, timeout=self._timeout
-        )
-        r2.raise_for_status()
-        if r2.json().get("authentication") is not True:
-            raise RuntimeError("Authentication failed")
+        async with self._sess.post(
+            f"http://{self._host}/start.php", data=payload
+        ) as r2:
+            r2.raise_for_status()
+            j2 = await r2.json(content_type=None)
+            if j2.get("authentication") is not True:
+                raise RuntimeError("Authentication failed")
 
-    def _read_live_json(self) -> dict:
-        r = self._sess.get(
-            f"http://{self._host}/mum-webservice/data.php", timeout=self._timeout
-        )
-        if r.status_code in (401, 403):
-            raise _SessionExpired
+    async def _read_live_json(self) -> dict:
+        assert self._sess is not None
+        async with self._sess.get(f"http://{self._host}/mum-webservice/data.php") as r:
+            if r.status in (401, 403):
+                raise _SessionExpired
 
-        r.raise_for_status()
-        data = r.json()
-        if data.get("status", 0) >= 900:
-            raise _SessionExpired
-        return data
+            r.raise_for_status()
+            data = await r.json(content_type=None)
+            if data.get("status", 0) >= 900:
+                raise _SessionExpired
+            return data
 
 
 class _SessionExpired(RuntimeError):

--- a/src/b2500_meter/powermeter/tq_em_test.py
+++ b/src/b2500_meter/powermeter/tq_em_test.py
@@ -1,128 +1,117 @@
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from b2500_meter.powermeter.tq_em import TQEnergyManager
 
 
-class TestTQEnergyManager(unittest.TestCase):
-    @patch("requests.Session.post")
-    @patch("requests.Session.get")
-    def test_three_phase(self, mock_get, mock_post):
-        # login GET
-        mock_get.side_effect = [
-            MagicMock(
-                status_code=200,
-                json=lambda: {"serial": "123", "authentication": False},
-            ),
-            MagicMock(
-                status_code=200,
-                json=lambda: {
-                    "1-0:21.4.0*255": 1,
-                    "1-0:22.4.0*255": 0,
-                    "1-0:41.4.0*255": 2,
-                    "1-0:42.4.0*255": 0,
-                    "1-0:61.4.0*255": 3,
-                    "1-0:62.4.0*255": 0,
-                },
-            ),
-        ]
-        mock_post.return_value = MagicMock(
-            status_code=200, json=lambda: {"authentication": True}
-        )
+def _make_resp(data, status=200):
+    """Create a mock aiohttp response with async context manager support."""
+    resp = MagicMock()
+    resp.json = AsyncMock(return_value=data)
+    resp.raise_for_status = MagicMock()
+    resp.status = status
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
 
+
+def _make_session(get_responses, post_responses=None):
+    """Create a mock aiohttp session with sequenced GET/POST responses."""
+    session = MagicMock()
+    session.get = MagicMock(side_effect=[_make_resp(d) for d in get_responses])
+    if post_responses:
+        session.post = MagicMock(side_effect=[_make_resp(d) for d in post_responses])
+    else:
+        session.post = MagicMock()
+    session.close = AsyncMock()
+    return session
+
+
+async def test_three_phase():
+    session = _make_session(
+        get_responses=[
+            {"serial": "123", "authentication": False},
+            {
+                "1-0:21.4.0*255": 1,
+                "1-0:22.4.0*255": 0,
+                "1-0:41.4.0*255": 2,
+                "1-0:42.4.0*255": 0,
+                "1-0:61.4.0*255": 3,
+                "1-0:62.4.0*255": 0,
+            },
+        ],
+        post_responses=[{"authentication": True}],
+    )
+    with patch("aiohttp.ClientSession", return_value=session):
         meter = TQEnergyManager("192.168.0.10")
-        self.assertEqual(meter.get_powermeter_watts(), [1.0, 2.0, 3.0])
+        await meter.start()
+        assert await meter.get_powermeter_watts_async() == [1.0, 2.0, 3.0]
+        await meter.stop()
 
-    @patch("requests.Session.post")
-    @patch("requests.Session.get")
-    def test_total_only(self, mock_get, mock_post):
-        mock_get.side_effect = [
-            MagicMock(
-                status_code=200,
-                json=lambda: {"serial": "321", "authentication": False},
-            ),
-            MagicMock(
-                status_code=200,
-                json=lambda: {"1-0:1.4.0*255": 9, "1-0:2.4.0*255": 0},
-            ),
-        ]
-        mock_post.return_value = MagicMock(
-            status_code=200, json=lambda: {"authentication": True}
-        )
 
+async def test_total_only():
+    session = _make_session(
+        get_responses=[
+            {"serial": "321", "authentication": False},
+            {"1-0:1.4.0*255": 9, "1-0:2.4.0*255": 0},
+        ],
+        post_responses=[{"authentication": True}],
+    )
+    with patch("aiohttp.ClientSession", return_value=session):
         meter = TQEnergyManager("192.168.0.12")
-        self.assertEqual(meter.get_powermeter_watts(), [9.0])
+        await meter.start()
+        assert await meter.get_powermeter_watts_async() == [9.0]
+        await meter.stop()
 
-    @patch("requests.Session.post")
-    @patch("requests.Session.get")
-    def test_relogin_on_expired_session(self, mock_get, mock_post):
-        mock_get.side_effect = [
-            MagicMock(
-                status_code=200,
-                json=lambda: {"serial": "123", "authentication": False},
-            ),
-            MagicMock(status_code=200, json=lambda: {"status": 901}),
-            MagicMock(
-                status_code=200,
-                json=lambda: {"serial": "123", "authentication": False},
-            ),
-            MagicMock(
-                status_code=200,
-                json=lambda: {"1-0:1.4.0*255": 5, "1-0:2.4.0*255": 0},
-            ),
-        ]
-        mock_post.side_effect = [
-            MagicMock(status_code=200, json=lambda: {"authentication": True}),
-            MagicMock(status_code=200, json=lambda: {"authentication": True}),
-        ]
 
+async def test_relogin_on_expired_session():
+    session = _make_session(
+        get_responses=[
+            {"serial": "123", "authentication": False},
+            {"status": 901},
+            {"serial": "123", "authentication": False},
+            {"1-0:1.4.0*255": 5, "1-0:2.4.0*255": 0},
+        ],
+        post_responses=[
+            {"authentication": True},
+            {"authentication": True},
+        ],
+    )
+    with patch("aiohttp.ClientSession", return_value=session):
         meter = TQEnergyManager("192.168.0.11")
-        self.assertEqual(meter.get_powermeter_watts(), [5.0])
+        await meter.start()
+        assert await meter.get_powermeter_watts_async() == [5.0]
+        await meter.stop()
 
-    @patch("requests.Session.post")
-    @patch("requests.Session.get")
-    def test_missing_export(self, mock_get, mock_post):
-        mock_get.side_effect = [
-            MagicMock(
-                status_code=200,
-                json=lambda: {"serial": "111", "authentication": False},
-            ),
-            MagicMock(
-                status_code=200,
-                json=lambda: {"1-0:1.4.0*255": 4},
-            ),
-        ]
-        mock_post.return_value = MagicMock(
-            status_code=200, json=lambda: {"authentication": True}
-        )
 
+async def test_missing_export():
+    session = _make_session(
+        get_responses=[
+            {"serial": "111", "authentication": False},
+            {"1-0:1.4.0*255": 4},
+        ],
+        post_responses=[{"authentication": True}],
+    )
+    with patch("aiohttp.ClientSession", return_value=session):
         meter = TQEnergyManager("192.168.0.15")
-        self.assertEqual(meter.get_powermeter_watts(), [4.0])
+        await meter.start()
+        assert await meter.get_powermeter_watts_async() == [4.0]
+        await meter.stop()
 
-    @patch("requests.Session.post")
-    @patch("requests.Session.get")
-    def test_three_phase_missing_export(self, mock_get, mock_post):
-        mock_get.side_effect = [
-            MagicMock(
-                status_code=200,
-                json=lambda: {"serial": "777", "authentication": False},
-            ),
-            MagicMock(
-                status_code=200,
-                json=lambda: {
-                    "1-0:21.4.0*255": 1,
-                    "1-0:41.4.0*255": 2,
-                    "1-0:61.4.0*255": 3,
-                },
-            ),
-        ]
-        mock_post.return_value = MagicMock(
-            status_code=200, json=lambda: {"authentication": True}
-        )
 
+async def test_three_phase_missing_export():
+    session = _make_session(
+        get_responses=[
+            {"serial": "777", "authentication": False},
+            {
+                "1-0:21.4.0*255": 1,
+                "1-0:41.4.0*255": 2,
+                "1-0:61.4.0*255": 3,
+            },
+        ],
+        post_responses=[{"authentication": True}],
+    )
+    with patch("aiohttp.ClientSession", return_value=session):
         meter = TQEnergyManager("192.168.0.16")
-        self.assertEqual(meter.get_powermeter_watts(), [1.0, 2.0, 3.0])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        await meter.start()
+        assert await meter.get_powermeter_watts_async() == [1.0, 2.0, 3.0]
+        await meter.stop()


### PR DESCRIPTION
## Summary
Migrated all powermeter implementations from synchronous `requests` library to asynchronous `aiohttp`, introducing proper async lifecycle management with `start()` and `stop()` methods.

## Key Changes

### Core Implementation
- **TQEnergyManager**: Converted from `requests.Session` to `aiohttp.ClientSession`
  - Added `start()` and `stop()` async lifecycle methods
  - Renamed `get_powermeter_watts()` to `get_powermeter_watts_async()`
  - Converted all HTTP operations to async context managers (`async with`)
  - Updated session state management with proper initialization checks

- **JsonHttpPowermeter**: Migrated to async aiohttp
  - Added `start()` and `stop()` lifecycle methods
  - Converted `get_json()` and `get_powermeter_watts()` to async
  - Replaced `HTTPBasicAuth` with `aiohttp.BasicAuth`
  - Moved auth and headers to session initialization

- **Tasmota**: Converted to async aiohttp
  - Added `start()` and `stop()` lifecycle methods
  - Converted `get_json()` and `get_powermeter_watts()` to async
  - Updated URL construction and JSON parsing for async context

### Testing
- Converted all test files from `unittest.TestCase` to pytest-style async tests
- Replaced `@patch` decorators with fixture-based mocking
- Created helper functions for mock aiohttp responses with async context manager support
- Updated `conftest.py` with enhanced `mock_aiohttp_session` fixture supporting both GET and POST operations
- All tests now use `async def` and `await` for async operations

## Implementation Details
- All HTTP timeouts are now configured at session creation time via `ClientTimeout`
- Session lifecycle is explicitly managed; methods raise `RuntimeError` if called before `start()`
- Mock responses properly implement async context manager protocol (`__aenter__`/`__aexit__`)
- Error handling updated to use `aiohttp.ClientError` instead of `requests.exceptions.RequestException`
- JSON parsing uses `content_type=None` parameter for flexibility with various response types

https://claude.ai/code/session_01SBNt14o7KsmWXnKS3tfqcK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Powermeter implementations have been updated to use asynchronous operations instead of synchronous blocking calls.

* **New Features**
  * Added start() and stop() lifecycle management methods for powermeter clients.

* **Tests**
  * Updated powermeter tests to support asynchronous operation patterns with proper lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->