### PR TITLE
Convert HomeAssistant to async/await with aiohttp

### DIFF
--- a/src/b2500_meter/powermeter/homeassistant.py
+++ b/src/b2500_meter/powermeter/homeassistant.py
@@ -1,12 +1,19 @@
 import asyncio
 import contextlib
 import json
+import logging
+from typing import Any
 
 import aiohttp
 
-from b2500_meter.config.logger import logger
-
 from .base import Powermeter
+
+# Stdlib logger: avoid importing b2500_meter.config (config_loader imports powermeter).
+logger = logging.getLogger("b2500-meter")
+
+# Home Assistant websocket subscribe_entities compressed state (homeassistant.const)
+_HA_S = "s"
+_HA_DIFF_ADD = "+"
 
 
 class HomeAssistant(Powermeter):
@@ -47,7 +54,7 @@ class HomeAssistant(Powermeter):
         self._entity_values: dict[str, float | None] = {}
         self._tracked_entities = self._collect_entities()
         self._msg_id = 0
-        self._get_states_id: int | None = None
+        self._subscribe_entities_id: int | None = None
         self._session: aiohttp.ClientSession | None = None
         self._ws_task: asyncio.Task[None] | None = None
         self._entities_ready = asyncio.Event()
@@ -108,10 +115,35 @@ class HomeAssistant(Powermeter):
                 logger.error(f"Home Assistant WebSocket error: {e}")
             # Reset protocol state for reconnection; keep _entity_values
             # (stale values are preferable to ValueError during brief disconnect;
-            # get_states on reconnect will refresh them)
+            # subscribe_entities re-sends initial states on reconnect)
             self._msg_id = 0
-            self._get_states_id = None
+            self._subscribe_entities_id = None
             await asyncio.sleep(5)
+
+    def _handle_compressed_entity_event(self, ev: dict[str, Any]) -> None:
+        """Apply subscribe_entities payloads (initial + diffs)."""
+        additions = ev.get("a")
+        if isinstance(additions, dict):
+            for eid, st in additions.items():
+                if (
+                    eid in self._tracked_entities
+                    and isinstance(st, dict)
+                    and _HA_S in st
+                ):
+                    self._update_entity_value(eid, st.get(_HA_S))
+        changes = ev.get("c")
+        if isinstance(changes, dict):
+            for eid, diff in changes.items():
+                if eid not in self._tracked_entities or not isinstance(diff, dict):
+                    continue
+                plus = diff.get(_HA_DIFF_ADD)
+                if isinstance(plus, dict) and _HA_S in plus:
+                    self._update_entity_value(eid, plus.get(_HA_S))
+        removals = ev.get("r")
+        if isinstance(removals, list):
+            for eid in removals:
+                if eid in self._tracked_entities:
+                    self._update_entity_value(eid, None)
 
     async def _handle_message(
         self, ws: aiohttp.ClientWebSocketResponse, raw: str
@@ -125,49 +157,37 @@ class HomeAssistant(Powermeter):
         msg_type = msg.get("type")
 
         if msg_type == "auth_required":
+            logger.debug("Home Assistant: auth required, sending token")
             await ws.send_json({"type": "auth", "access_token": self.access_token})
         elif msg_type == "auth_ok":
             logger.info("Home Assistant: authenticated")
-            self._get_states_id = self._next_id()
-            await ws.send_json({"id": self._get_states_id, "type": "get_states"})
-            subscribe_id = self._next_id()
+            if not self._tracked_entities:
+                logger.error(
+                    "Home Assistant: no entity IDs configured for subscription"
+                )
+                return
+            self._subscribe_entities_id = self._next_id()
             await ws.send_json(
                 {
-                    "id": subscribe_id,
-                    "type": "subscribe_trigger",
-                    "trigger": {
-                        "platform": "state",
-                        "entity_id": sorted(self._tracked_entities),
-                    },
+                    "id": self._subscribe_entities_id,
+                    "type": "subscribe_entities",
+                    "entity_ids": sorted(self._tracked_entities),
                 }
             )
         elif msg_type == "auth_invalid":
             logger.error(f"Home Assistant auth failed: {msg.get('message', '')}")
         elif msg_type == "result":
-            if msg.get("id") == self._get_states_id:
-                if msg.get("success"):
-                    self._handle_states(msg.get("result", []))
-                else:
-                    logger.error(
-                        f"Home Assistant get_states failed: {msg.get('error')}"
-                    )
+            if msg.get("id") == self._subscribe_entities_id and not msg.get("success"):
+                logger.error(
+                    f"Home Assistant subscribe_entities failed: {msg.get('error')}"
+                )
         elif msg_type == "event":
-            event = msg.get("event", {})
-            trigger = event.get("variables", {}).get("trigger", {})
-            to_state = trigger.get("to_state")
-            if to_state:
-                entity_id = to_state.get("entity_id")
-                if entity_id in self._tracked_entities:
-                    self._update_entity_value(entity_id, to_state.get("state"))
-
-    def _handle_states(self, states: list[dict]) -> None:
-        for state in states:
-            entity_id = state.get("entity_id")
-            if entity_id in self._tracked_entities:
-                self._update_entity_value(entity_id, state.get("state"))
-        self._check_entities_ready()
+            ev = msg.get("event")
+            if isinstance(ev, dict):
+                self._handle_compressed_entity_event(ev)
 
     def _update_entity_value(self, entity_id: str, state_val: object) -> None:
+        logger.debug(f"Home Assistant: update_entity_value: {entity_id}, {state_val}")
         if state_val is None:
             self._entity_values[entity_id] = None
             self._check_entities_ready()
@@ -218,6 +238,4 @@ class HomeAssistant(Powermeter):
         try:
             await asyncio.wait_for(self._entities_ready.wait(), timeout=timeout)
         except asyncio.TimeoutError:
-            raise TimeoutError(
-                "Timeout waiting for Home Assistant state"
-            ) from None
+            raise TimeoutError("Timeout waiting for Home Assistant state") from None

--- a/src/b2500_meter/powermeter/homeassistant.py
+++ b/src/b2500_meter/powermeter/homeassistant.py
@@ -1,8 +1,8 @@
+import asyncio
+import contextlib
 import json
-import threading
-import time
 
-import websocket
+import aiohttp
 
 from b2500_meter.config.logger import logger
 
@@ -44,29 +44,15 @@ class HomeAssistant(Powermeter):
         )
         self.path_prefix = path_prefix
 
-        self._lock = threading.Lock()
         self._entity_values: dict[str, float | None] = {}
         self._tracked_entities = self._collect_entities()
         self._msg_id = 0
         self._get_states_id: int | None = None
+        self._session: aiohttp.ClientSession | None = None
+        self._ws_task: asyncio.Task[None] | None = None
+        self._entities_ready = asyncio.Event()
 
-        url = self._build_ws_url()
-        self.ws = websocket.WebSocketApp(
-            url,
-            on_open=self._on_open,
-            on_message=self._on_message,
-            on_error=self._on_error,
-            on_close=self._on_close,
-        )
-
-        thread = threading.Thread(
-            target=self.ws.run_forever,
-            kwargs={"reconnect": 5},
-            daemon=True,
-        )
-        thread.start()
-
-    def _collect_entities(self) -> set:
+    def _collect_entities(self) -> set[str]:
         if self.power_calculate:
             entities = list(self.power_input_alias) + list(self.power_output_alias)
         else:
@@ -82,36 +68,78 @@ class HomeAssistant(Powermeter):
         self._msg_id += 1
         return self._msg_id
 
-    def _on_open(self, ws):
-        logger.info(f"Home Assistant WebSocket connected to {self.ip}")
+    async def start(self) -> None:
+        if self._session:
+            return
+        self._session = aiohttp.ClientSession()
+        self._ws_task = asyncio.create_task(self._ws_loop())
 
-    def _on_message(self, ws, message):
+    async def stop(self) -> None:
+        if self._ws_task:
+            self._ws_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._ws_task
+            self._ws_task = None
+        if self._session:
+            await self._session.close()
+            self._session = None
+
+    async def _ws_loop(self) -> None:
+        url = self._build_ws_url()
+        while True:
+            try:
+                assert self._session is not None
+                async with self._session.ws_connect(url, heartbeat=30) as ws:
+                    logger.info(f"Home Assistant WebSocket connected to {self.ip}")
+                    async for msg in ws:
+                        if msg.type == aiohttp.WSMsgType.TEXT:
+                            await self._handle_message(ws, msg.data)
+                        elif msg.type in (
+                            aiohttp.WSMsgType.ERROR,
+                            aiohttp.WSMsgType.CLOSE,
+                            aiohttp.WSMsgType.CLOSING,
+                            aiohttp.WSMsgType.CLOSED,
+                        ):
+                            break
+                    logger.info("Home Assistant WebSocket closed")
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.error(f"Home Assistant WebSocket error: {e}")
+            # Reset protocol state for reconnection; keep _entity_values
+            # (stale values are preferable to ValueError during brief disconnect;
+            # get_states on reconnect will refresh them)
+            self._msg_id = 0
+            self._get_states_id = None
+            await asyncio.sleep(5)
+
+    async def _handle_message(
+        self, ws: aiohttp.ClientWebSocketResponse, raw: str
+    ) -> None:
         try:
-            msg = json.loads(message)
+            msg = json.loads(raw)
         except json.JSONDecodeError:
-            logger.error(f"Home Assistant: failed to decode message: {message}")
+            logger.error(f"Home Assistant: failed to decode message: {raw}")
             return
 
         msg_type = msg.get("type")
 
         if msg_type == "auth_required":
-            ws.send(json.dumps({"type": "auth", "access_token": self.access_token}))
+            await ws.send_json({"type": "auth", "access_token": self.access_token})
         elif msg_type == "auth_ok":
             logger.info("Home Assistant: authenticated")
             self._get_states_id = self._next_id()
-            ws.send(json.dumps({"id": self._get_states_id, "type": "get_states"}))
+            await ws.send_json({"id": self._get_states_id, "type": "get_states"})
             subscribe_id = self._next_id()
-            ws.send(
-                json.dumps(
-                    {
-                        "id": subscribe_id,
-                        "type": "subscribe_trigger",
-                        "trigger": {
-                            "platform": "state",
-                            "entity_id": sorted(self._tracked_entities),
-                        },
-                    }
-                )
+            await ws.send_json(
+                {
+                    "id": subscribe_id,
+                    "type": "subscribe_trigger",
+                    "trigger": {
+                        "platform": "state",
+                        "entity_id": sorted(self._tracked_entities),
+                    },
+                }
             )
         elif msg_type == "auth_invalid":
             logger.error(f"Home Assistant auth failed: {msg.get('message', '')}")
@@ -132,72 +160,64 @@ class HomeAssistant(Powermeter):
                 if entity_id in self._tracked_entities:
                     self._update_entity_value(entity_id, to_state.get("state"))
 
-    def _handle_states(self, states):
+    def _handle_states(self, states: list[dict]) -> None:
         for state in states:
             entity_id = state.get("entity_id")
             if entity_id in self._tracked_entities:
                 self._update_entity_value(entity_id, state.get("state"))
+        self._check_entities_ready()
 
-    def _update_entity_value(self, entity_id, state_val):
+    def _update_entity_value(self, entity_id: str, state_val: object) -> None:
         if state_val is None:
-            with self._lock:
-                self._entity_values[entity_id] = None
+            self._entity_values[entity_id] = None
+            self._check_entities_ready()
             return
         try:
-            value = float(state_val)
-            with self._lock:
-                self._entity_values[entity_id] = value
+            value = float(state_val)  # type: ignore[arg-type]
+            self._entity_values[entity_id] = value
         except (ValueError, TypeError):
             logger.warning(
                 f"Home Assistant sensor {entity_id} state '{state_val}' is not numeric"
             )
-            with self._lock:
-                self._entity_values[entity_id] = None
+            self._entity_values[entity_id] = None
+        self._check_entities_ready()
 
-    def _get_entity_value(self, entity_id) -> float:
-        """Return cached value for entity. Caller must hold self._lock."""
+    def _check_entities_ready(self) -> None:
+        if all(self._entity_values.get(e) is not None for e in self._tracked_entities):
+            self._entities_ready.set()
+        else:
+            self._entities_ready.clear()
+
+    def _get_entity_value(self, entity_id: str) -> float:
         val = self._entity_values.get(entity_id)
         if val is None:
             raise ValueError(f"Home Assistant sensor {entity_id} has no state")
         return val
 
-    def _on_error(self, ws, error):
-        logger.error(f"Home Assistant WebSocket error: {error}")
+    async def get_powermeter_watts_async(self) -> list[float]:
+        if not self.power_calculate:
+            return [
+                self._get_entity_value(entity) for entity in self.current_power_entity
+            ]
+        else:
+            if len(self.power_input_alias) != len(self.power_output_alias):
+                raise ValueError(
+                    "Home Assistant power_input_alias and"
+                    " power_output_alias lengths differ"
+                )
+            results = []
+            for in_entity, out_entity in zip(
+                self.power_input_alias, self.power_output_alias, strict=False
+            ):
+                power_in = self._get_entity_value(in_entity)
+                power_out = self._get_entity_value(out_entity)
+                results.append(power_in - power_out)
+            return results
 
-    def _on_close(self, ws, close_status_code, close_msg):
-        logger.info(f"Home Assistant WebSocket closed: {close_status_code} {close_msg}")
-
-    def get_powermeter_watts(self):
-        with self._lock:
-            if not self.power_calculate:
-                return [
-                    self._get_entity_value(entity)
-                    for entity in self.current_power_entity
-                ]
-            else:
-                if len(self.power_input_alias) != len(self.power_output_alias):
-                    raise ValueError(
-                        "Home Assistant power_input_alias and"
-                        " power_output_alias lengths differ"
-                    )
-                results = []
-                for in_entity, out_entity in zip(
-                    self.power_input_alias, self.power_output_alias, strict=False
-                ):
-                    power_in = self._get_entity_value(in_entity)
-                    power_out = self._get_entity_value(out_entity)
-                    results.append(power_in - power_out)
-                return results
-
-    def wait_for_message(self, timeout=5):
-        start_time = time.time()
-        while True:
-            with self._lock:
-                if all(
-                    self._entity_values.get(e) is not None
-                    for e in self._tracked_entities
-                ):
-                    return
-            if time.time() - start_time > timeout:
-                raise TimeoutError("Timeout waiting for Home Assistant state")
-            time.sleep(0.1)
+    async def wait_for_message_async(self, timeout: float = 5) -> None:
+        try:
+            await asyncio.wait_for(self._entities_ready.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            raise TimeoutError(
+                "Timeout waiting for Home Assistant state"
+            ) from None

--- a/src/b2500_meter/powermeter/homeassistant_test.py
+++ b/src/b2500_meter/powermeter/homeassistant_test.py
@@ -22,18 +22,29 @@ def _create_powermeter(**overrides):
     return HomeAssistant(**defaults)
 
 
+def _compressed_initial_payload(states: list[dict]) -> dict:
+    """Build subscribe_entities initial `event.a` map (entity_id -> {s: ...})."""
+    a: dict = {}
+    for s in states:
+        eid = s.get("entity_id")
+        if not eid:
+            continue
+        a[eid] = {"s": s.get("state")}
+    return {"a": a}
+
+
 async def _simulate_auth_and_states(pm, states):
     ws = AsyncMock()
     await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
     await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    sid = pm._subscribe_entities_id
     await pm._handle_message(
         ws,
         json.dumps(
             {
-                "id": pm._get_states_id,
-                "type": "result",
-                "success": True,
-                "result": states,
+                "id": sid,
+                "type": "event",
+                "event": _compressed_initial_payload(states),
             }
         ),
     )
@@ -50,7 +61,7 @@ async def test_auth_required_sends_token():
     ws.send_json.assert_called_once_with({"type": "auth", "access_token": "token"})
 
 
-async def test_auth_ok_sends_get_states_and_subscribe():
+async def test_auth_ok_subscribes_entities():
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
@@ -59,15 +70,11 @@ async def test_auth_ok_sends_get_states_and_subscribe():
     await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
 
     calls = ws.send_json.call_args_list
-    assert len(calls) == 2
+    assert len(calls) == 1
 
-    get_states_msg = calls[0][0][0]
-    assert get_states_msg["type"] == "get_states"
-
-    subscribe_msg = calls[1][0][0]
-    assert subscribe_msg["type"] == "subscribe_trigger"
-    assert subscribe_msg["trigger"]["platform"] == "state"
-    assert "sensor.current_power" in subscribe_msg["trigger"]["entity_id"]
+    subscribe_msg = calls[0][0][0]
+    assert subscribe_msg["type"] == "subscribe_entities"
+    assert "sensor.current_power" in subscribe_msg["entity_ids"]
 
 
 async def test_auth_invalid_does_not_crash():
@@ -80,10 +87,10 @@ async def test_auth_invalid_does_not_crash():
     # Should not raise
 
 
-# get_states tests
+# subscribe_entities initial snapshot tests
 
 
-async def test_get_states_populates_value():
+async def test_initial_snapshot_populates_value():
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "1000"}]
@@ -91,28 +98,17 @@ async def test_get_states_populates_value():
     assert await pm.get_powermeter_watts_async() == [1000.0]
 
 
-async def test_get_states_failure():
+async def test_no_initial_event_leaves_values_missing():
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
     await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
-    await pm._handle_message(
-        ws,
-        json.dumps(
-            {
-                "id": pm._get_states_id,
-                "type": "result",
-                "success": False,
-                "error": {"code": "unknown", "message": "something broke"},
-            }
-        ),
-    )
 
     with pytest.raises(ValueError):
         await pm.get_powermeter_watts_async()
 
 
-async def test_get_states_ignores_untracked_entities():
+async def test_initial_snapshot_only_updates_tracked_entities():
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm,
@@ -142,13 +138,9 @@ async def test_trigger_event_updates_value():
                 "id": 2,
                 "type": "event",
                 "event": {
-                    "variables": {
-                        "trigger": {
-                            "entity_id": "sensor.current_power",
-                            "to_state": {
-                                "entity_id": "sensor.current_power",
-                                "state": "200",
-                            },
+                    "c": {
+                        "sensor.current_power": {
+                            "+": {"s": "200"},
                         }
                     }
                 },
@@ -172,13 +164,9 @@ async def test_trigger_event_ignores_untracked_entity():
                 "id": 2,
                 "type": "event",
                 "event": {
-                    "variables": {
-                        "trigger": {
-                            "entity_id": "sensor.other",
-                            "to_state": {
-                                "entity_id": "sensor.other",
-                                "state": "999",
-                            },
+                    "c": {
+                        "sensor.other": {
+                            "+": {"s": "999"},
                         }
                     }
                 },
@@ -371,10 +359,10 @@ async def test_wait_for_message_timeout():
         await pm.wait_for_message_async(timeout=0)
 
 
-# Subscribe trigger entity list test
+# subscribe_entities entity list test
 
 
-async def test_subscribe_trigger_contains_all_entities_calculate_mode():
+async def test_subscribe_entities_contains_all_entities_calculate_mode():
     pm = _create_powermeter(
         current_power_entity="",
         power_calculate=True,
@@ -386,8 +374,8 @@ async def test_subscribe_trigger_contains_all_entities_calculate_mode():
     ws.send_json.reset_mock()
     await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
 
-    subscribe_msg = ws.send_json.call_args_list[1][0][0]
-    entity_ids = subscribe_msg["trigger"]["entity_id"]
+    subscribe_msg = ws.send_json.call_args_list[0][0][0]
+    entity_ids = subscribe_msg["entity_ids"]
     assert "sensor.power_input" in entity_ids
     assert "sensor.power_output" in entity_ids
 
@@ -458,12 +446,9 @@ async def test_entities_ready_cleared_when_value_becomes_none():
             {
                 "type": "event",
                 "event": {
-                    "variables": {
-                        "trigger": {
-                            "to_state": {
-                                "entity_id": "sensor.current_power",
-                                "state": "unavailable",
-                            },
+                    "c": {
+                        "sensor.current_power": {
+                            "+": {"s": "unavailable"},
                         }
                     }
                 },

--- a/src/b2500_meter/powermeter/homeassistant_test.py
+++ b/src/b2500_meter/powermeter/homeassistant_test.py
@@ -1,378 +1,473 @@
 import json
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from .homeassistant import HomeAssistant
 
 
-class TestHomeAssistant(unittest.TestCase):
-    def _create_powermeter(self, **overrides):
-        defaults = dict(
-            ip="192.168.1.8",
-            port="8123",
-            use_https=False,
-            access_token="token",
-            current_power_entity="sensor.current_power",
-            power_calculate=False,
-            power_input_alias="",
-            power_output_alias="",
-            path_prefix=None,
-        )
-        defaults.update(overrides)
-        with (
-            patch("b2500_meter.powermeter.homeassistant.websocket.WebSocketApp"),
-            patch("b2500_meter.powermeter.homeassistant.threading.Thread"),
-        ):
-            pm = HomeAssistant(**defaults)
-        return pm
+def _create_powermeter(**overrides):
+    defaults = dict(
+        ip="192.168.1.8",
+        port="8123",
+        use_https=False,
+        access_token="token",
+        current_power_entity="sensor.current_power",
+        power_calculate=False,
+        power_input_alias="",
+        power_output_alias="",
+        path_prefix=None,
+    )
+    defaults.update(overrides)
+    return HomeAssistant(**defaults)
 
-    def _simulate_auth_and_states(self, pm, states):
-        ws = MagicMock()
-        pm._on_message(ws, json.dumps({"type": "auth_required"}))
-        pm._on_message(ws, json.dumps({"type": "auth_ok"}))
-        pm._on_message(
-            ws,
-            json.dumps(
-                {
-                    "id": pm._get_states_id,
-                    "type": "result",
-                    "success": True,
-                    "result": states,
-                }
-            ),
-        )
-        return ws
 
-    # Auth flow tests
+async def _simulate_auth_and_states(pm, states):
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {
+                "id": pm._get_states_id,
+                "type": "result",
+                "success": True,
+                "result": states,
+            }
+        ),
+    )
+    return ws
 
-    def test_auth_required_sends_token(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(ws, json.dumps({"type": "auth_required"}))
-        ws.send.assert_called_once_with(
-            json.dumps({"type": "auth", "access_token": "token"})
-        )
 
-    def test_auth_ok_sends_get_states_and_subscribe(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(ws, json.dumps({"type": "auth_required"}))
-        ws.send.reset_mock()
+# Auth flow tests
 
-        pm._on_message(ws, json.dumps({"type": "auth_ok"}))
 
-        calls = ws.send.call_args_list
-        self.assertEqual(len(calls), 2)
+async def test_auth_required_sends_token():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    ws.send_json.assert_called_once_with({"type": "auth", "access_token": "token"})
 
-        get_states_msg = json.loads(calls[0][0][0])
-        self.assertEqual(get_states_msg["type"], "get_states")
 
-        subscribe_msg = json.loads(calls[1][0][0])
-        self.assertEqual(subscribe_msg["type"], "subscribe_trigger")
-        self.assertEqual(subscribe_msg["trigger"]["platform"], "state")
-        self.assertIn("sensor.current_power", subscribe_msg["trigger"]["entity_id"])
+async def test_auth_ok_sends_get_states_and_subscribe():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    ws.send_json.reset_mock()
 
-    def test_auth_invalid_does_not_crash(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(
-            ws,
-            json.dumps({"type": "auth_invalid", "message": "bad token"}),
-        )
-        # Should not raise
+    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
 
-    # get_states tests
+    calls = ws.send_json.call_args_list
+    assert len(calls) == 2
 
-    def test_get_states_populates_value(self):
-        pm = self._create_powermeter()
-        self._simulate_auth_and_states(
-            pm, [{"entity_id": "sensor.current_power", "state": "1000"}]
-        )
-        self.assertEqual(pm.get_powermeter_watts(), [1000.0])
+    get_states_msg = calls[0][0][0]
+    assert get_states_msg["type"] == "get_states"
 
-    def test_get_states_failure(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(ws, json.dumps({"type": "auth_required"}))
-        pm._on_message(ws, json.dumps({"type": "auth_ok"}))
-        pm._on_message(
-            ws,
-            json.dumps(
-                {
-                    "id": pm._get_states_id,
-                    "type": "result",
-                    "success": False,
-                    "error": {"code": "unknown", "message": "something broke"},
-                }
-            ),
-        )
+    subscribe_msg = calls[1][0][0]
+    assert subscribe_msg["type"] == "subscribe_trigger"
+    assert subscribe_msg["trigger"]["platform"] == "state"
+    assert "sensor.current_power" in subscribe_msg["trigger"]["entity_id"]
 
-        with self.assertRaises(ValueError):
-            pm.get_powermeter_watts()
 
-    def test_get_states_ignores_untracked_entities(self):
-        pm = self._create_powermeter()
-        self._simulate_auth_and_states(
-            pm,
-            [
-                {"entity_id": "sensor.current_power", "state": "500"},
-                {"entity_id": "sensor.temperature", "state": "22"},
-            ],
-        )
-        self.assertEqual(pm.get_powermeter_watts(), [500.0])
+async def test_auth_invalid_does_not_crash():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(
+        ws,
+        json.dumps({"type": "auth_invalid", "message": "bad token"}),
+    )
+    # Should not raise
 
-    # Trigger event tests
 
-    def test_trigger_event_updates_value(self):
-        pm = self._create_powermeter()
-        self._simulate_auth_and_states(
-            pm, [{"entity_id": "sensor.current_power", "state": "100"}]
-        )
-        self.assertEqual(pm.get_powermeter_watts(), [100.0])
+# get_states tests
 
-        ws = MagicMock()
-        pm._on_message(
-            ws,
-            json.dumps(
-                {
-                    "id": 2,
-                    "type": "event",
-                    "event": {
-                        "variables": {
-                            "trigger": {
+
+async def test_get_states_populates_value():
+    pm = _create_powermeter()
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "1000"}]
+    )
+    assert await pm.get_powermeter_watts_async() == [1000.0]
+
+
+async def test_get_states_failure():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {
+                "id": pm._get_states_id,
+                "type": "result",
+                "success": False,
+                "error": {"code": "unknown", "message": "something broke"},
+            }
+        ),
+    )
+
+    with pytest.raises(ValueError):
+        await pm.get_powermeter_watts_async()
+
+
+async def test_get_states_ignores_untracked_entities():
+    pm = _create_powermeter()
+    await _simulate_auth_and_states(
+        pm,
+        [
+            {"entity_id": "sensor.current_power", "state": "500"},
+            {"entity_id": "sensor.temperature", "state": "22"},
+        ],
+    )
+    assert await pm.get_powermeter_watts_async() == [500.0]
+
+
+# Trigger event tests
+
+
+async def test_trigger_event_updates_value():
+    pm = _create_powermeter()
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "100"}]
+    )
+    assert await pm.get_powermeter_watts_async() == [100.0]
+
+    ws = AsyncMock()
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {
+                "id": 2,
+                "type": "event",
+                "event": {
+                    "variables": {
+                        "trigger": {
+                            "entity_id": "sensor.current_power",
+                            "to_state": {
                                 "entity_id": "sensor.current_power",
-                                "to_state": {
-                                    "entity_id": "sensor.current_power",
-                                    "state": "200",
-                                },
-                            }
+                                "state": "200",
+                            },
                         }
-                    },
-                }
-            ),
-        )
-        self.assertEqual(pm.get_powermeter_watts(), [200.0])
+                    }
+                },
+            }
+        ),
+    )
+    assert await pm.get_powermeter_watts_async() == [200.0]
 
-    def test_trigger_event_ignores_untracked_entity(self):
-        pm = self._create_powermeter()
-        self._simulate_auth_and_states(
-            pm, [{"entity_id": "sensor.current_power", "state": "100"}]
-        )
 
-        ws = MagicMock()
-        pm._on_message(
-            ws,
-            json.dumps(
-                {
-                    "id": 2,
-                    "type": "event",
-                    "event": {
-                        "variables": {
-                            "trigger": {
+async def test_trigger_event_ignores_untracked_entity():
+    pm = _create_powermeter()
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "100"}]
+    )
+
+    ws = AsyncMock()
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {
+                "id": 2,
+                "type": "event",
+                "event": {
+                    "variables": {
+                        "trigger": {
+                            "entity_id": "sensor.other",
+                            "to_state": {
                                 "entity_id": "sensor.other",
-                                "to_state": {
-                                    "entity_id": "sensor.other",
-                                    "state": "999",
-                                },
-                            }
+                                "state": "999",
+                            },
                         }
-                    },
-                }
-            ),
-        )
-        self.assertEqual(pm.get_powermeter_watts(), [100.0])
-
-    # Error condition tests
-
-    def test_sensor_has_no_state(self):
-        pm = self._create_powermeter()
-        with self.assertRaises(ValueError) as context:
-            pm.get_powermeter_watts()
-
-        self.assertEqual(
-            str(context.exception),
-            "Home Assistant sensor sensor.current_power has no state",
-        )
-
-    def test_sensor_state_none(self):
-        pm = self._create_powermeter()
-        self._simulate_auth_and_states(
-            pm, [{"entity_id": "sensor.current_power", "state": None}]
-        )
-
-        with self.assertRaises(ValueError) as context:
-            pm.get_powermeter_watts()
-
-        self.assertEqual(
-            str(context.exception),
-            "Home Assistant sensor sensor.current_power has no state",
-        )
-
-    def test_sensor_state_not_numeric(self):
-        pm = self._create_powermeter()
-        self._simulate_auth_and_states(
-            pm,
-            [{"entity_id": "sensor.current_power", "state": "unavailable"}],
-        )
-
-        with self.assertRaises(ValueError) as context:
-            pm.get_powermeter_watts()
-
-        self.assertEqual(
-            str(context.exception),
-            "Home Assistant sensor sensor.current_power has no state",
-        )
-
-    def test_malformed_json_message(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(ws, "not valid json")
-        # Should not raise; value stays absent
-        with self.assertRaises(ValueError):
-            pm.get_powermeter_watts()
-
-    # Three-phase tests
-
-    def test_three_phase_direct(self):
-        pm = self._create_powermeter(
-            current_power_entity=[
-                "sensor.power_phase1",
-                "sensor.power_phase2",
-                "sensor.power_phase3",
-            ]
-        )
-        self._simulate_auth_and_states(
-            pm,
-            [
-                {"entity_id": "sensor.power_phase1", "state": "100"},
-                {"entity_id": "sensor.power_phase2", "state": "200"},
-                {"entity_id": "sensor.power_phase3", "state": "300"},
-            ],
-        )
-        self.assertEqual(pm.get_powermeter_watts(), [100.0, 200.0, 300.0])
-
-    # Power calculate tests
-
-    def test_power_calculate_mode(self):
-        pm = self._create_powermeter(
-            current_power_entity="",
-            power_calculate=True,
-            power_input_alias="sensor.power_input",
-            power_output_alias="sensor.power_output",
-        )
-        self._simulate_auth_and_states(
-            pm,
-            [
-                {"entity_id": "sensor.power_input", "state": "1000"},
-                {"entity_id": "sensor.power_output", "state": "200"},
-            ],
-        )
-        self.assertEqual(pm.get_powermeter_watts(), [800.0])
-
-    def test_three_phase_calculated(self):
-        pm = self._create_powermeter(
-            current_power_entity="",
-            power_calculate=True,
-            power_input_alias=[
-                "sensor.power_in_1",
-                "sensor.power_in_2",
-                "sensor.power_in_3",
-            ],
-            power_output_alias=[
-                "sensor.power_out_1",
-                "sensor.power_out_2",
-                "sensor.power_out_3",
-            ],
-        )
-        self._simulate_auth_and_states(
-            pm,
-            [
-                {"entity_id": "sensor.power_in_1", "state": "1000"},
-                {"entity_id": "sensor.power_out_1", "state": "200"},
-                {"entity_id": "sensor.power_in_2", "state": "2000"},
-                {"entity_id": "sensor.power_out_2", "state": "300"},
-                {"entity_id": "sensor.power_in_3", "state": "3000"},
-                {"entity_id": "sensor.power_out_3", "state": "400"},
-            ],
-        )
-        self.assertEqual(pm.get_powermeter_watts(), [800.0, 1700.0, 2600.0])
-
-    def test_power_alias_length_mismatch(self):
-        pm = self._create_powermeter(
-            current_power_entity="",
-            power_calculate=True,
-            power_input_alias=["sensor.power_in_1", "sensor.power_in_2"],
-            power_output_alias=["sensor.power_out_1"],
-        )
-        # Populate values so we get past the "no state" check
-        self._simulate_auth_and_states(
-            pm,
-            [
-                {"entity_id": "sensor.power_in_1", "state": "100"},
-                {"entity_id": "sensor.power_in_2", "state": "200"},
-                {"entity_id": "sensor.power_out_1", "state": "50"},
-            ],
-        )
-
-        with self.assertRaises(ValueError) as context:
-            pm.get_powermeter_watts()
-
-        self.assertEqual(
-            str(context.exception),
-            "Home Assistant power_input_alias and power_output_alias lengths differ",
-        )
-
-    # WebSocket URL tests
-
-    def test_ws_url_http(self):
-        pm = self._create_powermeter()
-        self.assertEqual(pm._build_ws_url(), "ws://192.168.1.8:8123/api/websocket")
-
-    def test_ws_url_https(self):
-        pm = self._create_powermeter(use_https=True)
-        self.assertEqual(pm._build_ws_url(), "wss://192.168.1.8:8123/api/websocket")
-
-    def test_ws_url_with_path_prefix(self):
-        pm = self._create_powermeter(path_prefix="/prefix")
-        self.assertEqual(
-            pm._build_ws_url(),
-            "ws://192.168.1.8:8123/prefix/api/websocket",
-        )
-
-    # wait_for_message test
-
-    def test_wait_for_message_returns_when_data_available(self):
-        pm = self._create_powermeter()
-        self._simulate_auth_and_states(
-            pm, [{"entity_id": "sensor.current_power", "state": "100"}]
-        )
-        # Should return immediately, not raise
-        pm.wait_for_message(timeout=1)
-
-    def test_wait_for_message_timeout(self):
-        pm = self._create_powermeter()
-        with self.assertRaises(TimeoutError):
-            pm.wait_for_message(timeout=0)
-
-    # Subscribe trigger entity list test
-
-    def test_subscribe_trigger_contains_all_entities_calculate_mode(self):
-        pm = self._create_powermeter(
-            current_power_entity="",
-            power_calculate=True,
-            power_input_alias="sensor.power_input",
-            power_output_alias="sensor.power_output",
-        )
-        ws = MagicMock()
-        pm._on_message(ws, json.dumps({"type": "auth_required"}))
-        ws.send.reset_mock()
-        pm._on_message(ws, json.dumps({"type": "auth_ok"}))
-
-        subscribe_msg = json.loads(ws.send.call_args_list[1][0][0])
-        entity_ids = subscribe_msg["trigger"]["entity_id"]
-        self.assertIn("sensor.power_input", entity_ids)
-        self.assertIn("sensor.power_output", entity_ids)
+                    }
+                },
+            }
+        ),
+    )
+    assert await pm.get_powermeter_watts_async() == [100.0]
 
 
-if __name__ == "__main__":
-    unittest.main()
+# Error condition tests
+
+
+async def test_sensor_has_no_state():
+    pm = _create_powermeter()
+    with pytest.raises(ValueError) as exc_info:
+        await pm.get_powermeter_watts_async()
+
+    assert (
+        str(exc_info.value) == "Home Assistant sensor sensor.current_power has no state"
+    )
+
+
+async def test_sensor_state_none():
+    pm = _create_powermeter()
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": None}]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        await pm.get_powermeter_watts_async()
+
+    assert (
+        str(exc_info.value) == "Home Assistant sensor sensor.current_power has no state"
+    )
+
+
+async def test_sensor_state_not_numeric():
+    pm = _create_powermeter()
+    await _simulate_auth_and_states(
+        pm,
+        [{"entity_id": "sensor.current_power", "state": "unavailable"}],
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        await pm.get_powermeter_watts_async()
+
+    assert (
+        str(exc_info.value) == "Home Assistant sensor sensor.current_power has no state"
+    )
+
+
+async def test_malformed_json_message():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(ws, "not valid json")
+    # Should not raise; value stays absent
+    with pytest.raises(ValueError):
+        await pm.get_powermeter_watts_async()
+
+
+# Three-phase tests
+
+
+async def test_three_phase_direct():
+    pm = _create_powermeter(
+        current_power_entity=[
+            "sensor.power_phase1",
+            "sensor.power_phase2",
+            "sensor.power_phase3",
+        ]
+    )
+    await _simulate_auth_and_states(
+        pm,
+        [
+            {"entity_id": "sensor.power_phase1", "state": "100"},
+            {"entity_id": "sensor.power_phase2", "state": "200"},
+            {"entity_id": "sensor.power_phase3", "state": "300"},
+        ],
+    )
+    assert await pm.get_powermeter_watts_async() == [100.0, 200.0, 300.0]
+
+
+# Power calculate tests
+
+
+async def test_power_calculate_mode():
+    pm = _create_powermeter(
+        current_power_entity="",
+        power_calculate=True,
+        power_input_alias="sensor.power_input",
+        power_output_alias="sensor.power_output",
+    )
+    await _simulate_auth_and_states(
+        pm,
+        [
+            {"entity_id": "sensor.power_input", "state": "1000"},
+            {"entity_id": "sensor.power_output", "state": "200"},
+        ],
+    )
+    assert await pm.get_powermeter_watts_async() == [800.0]
+
+
+async def test_three_phase_calculated():
+    pm = _create_powermeter(
+        current_power_entity="",
+        power_calculate=True,
+        power_input_alias=[
+            "sensor.power_in_1",
+            "sensor.power_in_2",
+            "sensor.power_in_3",
+        ],
+        power_output_alias=[
+            "sensor.power_out_1",
+            "sensor.power_out_2",
+            "sensor.power_out_3",
+        ],
+    )
+    await _simulate_auth_and_states(
+        pm,
+        [
+            {"entity_id": "sensor.power_in_1", "state": "1000"},
+            {"entity_id": "sensor.power_out_1", "state": "200"},
+            {"entity_id": "sensor.power_in_2", "state": "2000"},
+            {"entity_id": "sensor.power_out_2", "state": "300"},
+            {"entity_id": "sensor.power_in_3", "state": "3000"},
+            {"entity_id": "sensor.power_out_3", "state": "400"},
+        ],
+    )
+    assert await pm.get_powermeter_watts_async() == [800.0, 1700.0, 2600.0]
+
+
+async def test_power_alias_length_mismatch():
+    pm = _create_powermeter(
+        current_power_entity="",
+        power_calculate=True,
+        power_input_alias=["sensor.power_in_1", "sensor.power_in_2"],
+        power_output_alias=["sensor.power_out_1"],
+    )
+    await _simulate_auth_and_states(
+        pm,
+        [
+            {"entity_id": "sensor.power_in_1", "state": "100"},
+            {"entity_id": "sensor.power_in_2", "state": "200"},
+            {"entity_id": "sensor.power_out_1", "state": "50"},
+        ],
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        await pm.get_powermeter_watts_async()
+
+    assert (
+        str(exc_info.value)
+        == "Home Assistant power_input_alias and power_output_alias lengths differ"
+    )
+
+
+# WebSocket URL tests
+
+
+def test_ws_url_http():
+    pm = _create_powermeter()
+    assert pm._build_ws_url() == "ws://192.168.1.8:8123/api/websocket"
+
+
+def test_ws_url_https():
+    pm = _create_powermeter(use_https=True)
+    assert pm._build_ws_url() == "wss://192.168.1.8:8123/api/websocket"
+
+
+def test_ws_url_with_path_prefix():
+    pm = _create_powermeter(path_prefix="/prefix")
+    assert pm._build_ws_url() == "ws://192.168.1.8:8123/prefix/api/websocket"
+
+
+# wait_for_message tests
+
+
+async def test_wait_for_message_returns_when_data_available():
+    pm = _create_powermeter()
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "100"}]
+    )
+    # Should return immediately, not raise
+    await pm.wait_for_message_async(timeout=1)
+
+
+async def test_wait_for_message_timeout():
+    pm = _create_powermeter()
+    with pytest.raises(TimeoutError):
+        await pm.wait_for_message_async(timeout=0)
+
+
+# Subscribe trigger entity list test
+
+
+async def test_subscribe_trigger_contains_all_entities_calculate_mode():
+    pm = _create_powermeter(
+        current_power_entity="",
+        power_calculate=True,
+        power_input_alias="sensor.power_input",
+        power_output_alias="sensor.power_output",
+    )
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    ws.send_json.reset_mock()
+    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+
+    subscribe_msg = ws.send_json.call_args_list[1][0][0]
+    entity_ids = subscribe_msg["trigger"]["entity_id"]
+    assert "sensor.power_input" in entity_ids
+    assert "sensor.power_output" in entity_ids
+
+
+# Lifecycle tests
+
+
+async def test_start_creates_session_and_task():
+    pm = _create_powermeter()
+    with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
+        mock_loop.return_value = None
+        await pm.start()
+        assert pm._session is not None
+        assert pm._ws_task is not None
+        await pm.stop()
+
+
+async def test_start_is_idempotent():
+    pm = _create_powermeter()
+    with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
+        mock_loop.return_value = None
+        await pm.start()
+        session1 = pm._session
+        await pm.start()
+        assert pm._session is session1
+        await pm.stop()
+
+
+async def test_stop_closes_session():
+    pm = _create_powermeter()
+    with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
+        mock_loop.return_value = None
+        await pm.start()
+        await pm.stop()
+        assert pm._session is None
+        assert pm._ws_task is None
+
+
+async def test_stop_without_start():
+    pm = _create_powermeter()
+    # Should not raise
+    await pm.stop()
+
+
+# entities_ready event tests
+
+
+async def test_entities_ready_set_when_all_present():
+    pm = _create_powermeter()
+    assert not pm._entities_ready.is_set()
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "100"}]
+    )
+    assert pm._entities_ready.is_set()
+
+
+async def test_entities_ready_cleared_when_value_becomes_none():
+    pm = _create_powermeter()
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "100"}]
+    )
+    assert pm._entities_ready.is_set()
+
+    ws = AsyncMock()
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {
+                "type": "event",
+                "event": {
+                    "variables": {
+                        "trigger": {
+                            "to_state": {
+                                "entity_id": "sensor.current_power",
+                                "state": "unavailable",
+                            },
+                        }
+                    }
+                },
+            }
+        ),
+    )
+    assert not pm._entities_ready.is_set()


### PR DESCRIPTION
## Summary
Refactored the HomeAssistant integration from synchronous threading-based WebSocket communication to async/await using aiohttp. This modernizes the codebase and improves resource management.

## Key Changes

### Core Architecture
- Replaced `websocket-client` library with `aiohttp` for WebSocket communication
- Converted from threading-based model to async/await with asyncio
- Removed `threading.Lock` synchronization in favor of async-safe operations
- Added explicit `start()` and `stop()` lifecycle methods for session management

### API Changes
- Renamed `get_powermeter_watts()` to `get_powermeter_watts_async()` (now async)
- Renamed `wait_for_message()` to `wait_for_message_async()` (now async)
- Renamed internal `_on_message()` to `_handle_message()` (now async)
- Removed `_on_open()`, `_on_error()`, and `_on_close()` callbacks (integrated into `_ws_loop()`)

### Implementation Details
- WebSocket connection is now managed in `_ws_loop()` coroutine with automatic reconnection (5-second backoff)
- Added `_entities_ready` asyncio.Event to track when all tracked entities have valid state
- Added `_check_entities_ready()` method to manage entity readiness state
- Improved error handling with proper exception logging and graceful reconnection
- Removed manual JSON serialization; using `send_json()` for cleaner message sending
- Type hints improved throughout the codebase

### Testing
- Converted from unittest.TestCase to pytest with async test support
- Updated all tests to use `async def` and `await` syntax
- Replaced `MagicMock` with `AsyncMock` for async method mocking
- Removed WebSocket/threading patches (no longer needed with async model)
- Added new tests for lifecycle management (`start()`, `stop()`)
- Added tests for `_entities_ready` event behavior

## Migration Notes
Code using this integration must now:
1. Call `await pm.start()` before using the integration
2. Call `await pm.stop()` when done
3. Use `await pm.get_powermeter_watts_async()` instead of `get_powermeter_watts()`
4. Use `await pm.wait_for_message_async()` instead of `wait_for_message()`

https://claude.ai/code/session_01PMd12eLCLuqfiCWrP7VuvT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle management methods for Home Assistant connection control.
  * Converted power meter and message APIs to asynchronous operations for improved responsiveness.
  * Enhanced subscription mechanism with improved entity state tracking.

* **Improvements**
  * Implemented automatic reconnection handling for Home Assistant connectivity.
  * Added comprehensive error logging and debugging capabilities.
  * Refined entity state synchronization with better change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->