### PR TITLE
Migrate HomeWizard powermeter from sync websocket to async

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "paho-mqtt",
     "jsonpath-ng",
     "pymodbus==3.6.5",
-"smllib",
+    "smllib",
     "pyserial",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ dependencies = [
     "paho-mqtt",
     "jsonpath-ng",
     "pymodbus==3.6.5",
-    "websocket-client==1.8.0",
-    "smllib",
+"smllib",
     "pyserial",
 ]
 

--- a/src/b2500_meter/powermeter/homewizard.py
+++ b/src/b2500_meter/powermeter/homewizard.py
@@ -50,6 +50,8 @@ class HomeWizardPowermeter(Powermeter):
     async def start(self) -> None:
         if self._session:
             return
+        self.values = None
+        self._message_event = asyncio.Event()
         self._session = aiohttp.ClientSession()
         self._ws_task = asyncio.create_task(self._ws_loop())
 

--- a/src/b2500_meter/powermeter/homewizard.py
+++ b/src/b2500_meter/powermeter/homewizard.py
@@ -102,6 +102,10 @@ class HomeWizardPowermeter(Powermeter):
             logger.error(f"HomeWizard: failed to decode message: {raw}")
             return
 
+        if not isinstance(msg, dict):
+            logger.error(f"HomeWizard: unexpected message format: {raw}")
+            return
+
         msg_type = msg.get("type")
         if msg_type == "authorization_requested":
             await ws.send_json({"type": "authorization", "data": self.token})
@@ -109,8 +113,9 @@ class HomeWizardPowermeter(Powermeter):
             logger.info("HomeWizard: authorized, subscribing to measurements")
             await ws.send_json({"type": "subscribe", "data": "measurement"})
         elif msg_type == "measurement":
-            data = msg.get("data", {})
-            self._handle_measurement(data)
+            data = msg.get("data")
+            if isinstance(data, dict):
+                self._handle_measurement(data)
         elif msg_type == "error":
             error_data = msg.get("data", {})
             logger.error(f"HomeWizard error: {error_data.get('message', msg)}")

--- a/src/b2500_meter/powermeter/homewizard.py
+++ b/src/b2500_meter/powermeter/homewizard.py
@@ -1,14 +1,16 @@
+import asyncio
+import contextlib
 import json
+import logging
 import os
 import ssl
-import threading
-import time
 
-import websocket
-
-from b2500_meter.config.logger import logger
+import aiohttp
 
 from .base import Powermeter
+
+# Stdlib logger: avoid importing b2500_meter.config (config_loader imports powermeter).
+logger = logging.getLogger("b2500-meter")
 
 # Certificate: https://api-documentation.homewizard.com/assets/files/homewizard-ca-cert-56d062ef8e71d1038f464ea905d42fc6.pem
 # Docs: https://api-documentation.homewizard.com/docs/v2/authorization#https
@@ -16,13 +18,17 @@ CA_CERT_PATH = os.path.join(os.path.dirname(__file__), "homewizard_ca.pem")
 
 
 class HomeWizardPowermeter(Powermeter):
-    def __init__(self, ip, token, serial, verify_ssl=True):
+    def __init__(
+        self, ip: str, token: str, serial: str, verify_ssl: bool = True
+    ) -> None:
         self.ip = ip
         self.token = token
         self.serial = serial
         self._verify_ssl = verify_ssl
-        self.values = None
-        self._lock = threading.Lock()
+        self.values: list[float] | None = None
+        self._session: aiohttp.ClientSession | None = None
+        self._ws_task: asyncio.Task[None] | None = None
+        self._message_event = asyncio.Event()
 
         if not verify_ssl:
             logger.warning(
@@ -30,24 +36,7 @@ class HomeWizardPowermeter(Powermeter):
                 "(VERIFY_SSL=False); use only on a trusted LAN"
             )
 
-        url = f"wss://{self.ip}/api/ws"
-        self.ws = websocket.WebSocketApp(
-            url,
-            on_open=self._on_open,
-            on_message=self._on_message,
-            on_error=self._on_error,
-            on_close=self._on_close,
-        )
-
-        sslopt = self._build_sslopt()
-        thread = threading.Thread(
-            target=self.ws.run_forever,
-            kwargs={"reconnect": 5, "sslopt": sslopt},
-            daemon=True,
-        )
-        thread.start()
-
-    def _build_sslopt(self):
+    def _build_ssl_context(self) -> ssl.SSLContext:
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         if self._verify_ssl:
             ssl_context.load_verify_locations(CA_CERT_PATH)
@@ -56,27 +45,67 @@ class HomeWizardPowermeter(Powermeter):
         else:
             ssl_context.check_hostname = False
             ssl_context.verify_mode = ssl.CERT_NONE
-        return {
-            "context": ssl_context,
-            "server_hostname": f"appliance/p1dongle/{self.serial}",
-        }
+        return ssl_context
 
-    def _on_open(self, ws):
-        logger.info(f"HomeWizard WebSocket connected to {self.ip}")
+    async def start(self) -> None:
+        if self._session:
+            return
+        self._session = aiohttp.ClientSession()
+        self._ws_task = asyncio.create_task(self._ws_loop())
 
-    def _on_message(self, ws, message):
+    async def stop(self) -> None:
+        if self._ws_task:
+            self._ws_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._ws_task
+            self._ws_task = None
+        if self._session:
+            await self._session.close()
+            self._session = None
+
+    async def _ws_loop(self) -> None:
+        url = f"wss://{self.ip}/api/ws"
+        ssl_context = self._build_ssl_context()
+        server_hostname = f"appliance/p1dongle/{self.serial}"
+        while True:
+            try:
+                assert self._session is not None
+                async with self._session.ws_connect(
+                    url, ssl=ssl_context, server_hostname=server_hostname
+                ) as ws:
+                    logger.info(f"HomeWizard WebSocket connected to {self.ip}")
+                    async for msg in ws:
+                        if msg.type == aiohttp.WSMsgType.TEXT:
+                            await self._handle_message(ws, msg.data)
+                        elif msg.type in (
+                            aiohttp.WSMsgType.ERROR,
+                            aiohttp.WSMsgType.CLOSE,
+                            aiohttp.WSMsgType.CLOSING,
+                            aiohttp.WSMsgType.CLOSED,
+                        ):
+                            break
+                    logger.info("HomeWizard WebSocket closed")
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.error(f"HomeWizard WebSocket error: {e}")
+            await asyncio.sleep(5)
+
+    async def _handle_message(
+        self, ws: aiohttp.ClientWebSocketResponse, raw: str
+    ) -> None:
         try:
-            msg = json.loads(message)
+            msg = json.loads(raw)
         except json.JSONDecodeError:
-            logger.error(f"HomeWizard: failed to decode message: {message}")
+            logger.error(f"HomeWizard: failed to decode message: {raw}")
             return
 
         msg_type = msg.get("type")
         if msg_type == "authorization_requested":
-            ws.send(json.dumps({"type": "authorization", "data": self.token}))
+            await ws.send_json({"type": "authorization", "data": self.token})
         elif msg_type == "authorized":
             logger.info("HomeWizard: authorized, subscribing to measurements")
-            ws.send(json.dumps({"type": "subscribe", "data": "measurement"}))
+            await ws.send_json({"type": "subscribe", "data": "measurement"})
         elif msg_type == "measurement":
             data = msg.get("data", {})
             self._handle_measurement(data)
@@ -86,7 +115,7 @@ class HomeWizardPowermeter(Powermeter):
         else:
             logger.debug(f"HomeWizard: unknown message type: {msg_type}")
 
-    def _handle_measurement(self, data):
+    def _handle_measurement(self, data: dict) -> None:
         if "power_l1_w" in data:
             values = [
                 data["power_l1_w"],
@@ -98,27 +127,16 @@ class HomeWizardPowermeter(Powermeter):
         else:
             return
 
-        with self._lock:
-            self.values = values
+        self.values = values
+        self._message_event.set()
 
-    def _on_error(self, ws, error):
-        logger.error(f"HomeWizard WebSocket error: {error}")
-
-    def _on_close(self, ws, close_status_code, close_msg):
-        logger.info(f"HomeWizard WebSocket closed: {close_status_code} {close_msg}")
-
-    def get_powermeter_watts(self):
-        with self._lock:
-            if self.values is not None:
-                return list(self.values)
+    async def get_powermeter_watts_async(self) -> list[float]:
+        if self.values is not None:
+            return list(self.values)
         raise ValueError("No value received from HomeWizard")
 
-    def wait_for_message(self, timeout=5):
-        start_time = time.time()
-        while True:
-            with self._lock:
-                if self.values is not None:
-                    return
-            if time.time() - start_time > timeout:
-                raise TimeoutError("Timeout waiting for HomeWizard measurement")
-            time.sleep(1)
+    async def wait_for_message_async(self, timeout: float = 5) -> None:
+        try:
+            await asyncio.wait_for(self._message_event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            raise TimeoutError("Timeout waiting for HomeWizard measurement") from None

--- a/src/b2500_meter/powermeter/homewizard_test.py
+++ b/src/b2500_meter/powermeter/homewizard_test.py
@@ -1,183 +1,346 @@
+import asyncio
 import json
 import ssl
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
 
 from .homewizard import HomeWizardPowermeter
 
 
-class TestHomeWizardPowermeter(unittest.TestCase):
-    def _create_powermeter(self, **kwargs):
-        with (
-            patch("b2500_meter.powermeter.homewizard.websocket.WebSocketApp"),
-            patch("b2500_meter.powermeter.homewizard.threading.Thread"),
+def _create_powermeter(**overrides):
+    defaults = dict(
+        ip="192.168.1.1",
+        token="ABCD1234",
+        serial="aabbccddee",
+    )
+    defaults.update(overrides)
+    return HomeWizardPowermeter(**defaults)
+
+
+def _ws_text(data: dict) -> aiohttp.WSMessage:
+    return aiohttp.WSMessage(aiohttp.WSMsgType.TEXT, json.dumps(data), None)
+
+
+# --- Category A: Measurement parsing ---
+
+
+def test_measurement_three_phase():
+    pm = _create_powermeter()
+    pm._handle_measurement(
+        {"power_w": -543, "power_l1_w": -200, "power_l2_w": -143, "power_l3_w": -200}
+    )
+    assert pm.values == [-200, -143, -200]
+
+
+def test_measurement_single_phase():
+    pm = _create_powermeter()
+    pm._handle_measurement({"power_w": 500})
+    assert pm.values == [500]
+
+
+def test_measurement_missing_phases():
+    pm = _create_powermeter()
+    pm._handle_measurement({"power_w": -543, "power_l1_w": -543})
+    assert pm.values == [-543, 0, 0]
+
+
+def test_measurement_no_power_fields():
+    pm = _create_powermeter()
+    pm._handle_measurement({"energy_import_kwh": 1234.5})
+    assert pm.values is None
+
+
+def test_negative_power_preserved():
+    pm = _create_powermeter()
+    pm._handle_measurement({"power_w": -1500})
+    assert pm.values == [-1500]
+
+
+def test_measurement_sets_event():
+    pm = _create_powermeter()
+    assert not pm._message_event.is_set()
+    pm._handle_measurement({"power_w": 100})
+    assert pm._message_event.is_set()
+
+
+# --- Category B: Auth/subscribe flow ---
+
+
+async def test_authorization_requested_sends_token():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {"type": "authorization_requested", "data": {"api_version": "2.0.0"}}
+        ),
+    )
+    ws.send_json.assert_called_once_with({"type": "authorization", "data": "ABCD1234"})
+
+
+async def test_authorized_subscribes_to_measurements():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps({"type": "authorized"}))
+    ws.send_json.assert_called_once_with({"type": "subscribe", "data": "measurement"})
+
+
+async def test_error_message_does_not_crash():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(
+        ws,
+        json.dumps({"type": "error", "data": {"message": "user:not-authorized"}}),
+    )
+    assert pm.values is None
+
+
+async def test_malformed_json_does_not_crash():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(ws, "not valid json")
+    assert pm.values is None
+
+
+async def test_unknown_message_type_does_not_crash():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps({"type": "unknown_type"}))
+    assert pm.values is None
+
+
+async def test_measurement_message_stores_values():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(
+        ws,
+        json.dumps({"type": "measurement", "data": {"power_w": 500}}),
+    )
+    assert await pm.get_powermeter_watts_async() == [500]
+
+
+# --- Category C: SSL context ---
+
+
+def test_ssl_context_verify_enabled():
+    pm = _create_powermeter()
+    ctx = pm._build_ssl_context()
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.check_hostname is True
+
+
+def test_ssl_context_verify_disabled():
+    pm = _create_powermeter(verify_ssl=False)
+    ctx = pm._build_ssl_context()
+    assert ctx.verify_mode == ssl.CERT_NONE
+    assert ctx.check_hostname is False
+
+
+# --- Category D: get_powermeter_watts_async ---
+
+
+async def test_get_watts_no_data_raises():
+    pm = _create_powermeter()
+    with pytest.raises(ValueError):
+        await pm.get_powermeter_watts_async()
+
+
+async def test_get_watts_returns_copy():
+    pm = _create_powermeter()
+    pm._handle_measurement({"power_w": 100})
+    result = await pm.get_powermeter_watts_async()
+    result.append(999)
+    assert await pm.get_powermeter_watts_async() == [100]
+
+
+# --- Category E: wait_for_message_async ---
+
+
+async def test_wait_for_message_returns_when_data_available():
+    pm = _create_powermeter()
+    pm._handle_measurement({"power_w": 100})
+    await pm.wait_for_message_async(timeout=1)
+
+
+async def test_wait_for_message_timeout():
+    pm = _create_powermeter()
+    with pytest.raises(TimeoutError):
+        await pm.wait_for_message_async(timeout=0)
+
+
+# --- Category F: Lifecycle ---
+
+
+async def test_start_creates_session_and_task():
+    pm = _create_powermeter()
+    with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
+        mock_loop.return_value = None
+        await pm.start()
+        assert pm._session is not None
+        assert pm._ws_task is not None
+        await pm.stop()
+
+
+async def test_start_is_idempotent():
+    pm = _create_powermeter()
+    with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
+        mock_loop.return_value = None
+        await pm.start()
+        session1 = pm._session
+        await pm.start()
+        assert pm._session is session1
+        await pm.stop()
+
+
+async def test_stop_closes_session():
+    pm = _create_powermeter()
+    with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
+        mock_loop.return_value = None
+        await pm.start()
+        await pm.stop()
+        assert pm._session is None
+        assert pm._ws_task is None
+
+
+async def test_stop_without_start():
+    pm = _create_powermeter()
+    await pm.stop()
+
+
+# --- Category G: Full WS flow ---
+
+
+class _FakeWs:
+    """A fake ws that yields given messages and records send_json calls."""
+
+    def __init__(self, messages):
+        self._messages = messages
+        self.send_json = AsyncMock()
+
+    async def __aiter__(self):
+        for msg in self._messages:
+            yield msg
+
+
+async def test_full_auth_subscribe_measurement_flow():
+    pm = _create_powermeter()
+
+    messages = [
+        _ws_text({"type": "authorization_requested", "data": {"api_version": "2.0.0"}}),
+        _ws_text({"type": "authorized"}),
+        _ws_text({"type": "measurement", "data": {"power_w": 500}}),
+    ]
+    ws = _FakeWs(messages)
+
+    async for msg in ws:
+        if msg.type == aiohttp.WSMsgType.TEXT:
+            await pm._handle_message(ws, msg.data)
+
+    ws.send_json.assert_any_call({"type": "authorization", "data": "ABCD1234"})
+    ws.send_json.assert_any_call({"type": "subscribe", "data": "measurement"})
+    assert await pm.get_powermeter_watts_async() == [500]
+
+
+async def test_close_message_exits_iteration():
+    pm = _create_powermeter()
+
+    messages = [
+        _ws_text({"type": "authorized"}),
+        aiohttp.WSMessage(aiohttp.WSMsgType.CLOSE, None, None),
+        _ws_text({"type": "measurement", "data": {"power_w": 500}}),
+    ]
+    ws = _FakeWs(messages)
+
+    processed = []
+    async for msg in ws:
+        if msg.type == aiohttp.WSMsgType.TEXT:
+            await pm._handle_message(ws, msg.data)
+            processed.append(msg)
+        elif msg.type in (
+            aiohttp.WSMsgType.CLOSE,
+            aiohttp.WSMsgType.CLOSING,
+            aiohttp.WSMsgType.CLOSED,
+            aiohttp.WSMsgType.ERROR,
         ):
-            pm = HomeWizardPowermeter("192.168.1.1", "ABCD1234", "aabbccddee", **kwargs)
-        return pm
+            break
 
-    def test_on_message_authorization_requested(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(
-            ws,
-            json.dumps(
-                {
-                    "type": "authorization_requested",
-                    "data": {"api_version": "2.0.0"},
-                }
-            ),
-        )
-        ws.send.assert_called_once_with(
-            json.dumps({"type": "authorization", "data": "ABCD1234"})
-        )
-
-    def test_on_message_authorized(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(ws, json.dumps({"type": "authorized"}))
-        ws.send.assert_called_once_with(
-            json.dumps({"type": "subscribe", "data": "measurement"})
-        )
-
-    def test_on_message_measurement_three_phase(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(
-            ws,
-            json.dumps(
-                {
-                    "type": "measurement",
-                    "data": {
-                        "power_w": -543,
-                        "power_l1_w": -200,
-                        "power_l2_w": -143,
-                        "power_l3_w": -200,
-                    },
-                }
-            ),
-        )
-        self.assertEqual(pm.get_powermeter_watts(), [-200, -143, -200])
-
-    def test_on_message_measurement_single_phase(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(
-            ws,
-            json.dumps(
-                {
-                    "type": "measurement",
-                    "data": {
-                        "power_w": 500,
-                    },
-                }
-            ),
-        )
-        self.assertEqual(pm.get_powermeter_watts(), [500])
-
-    def test_on_message_measurement_missing_phases(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(
-            ws,
-            json.dumps(
-                {
-                    "type": "measurement",
-                    "data": {
-                        "power_w": -543,
-                        "power_l1_w": -543,
-                    },
-                }
-            ),
-        )
-        self.assertEqual(pm.get_powermeter_watts(), [-543, 0, 0])
-
-    def test_on_message_measurement_no_power_fields(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(
-            ws,
-            json.dumps(
-                {
-                    "type": "measurement",
-                    "data": {
-                        "energy_import_kwh": 1234.5,
-                    },
-                }
-            ),
-        )
-        with self.assertRaises(ValueError):
-            pm.get_powermeter_watts()
-
-    def test_on_message_error(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(
-            ws,
-            json.dumps(
-                {
-                    "type": "error",
-                    "data": {"message": "user:not-authorized"},
-                }
-            ),
-        )
-        with self.assertRaises(ValueError):
-            pm.get_powermeter_watts()
-
-    def test_on_message_malformed_json(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(ws, "not valid json")
-        with self.assertRaises(ValueError):
-            pm.get_powermeter_watts()
-
-    def test_get_powermeter_watts_no_data(self):
-        pm = self._create_powermeter()
-        with self.assertRaises(ValueError):
-            pm.get_powermeter_watts()
-
-    def test_get_powermeter_watts_returns_copy(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(
-            ws,
-            json.dumps(
-                {
-                    "type": "measurement",
-                    "data": {"power_w": 100},
-                }
-            ),
-        )
-        result = pm.get_powermeter_watts()
-        result.append(999)
-        self.assertEqual(pm.get_powermeter_watts(), [100])
-
-    def test_negative_power_preserved(self):
-        pm = self._create_powermeter()
-        ws = MagicMock()
-        pm._on_message(
-            ws,
-            json.dumps(
-                {
-                    "type": "measurement",
-                    "data": {"power_w": -1500},
-                }
-            ),
-        )
-        self.assertEqual(pm.get_powermeter_watts(), [-1500])
-
-    def test_verify_ssl_disabled_skips_certificate_validation(self):
-        pm = self._create_powermeter(verify_ssl=False)
-        sslopt = pm._build_sslopt()
-        self.assertEqual(sslopt["context"].verify_mode, ssl.CERT_NONE)
-        self.assertFalse(sslopt["context"].check_hostname)
-        self.assertEqual(sslopt["server_hostname"], "appliance/p1dongle/aabbccddee")
-
-    def test_verify_ssl_default_validates_certificate(self):
-        pm = self._create_powermeter()
-        sslopt = pm._build_sslopt()
-        self.assertEqual(sslopt["context"].verify_mode, ssl.CERT_REQUIRED)
-        self.assertTrue(sslopt["context"].check_hostname)
+    assert len(processed) == 1
+    assert pm.values is None
 
 
-if __name__ == "__main__":
-    unittest.main()
+# --- Category H: Reconnection ---
+
+
+def _mock_ws_context(ws):
+    """Create an async context manager that yields *ws*."""
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=ws)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+def _empty_ws():
+    """Create a mock ws whose async iteration ends immediately."""
+    ws = AsyncMock()
+
+    async def empty_aiter():
+        return
+        yield  # pragma: no cover — makes this an async generator
+
+    ws.__aiter__ = empty_aiter
+    return ws
+
+
+async def test_ws_loop_reconnects_after_disconnect():
+    pm = _create_powermeter()
+    pm._session = MagicMock(spec=aiohttp.ClientSession)
+
+    call_count = 0
+
+    def fake_ws_connect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            raise asyncio.CancelledError
+        return _mock_ws_context(_empty_ws())
+
+    pm._session.ws_connect = fake_ws_connect
+
+    with (
+        patch(
+            "b2500_meter.powermeter.homewizard.asyncio.sleep", new_callable=AsyncMock
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await pm._ws_loop()
+
+    assert call_count == 2
+
+
+async def test_ws_loop_reconnects_on_client_error():
+    pm = _create_powermeter()
+    pm._session = MagicMock(spec=aiohttp.ClientSession)
+
+    call_count = 0
+
+    def fake_ws_connect(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise aiohttp.ClientError("connection failed")
+        raise asyncio.CancelledError
+
+    pm._session.ws_connect = fake_ws_connect
+
+    with (
+        patch(
+            "b2500_meter.powermeter.homewizard.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await pm._ws_loop()
+
+    assert call_count == 2
+    mock_sleep.assert_called_with(5)

--- a/src/b2500_meter/powermeter/homewizard_test.py
+++ b/src/b2500_meter/powermeter/homewizard_test.py
@@ -209,6 +209,20 @@ async def test_stop_without_start():
     await pm.stop()
 
 
+async def test_start_resets_stale_state():
+    pm = _create_powermeter()
+    # Simulate leftover state from a previous session
+    pm.values = [999.0]
+    pm._message_event.set()
+
+    with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
+        mock_loop.return_value = None
+        await pm.start()
+        assert pm.values is None
+        assert not pm._message_event.is_set()
+        await pm.stop()
+
+
 # --- Category G: Full WS flow ---
 
 

--- a/src/b2500_meter/powermeter/homewizard_test.py
+++ b/src/b2500_meter/powermeter/homewizard_test.py
@@ -111,6 +111,24 @@ async def test_unknown_message_type_does_not_crash():
     assert pm.values is None
 
 
+async def test_non_dict_json_does_not_crash():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps([1, 2, 3]))
+    assert pm.values is None
+    await pm._handle_message(ws, json.dumps("just a string"))
+    assert pm.values is None
+
+
+async def test_measurement_non_dict_data_ignored():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(
+        ws, json.dumps({"type": "measurement", "data": "not a dict"})
+    )
+    assert pm.values is None
+
+
 async def test_measurement_message_stores_values():
     pm = _create_powermeter()
     ws = AsyncMock()

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,6 @@ dependencies = [
     { name = "requests" },
     { name = "smllib" },
     { name = "urllib3" },
-    { name = "websocket-client" },
 ]
 
 [package.optional-dependencies]
@@ -212,7 +211,6 @@ requires-dist = [
     { name = "textual", marker = "extra == 'sim'", specifier = ">=1.0.0" },
     { name = "textual-plot", marker = "extra == 'sim'", specifier = ">=0.10.1" },
     { name = "urllib3" },
-    { name = "websocket-client", specifier = "==1.8.0" },
 ]
 provides-extras = ["dev", "sim"]
 
@@ -1520,15 +1518,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "websocket-client"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Refactored the HomeWizard powermeter implementation to use async/await patterns with `aiohttp` instead of the synchronous `websocket-client` library. This modernizes the codebase and enables better integration with async event loops.

## Key Changes

- **Async WebSocket**: Replaced `websocket.WebSocketApp` with `aiohttp.ClientSession.ws_connect()` for async WebSocket communication
- **Lifecycle Management**: Added `start()` and `stop()` methods to manage the aiohttp session and WebSocket connection task
- **Message Handling**: Converted `_on_message()` to async `_handle_message()` method that processes incoming WebSocket messages
- **Reconnection Logic**: Implemented `_ws_loop()` coroutine that handles automatic reconnection with 5-second backoff on connection failures
- **Event Signaling**: Replaced threading lock with `asyncio.Event` for thread-safe measurement updates
- **API Changes**: 
  - `get_powermeter_watts()` → `get_powermeter_watts_async()` (now async)
  - `wait_for_message()` → `wait_for_message_async()` (now async)
- **SSL Context**: Simplified `_build_sslopt()` to `_build_ssl_context()` returning just the SSL context (aiohttp handles server_hostname separately)
- **Dependencies**: Removed `websocket-client` dependency

## Testing
Completely rewrote test suite from unittest to pytest with async support:
- Organized tests into 8 categories (measurement parsing, auth/subscribe flow, SSL context, async methods, lifecycle, full WS flow, reconnection)
- Added comprehensive async test coverage using `AsyncMock` and `pytest`
- Tests now validate the full auth→subscribe→measurement flow and reconnection behavior

https://claude.ai/code/session_01M2csyEXjJcw9GqXbmhmzX5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added async `start()` and `stop()` lifecycle methods for power meter device management.

* **Changes**
  * Power meter retrieval and message waiting methods are now async: `get_powermeter_watts_async()` and `wait_for_message_async()`.

* **Chores**
  * Removed unused dependency from project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->