### PR TITLE
Migrate MQTT client from paho-mqtt to aiomqtt with async support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install mosquitto (for MQTT integration tests)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq mosquitto
+
       - name: Install dependencies
         run: uv sync --frozen --extra dev
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "aiohttp>=3.9.0",
     "requests",
     "urllib3",
-    "paho-mqtt",
+    "aiomqtt>=2.0.0,<3",
     "jsonpath-ng",
     "pymodbus==3.6.5",
     "websocket-client==1.8.0",

--- a/src/b2500_meter/powermeter/mqtt.py
+++ b/src/b2500_meter/powermeter/mqtt.py
@@ -1,12 +1,15 @@
+import asyncio
+import contextlib
 import json
-import time
 
-import paho.mqtt.client as mqtt
+import aiomqtt
 from jsonpath_ng import parse
 
 from b2500_meter.config.logger import logger
 
 from .base import Powermeter
+
+RECONNECT_DELAY = 5
 
 
 def extract_json_value(data, path):
@@ -34,44 +37,62 @@ class MqttPowermeter(Powermeter):
         self.json_path = json_path
         self.username = username
         self.password = password
-        self.value = None
+        self.value: float | None = None
+        self._run_task: asyncio.Task[None] | None = None
+        self._message_event = asyncio.Event()
+        self._connected_event = asyncio.Event()
 
-        # Initialize MQTT client
-        self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
-        if self.username and self.password:
-            self.client.username_pw_set(self.username, self.password)
-        self.client.on_connect = self.on_connect
-        self.client.on_message = self.on_message
+    async def start(self) -> None:
+        self._run_task = asyncio.create_task(self._run())
 
-        # Connect to the broker
-        self.client.connect(self.broker, self.port, 60)
-        self.client.loop_start()
-
-    def on_connect(self, client, userdata, flags, reason_code, properties):
-        logger.info(f"Connected with result code {reason_code}")
-        # Subscribe to the topic
-        client.subscribe(self.topic)
-
-    def on_message(self, client, userdata, msg):
-        payload = msg.payload.decode()
-        if self.json_path:
+    async def _run(self) -> None:
+        while True:
             try:
-                data = json.loads(payload)
-                self.value = extract_json_value(data, self.json_path)
-            except json.JSONDecodeError:
-                logger.error("Failed to decode JSON")
-        else:
-            self.value = float(payload)
+                async with aiomqtt.Client(
+                    hostname=self.broker,
+                    port=self.port,
+                    username=self.username,
+                    password=self.password,
+                    keepalive=60,
+                ) as client:
+                    logger.info(f"Connected to MQTT broker {self.broker}:{self.port}")
+                    await client.subscribe(self.topic)
+                    self._connected_event.set()
+                    async for message in client.messages:
+                        raw = message.payload
+                        payload = raw.decode() if isinstance(raw, bytes) else str(raw)
+                        try:
+                            if self.json_path:
+                                data = json.loads(payload)
+                                self.value = extract_json_value(data, self.json_path)
+                            else:
+                                self.value = float(payload)
+                            self._message_event.set()
+                        except (json.JSONDecodeError, ValueError) as e:
+                            logger.error(f"Failed to parse MQTT payload: {e}")
+            except aiomqtt.MqttError as e:
+                self._connected_event.clear()
+                logger.warning(
+                    f"MQTT connection error: {e}. Reconnecting in {RECONNECT_DELAY}s..."
+                )
+                await asyncio.sleep(RECONNECT_DELAY)
 
-    def get_powermeter_watts(self):
+    async def stop(self) -> None:
+        if self._run_task:
+            self._run_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._run_task
+            self._run_task = None
+
+    async def get_powermeter_watts_async(self) -> list[float]:
         if self.value is not None:
             return [self.value]
-        else:
-            raise ValueError("No value received from MQTT")
+        raise ValueError("No value received from MQTT")
 
-    def wait_for_message(self, timeout=5):
-        start_time = time.time()
-        while self.value is None:
-            if time.time() - start_time > timeout:
-                raise TimeoutError("Timeout waiting for MQTT message")
-            time.sleep(1)
+    async def wait_for_message_async(self, timeout=5):
+        if self.value is not None:
+            return
+        try:
+            await asyncio.wait_for(self._message_event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            raise TimeoutError("Timeout waiting for MQTT message") from None

--- a/src/b2500_meter/powermeter/mqtt.py
+++ b/src/b2500_meter/powermeter/mqtt.py
@@ -43,6 +43,9 @@ class MqttPowermeter(Powermeter):
         self._connected_event = asyncio.Event()
 
     async def start(self) -> None:
+        self.value = None
+        self._message_event.clear()
+        self._connected_event.clear()
         self._run_task = asyncio.create_task(self._run())
 
     async def _run(self) -> None:

--- a/src/b2500_meter/powermeter/mqtt_test.py
+++ b/src/b2500_meter/powermeter/mqtt_test.py
@@ -82,7 +82,6 @@ async def test_get_powermeter_watts_async_raises_when_no_value():
 async def test_wait_for_message_async_returns_immediately():
     pm = _make_pm()
     pm.value = 1.0
-    pm._message_event.set()
     await pm.wait_for_message_async(timeout=0.1)
 
 
@@ -155,6 +154,7 @@ def mqtt_broker():
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.wait()
+    shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 @_needs_mosquitto

--- a/src/b2500_meter/powermeter/mqtt_test.py
+++ b/src/b2500_meter/powermeter/mqtt_test.py
@@ -1,46 +1,227 @@
-import unittest
+import asyncio
+import json
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
 
-from .mqtt import extract_json_value
+import pytest
+
+from .mqtt import MqttPowermeter, extract_json_value
+
+# ---------------------------------------------------------------------------
+# extract_json_value unit tests
+# ---------------------------------------------------------------------------
 
 
-class TestExtractJsonValue(unittest.TestCase):
-    def test_extract_curr_w(self):
-        data = {
-            "SML": {
-                "curr_w": 381,
-            }
+def test_extract_curr_w():
+    data = {"SML": {"curr_w": 381}}
+    assert extract_json_value(data, "$.SML.curr_w") == 381
+
+
+def test_extract_nonexistent_path():
+    data = {"SML": {"curr_w": 381}}
+    with pytest.raises(ValueError):
+        extract_json_value(data, "$.SML.nonexistent")
+
+
+def test_extract_float_value():
+    data = {"SML": {"curr_w": 381.75}}
+    assert extract_json_value(data, "$.SML.curr_w") == 381.75
+
+
+def test_extract_from_array():
+    data = {
+        "SML": {
+            "measurements": [{"curr_w": 100.5}, {"curr_w": 200.75}, {"curr_w": 300}]
         }
-        path = "$.SML.curr_w"
-        self.assertEqual(extract_json_value(data, path), 381)
-
-    def test_extract_nonexistent_path(self):
-        data = {
-            "SML": {
-                "curr_w": 381,
-            }
-        }
-        path = "$.SML.nonexistent"
-        with self.assertRaises(ValueError):
-            extract_json_value(data, path)
-
-    def test_extract_float_value(self):
-        data = {
-            "SML": {
-                "curr_w": 381.75,
-            }
-        }
-        path = "$.SML.curr_w"
-        self.assertEqual(extract_json_value(data, path), 381.75)
-
-    def test_extract_from_array(self):
-        data = {
-            "SML": {
-                "measurements": [{"curr_w": 100.5}, {"curr_w": 200.75}, {"curr_w": 300}]
-            }
-        }
-        path = "$.SML.measurements[1].curr_w"
-        self.assertEqual(extract_json_value(data, path), 200.75)
+    }
+    assert extract_json_value(data, "$.SML.measurements[1].curr_w") == 200.75
 
 
-if __name__ == "__main__":
-    unittest.main()
+# ---------------------------------------------------------------------------
+# MqttPowermeter async unit tests (no broker needed)
+# ---------------------------------------------------------------------------
+
+TEST_TOPIC = "test/power"
+
+
+def _make_pm(
+    broker: str = "localhost",
+    port: int = 1883,
+    topic: str = TEST_TOPIC,
+    json_path: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+) -> MqttPowermeter:
+    return MqttPowermeter(
+        broker=broker,
+        port=port,
+        topic=topic,
+        json_path=json_path,
+        username=username,
+        password=password,
+    )
+
+
+async def test_get_powermeter_watts_async_returns_value():
+    pm = _make_pm()
+    pm.value = 42.0
+    assert await pm.get_powermeter_watts_async() == [42.0]
+
+
+async def test_get_powermeter_watts_async_raises_when_no_value():
+    pm = _make_pm()
+    with pytest.raises(ValueError, match="No value received"):
+        await pm.get_powermeter_watts_async()
+
+
+async def test_wait_for_message_async_returns_immediately():
+    pm = _make_pm()
+    pm.value = 1.0
+    pm._message_event.set()
+    await pm.wait_for_message_async(timeout=0.1)
+
+
+async def test_wait_for_message_async_times_out():
+    pm = _make_pm()
+    with pytest.raises(TimeoutError, match="Timeout waiting"):
+        await pm.wait_for_message_async(timeout=0.1)
+
+
+async def test_wait_for_message_async_wakes_on_event():
+    pm = _make_pm()
+
+    async def _set_later():
+        await asyncio.sleep(0.05)
+        pm.value = 99.0
+        pm._message_event.set()
+
+    task = asyncio.create_task(_set_later())
+    await pm.wait_for_message_async(timeout=2)
+    await task
+    assert pm.value == 99.0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require mosquitto)
+# ---------------------------------------------------------------------------
+
+_needs_mosquitto = pytest.mark.skipif(
+    shutil.which("mosquitto") is None,
+    reason="mosquitto not installed",
+)
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def mqtt_broker():
+    port = _find_free_port()
+    tmpdir = tempfile.mkdtemp()
+    config_path = Path(tmpdir) / "mosquitto.conf"
+    config_path.write_text(
+        f"listener {port} 127.0.0.1\nallow_anonymous true\npersistence false\n"
+    )
+    proc = subprocess.Popen(
+        ["mosquitto", "-c", str(config_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    # Wait for broker to be ready
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        proc.terminate()
+        raise RuntimeError("mosquitto did not start in time")
+
+    yield port
+
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+@_needs_mosquitto
+async def test_receives_plain_value(mqtt_broker):
+    import aiomqtt
+
+    port = mqtt_broker
+    topic = "test/plain"
+    pm = MqttPowermeter(broker="127.0.0.1", port=port, topic=topic)
+    await pm.start()
+    try:
+        await asyncio.wait_for(pm._connected_event.wait(), timeout=5)
+        async with aiomqtt.Client(hostname="127.0.0.1", port=port) as pub:
+            await pub.publish(topic, payload=b"42.5")
+        await pm.wait_for_message_async(timeout=5)
+        assert await pm.get_powermeter_watts_async() == [42.5]
+    finally:
+        await pm.stop()
+
+
+@_needs_mosquitto
+async def test_receives_json_value(mqtt_broker):
+    import aiomqtt
+
+    port = mqtt_broker
+    topic = "test/json"
+    pm = MqttPowermeter(broker="127.0.0.1", port=port, topic=topic, json_path="$.power")
+    await pm.start()
+    try:
+        await asyncio.wait_for(pm._connected_event.wait(), timeout=5)
+        async with aiomqtt.Client(hostname="127.0.0.1", port=port) as pub:
+            await pub.publish(topic, payload=json.dumps({"power": 123.4}).encode())
+        await pm.wait_for_message_async(timeout=5)
+        assert await pm.get_powermeter_watts_async() == [123.4]
+    finally:
+        await pm.stop()
+
+
+@_needs_mosquitto
+async def test_wait_for_message_timeout_with_no_publish(mqtt_broker):
+    port = mqtt_broker
+    topic = "test/timeout"
+    pm = MqttPowermeter(broker="127.0.0.1", port=port, topic=topic)
+    await pm.start()
+    try:
+        await asyncio.wait_for(pm._connected_event.wait(), timeout=5)
+        with pytest.raises(TimeoutError):
+            await pm.wait_for_message_async(timeout=0.5)
+    finally:
+        await pm.stop()
+
+
+@_needs_mosquitto
+async def test_receives_multiple_messages_returns_latest(mqtt_broker):
+    import aiomqtt
+
+    port = mqtt_broker
+    topic = "test/multi"
+    pm = MqttPowermeter(broker="127.0.0.1", port=port, topic=topic)
+    await pm.start()
+    try:
+        await asyncio.wait_for(pm._connected_event.wait(), timeout=5)
+        async with aiomqtt.Client(hostname="127.0.0.1", port=port) as pub:
+            for val in [10.0, 20.0, 30.0]:
+                await pub.publish(topic, payload=str(val).encode())
+        # Give the listener time to process all messages
+        await asyncio.sleep(0.5)
+        assert await pm.get_powermeter_watts_async() == [30.0]
+    finally:
+        await pm.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -136,6 +136,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aiomqtt"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "paho-mqtt" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/44/cfc58272783a11729462dc6df5adbfeabd084f840f609054ac772ae98c19/aiomqtt-2.5.1.tar.gz", hash = "sha256:25a0a47d157e8f158d2da1110ea4786c0615518751e94f7b04976c977a8ff20d", size = 86641, upload-time = "2026-03-05T18:28:56.421Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/9e/5089fa596220bf0dc73deeb23db27904e4b3504986caf08571f6f5cb84a8/aiomqtt-2.5.1-py3-none-any.whl", hash = "sha256:fd58c3593160e4d475d90ce911cdfc4239cd64de96b0ba22edf6c86bd7afa278", size = 16051, upload-time = "2026-03-05T18:28:55.14Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -172,8 +185,8 @@ version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "aiomqtt" },
     { name = "jsonpath-ng" },
-    { name = "paho-mqtt" },
     { name = "pymodbus" },
     { name = "pyserial" },
     { name = "requests" },
@@ -198,9 +211,9 @@ sim = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
+    { name = "aiomqtt", specifier = ">=2.0.0,<3" },
     { name = "jsonpath-ng" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
-    { name = "paho-mqtt" },
     { name = "pymodbus", specifier = "==3.6.5" },
     { name = "pyserial" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },


### PR DESCRIPTION
## Summary
Refactored the MQTT powermeter implementation to use the `aiomqtt` library instead of `paho-mqtt`, enabling full async/await support and improving the overall architecture. Updated all tests to use pytest with async test functions and added comprehensive integration tests with a real MQTT broker.

## Key Changes

### Source Code (`mqtt.py`)
- **Replaced MQTT client library**: Migrated from `paho.mqtt.client` (callback-based) to `aiomqtt` (async-native)
- **Async architecture**: Converted all blocking operations to async:
  - `get_powermeter_watts()` → `get_powermeter_watts_async()`
  - `wait_for_message()` → `wait_for_message_async()`
  - Added `start()` and `stop()` lifecycle methods
- **Connection management**: Implemented automatic reconnection with configurable delay (5s) on connection failures
- **Event-driven messaging**: Replaced polling with `asyncio.Event` for message arrival notifications
- **Improved error handling**: Better exception handling for JSON parsing and MQTT errors with detailed logging

### Tests (`mqtt_test.py`)
- **Migrated from unittest to pytest**: Converted all test classes to pytest-style functions
- **Async test support**: All tests now use `async def` and `await` syntax
- **Unit tests**: Kept existing `extract_json_value` tests with simplified assertions
- **Async unit tests**: Added tests for async methods without requiring a broker
- **Integration tests**: Added comprehensive integration tests that:
  - Spawn a real mosquitto broker instance
  - Test plain value reception
  - Test JSON path extraction
  - Test timeout behavior
  - Test multiple message handling
  - Skip gracefully if mosquitto is not installed

### Dependencies (`pyproject.toml`)
- Replaced `paho-mqtt` with `aiomqtt>=2.0.0,<3`

## Notable Implementation Details
- The `_run()` coroutine handles the main MQTT connection loop with automatic reconnection
- Message events are cleared before waiting to avoid race conditions
- Integration tests use a session-scoped fixture to manage the mosquitto broker lifecycle
- All async operations properly handle cancellation and cleanup

https://claude.ai/code/session_01EL4fBh2cZ7uufvJhvZZGuj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Migrated MQTT client to asynchronous implementation for improved performance and responsiveness
  * Updated MQTT library dependency to the latest version

* **Tests**
  * Expanded test coverage with integration tests validating broker communication and message handling

* **Chores**
  * Updated CI environment setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->