### PR TITLE
Migrate ModbusPowermeter to async/await with lifecycle management

### DIFF
--- a/src/b2500_meter/powermeter/modbus.py
+++ b/src/b2500_meter/powermeter/modbus.py
@@ -1,4 +1,4 @@
-from pymodbus.client import ModbusTcpClient
+from pymodbus.client import AsyncModbusTcpClient
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
 
@@ -57,11 +57,26 @@ class ModbusPowermeter(Powermeter):
         if not self._read_method:
             raise ValueError(f"Unsupported register type: {register_type}")
 
-        self.client = ModbusTcpClient(host, port=port)
+        self.client: AsyncModbusTcpClient | None = None
 
-    def get_powermeter_watts(self):
+    async def start(self) -> None:
+        if self.client:
+            return
+        self.client = AsyncModbusTcpClient(self.host, port=self.port)
+        if not await self.client.connect():
+            self.client = None
+            raise ConnectionError(f"Failed to connect to {self.host}:{self.port}")
+
+    async def stop(self) -> None:
+        if self.client:
+            self.client.close()
+            self.client = None
+
+    async def get_powermeter_watts_async(self) -> list[float]:
+        if not self.client:
+            raise RuntimeError("Client not started; call start() first")
         read = getattr(self.client, self._read_method)
-        result = read(self.address, self.count, slave=self.unit_id)
+        result = await read(self.address, self.count, slave=self.unit_id)
         if result.isError():
             raise Exception("Error reading Modbus data")
         decoder = BinaryPayloadDecoder.fromRegisters(

--- a/src/b2500_meter/powermeter/modbus_test.py
+++ b/src/b2500_meter/powermeter/modbus_test.py
@@ -1,28 +1,52 @@
-import unittest
-from unittest.mock import patch
+import struct
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pymodbus.datastore import (
+    ModbusSequentialDataBlock,
+    ModbusServerContext,
+    ModbusSlaveContext,
+)
+from pymodbus.server import ModbusTcpServer
 
 from b2500_meter.powermeter import ModbusPowermeter
 
+# ---------------------------------------------------------------------------
+# Tier 1 — Migration-critical (mock-based)
+# ---------------------------------------------------------------------------
 
-class TestPowermeters(unittest.TestCase):
-    @patch("b2500_meter.powermeter.modbus.ModbusTcpClient")
-    def test_modbuspowermeter_get_powermeter_watts(self, MockModbusTcpClient):
-        mock_client = MockModbusTcpClient.return_value
-        mock_client.read_holding_registers.return_value.isError.return_value = False
-        mock_client.read_holding_registers.return_value.registers = [500]
 
-        modbuspowermeter = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
-        self.assertEqual(modbuspowermeter.get_powermeter_watts(), [500.0])
-        MockModbusTcpClient.assert_called_with("192.168.1.14", port=502)
+async def test_get_powermeter_watts():
+    with patch("b2500_meter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
+        mock_client = MockClient.return_value
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_client.close = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.isError.return_value = False
+        mock_result.registers = [500]
+        mock_client.read_holding_registers = AsyncMock(return_value=mock_result)
+
+        pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
+        await pm.start()
+        assert await pm.get_powermeter_watts_async() == [500.0]
+        MockClient.assert_called_with("192.168.1.14", port=502)
         mock_client.read_holding_registers.assert_called_once_with(0, 1, slave=1)
+        await pm.stop()
 
-    @patch("b2500_meter.powermeter.modbus.ModbusTcpClient")
-    def test_modbuspowermeter_float32(self, MockModbusTcpClient):
-        mock_client = MockModbusTcpClient.return_value
-        mock_client.read_holding_registers.return_value.isError.return_value = False
-        mock_client.read_holding_registers.return_value.registers = [0x4120, 0x0000]
 
-        modbuspowermeter = ModbusPowermeter(
+async def test_float32():
+    with patch("b2500_meter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
+        mock_client = MockClient.return_value
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_client.close = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.isError.return_value = False
+        mock_result.registers = [0x4120, 0x0000]
+        mock_client.read_holding_registers = AsyncMock(return_value=mock_result)
+
+        pm = ModbusPowermeter(
             "192.168.1.14",
             502,
             1,
@@ -32,21 +56,175 @@ class TestPowermeters(unittest.TestCase):
             byte_order="BIG",
             word_order="BIG",
         )
-        self.assertEqual(modbuspowermeter.get_powermeter_watts(), [10.0])
+        await pm.start()
+        assert await pm.get_powermeter_watts_async() == [10.0]
         mock_client.read_holding_registers.assert_called_once_with(0, 2, slave=1)
+        await pm.stop()
 
-    @patch("b2500_meter.powermeter.modbus.ModbusTcpClient")
-    def test_modbuspowermeter_input_registers(self, MockModbusTcpClient):
-        mock_client = MockModbusTcpClient.return_value
-        mock_client.read_input_registers.return_value.isError.return_value = False
-        mock_client.read_input_registers.return_value.registers = [500]
 
-        modbuspowermeter = ModbusPowermeter(
-            "192.168.1.14", 502, 1, 0, 1, register_type="INPUT"
-        )
-        self.assertEqual(modbuspowermeter.get_powermeter_watts(), [500.0])
+async def test_input_registers():
+    with patch("b2500_meter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
+        mock_client = MockClient.return_value
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_client.close = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.isError.return_value = False
+        mock_result.registers = [500]
+        mock_client.read_input_registers = AsyncMock(return_value=mock_result)
+
+        pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1, register_type="INPUT")
+        await pm.start()
+        assert await pm.get_powermeter_watts_async() == [500.0]
         mock_client.read_input_registers.assert_called_once_with(0, 1, slave=1)
+        await pm.stop()
 
 
-if __name__ == "__main__":
-    unittest.main()
+async def test_start_creates_client_and_connects():
+    pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
+    assert pm.client is None
+    with patch("b2500_meter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
+        mock_instance = MockClient.return_value
+        mock_instance.connect = AsyncMock(return_value=True)
+        await pm.start()
+        MockClient.assert_called_once_with("192.168.1.14", port=502)
+        mock_instance.connect.assert_awaited_once()
+        assert pm.client is mock_instance
+
+
+async def test_read_before_start_raises():
+    pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
+    with pytest.raises(RuntimeError, match="Client not started"):
+        await pm.get_powermeter_watts_async()
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — Lifecycle correctness (mock-based)
+# ---------------------------------------------------------------------------
+
+
+async def test_stop_closes_and_resets():
+    with patch("b2500_meter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
+        mock_instance = MockClient.return_value
+        mock_instance.connect = AsyncMock(return_value=True)
+        mock_instance.close = MagicMock()
+
+        pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
+        await pm.start()
+        await pm.stop()
+        mock_instance.close.assert_called_once()
+        assert pm.client is None
+
+
+async def test_start_is_idempotent():
+    with patch("b2500_meter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
+        mock_instance = MockClient.return_value
+        mock_instance.connect = AsyncMock(return_value=True)
+
+        pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
+        await pm.start()
+        await pm.start()
+        MockClient.assert_called_once()
+        mock_instance.connect.assert_awaited_once()
+
+
+async def test_read_error_raises():
+    with patch("b2500_meter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
+        mock_client = MockClient.return_value
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_client.close = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.isError.return_value = True
+        mock_client.read_holding_registers = AsyncMock(return_value=mock_result)
+
+        pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
+        await pm.start()
+        with pytest.raises(Exception, match="Error reading Modbus data"):
+            await pm.get_powermeter_watts_async()
+        await pm.stop()
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 — E2E with local Modbus TCP server
+# ---------------------------------------------------------------------------
+
+
+def _float32_to_registers(value: float) -> list[int]:
+    """Encode a float as two big-endian 16-bit registers."""
+    packed = struct.pack(">f", value)
+    return [int.from_bytes(packed[0:2], "big"), int.from_bytes(packed[2:4], "big")]
+
+
+@pytest.fixture
+async def modbus_server():
+    """Start a local Modbus TCP server on an ephemeral port."""
+    # Holding registers: address 0+ with some known values
+    hr_values = [0] * 100
+    hr_values[0] = 500  # UINT16 at address 0
+    # FLOAT32 for 10.0 at address 10 (two registers)
+    float_regs = _float32_to_registers(10.0)
+    hr_values[10] = float_regs[0]
+    hr_values[11] = float_regs[1]
+
+    # Input registers: address 0+ with known values
+    ir_values = [0] * 100
+    ir_values[0] = 750
+
+    store = ModbusSlaveContext(
+        hr=ModbusSequentialDataBlock(0, hr_values),
+        ir=ModbusSequentialDataBlock(0, ir_values),
+        zero_mode=True,
+    )
+    context = ModbusServerContext(slaves=store, single=True)
+    server = ModbusTcpServer(context, address=("127.0.0.1", 0))
+    await server.listen()
+    port = server.transport.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+    yield port
+    await server.shutdown()
+
+
+async def test_e2e_uint16_holding(modbus_server: int):
+    pm = ModbusPowermeter("127.0.0.1", modbus_server, 1, 0, 1)
+    await pm.start()
+    try:
+        result = await pm.get_powermeter_watts_async()
+        assert result == [500.0]
+    finally:
+        await pm.stop()
+
+
+async def test_e2e_float32(modbus_server: int):
+    pm = ModbusPowermeter(
+        "127.0.0.1",
+        modbus_server,
+        1,
+        10,
+        2,
+        data_type="FLOAT32",
+        byte_order="BIG",
+        word_order="BIG",
+    )
+    await pm.start()
+    try:
+        result = await pm.get_powermeter_watts_async()
+        assert result == [10.0]
+    finally:
+        await pm.stop()
+
+
+async def test_e2e_input_registers(modbus_server: int):
+    pm = ModbusPowermeter(
+        "127.0.0.1",
+        modbus_server,
+        1,
+        0,
+        1,
+        register_type="INPUT",
+    )
+    await pm.start()
+    try:
+        result = await pm.get_powermeter_watts_async()
+        assert result == [750.0]
+    finally:
+        await pm.stop()


### PR DESCRIPTION
## Summary
Refactored `ModbusPowermeter` to use async/await patterns with explicit lifecycle management (`start()`/`stop()` methods), replacing the synchronous `ModbusTcpClient` with `AsyncModbusTcpClient`. Updated all tests to use pytest with async test functions and added comprehensive test coverage including end-to-end tests with a local Modbus TCP server.

## Key Changes

**Source Code (`modbus.py`):**
- Replaced `ModbusTcpClient` with `AsyncModbusTcpClient` for non-blocking I/O
- Changed client initialization from constructor to explicit `start()` method
- Added `stop()` method for proper resource cleanup and client reset
- Renamed `get_powermeter_watts()` to `get_powermeter_watts_async()` and made it async
- Added runtime check to ensure client is started before reading
- Stored host/port as instance variables for use in `start()`

**Tests (`modbus_test.py`):**
- Migrated from `unittest` to `pytest` with async test support
- Converted all test methods to async functions
- Updated mocks to use `AsyncMock` for async methods
- Organized tests into three tiers:
  - **Tier 1**: Migration-critical mock-based tests (basic functionality)
  - **Tier 2**: Lifecycle correctness tests (start/stop behavior, error handling)
  - **Tier 3**: End-to-end tests with a real local Modbus TCP server
- Added fixture for ephemeral Modbus TCP server with pre-populated registers
- Added helper function `_float32_to_registers()` for test data encoding
- Added tests for edge cases: reading before start, idempotent start, read errors

## Notable Implementation Details
- `start()` is idempotent—calling it multiple times only creates and connects once
- `stop()` safely handles the case where client is already `None`
- Client state is explicitly managed; `None` indicates not started
- E2E tests validate actual Modbus protocol communication without mocks

https://claude.ai/code/session_01ToWVHhS1NaZ8n4CHn5yFaL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Power meter API is now asynchronous. `get_powermeter_watts_async()` replaces the previous synchronous method.
  * New lifecycle methods required: call `start()` before reading power data and `stop()` when finished.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->