### PR TITLE
Add multi-phase support for MQTT powermeter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Next
-- Added multi-phase support for MQTT powermeter: multiple topics (`TOPICS`) or multiple JSON paths (`JSON_PATHS`) from a single topic ([#208](https://github.com/tomquist/b2500-meter/issues/208))
+- Added multi-phase support for MQTT powermeter: multiple topics (`TOPICS`) or multiple JSON paths (`JSON_PATHS`) from a single topic ([#208](https://github.com/tomquist/b2500-meter/issues/208), [#280](https://github.com/tomquist/b2500-meter/pull/280))
 - Migrated powermeters to native asyncio, replacing blocking `requests`/threading with `aiohttp` and async lifecycle management for improved concurrency
 - Added support for emulating a *CT002/CT003*, which is recommended to steer multiple devices
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Added multi-phase support for MQTT powermeter: multiple topics (`TOPICS`) or multiple JSON paths (`JSON_PATHS`) from a single topic ([#208](https://github.com/tomquist/b2500-meter/issues/208))
 - Migrated powermeters to native asyncio, replacing blocking `requests`/threading with `aiohttp` and async lifecycle management for improved concurrency
 - Added support for emulating a *CT002/CT003*, which is recommended to steer multiple devices
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))

--- a/README.md
+++ b/README.md
@@ -521,6 +521,29 @@ PASSWORD = mqtt_pass (Optional)
 The `JSON_PATH` option is used to extract the power value from a JSON payload. The path must be a [valid JSONPath expression](https://goessner.net/articles/JsonPath/).
 If the payload is a simple integer value, you can omit this option.
 
+#### Multi-phase MQTT
+
+For three-phase setups, there are two options:
+
+**Option 1: Multiple topics** — one topic per phase, each publishing a plain numeric value (or JSON with the same path):
+
+```ini
+[MQTT]
+BROKER = broker.example.com
+TOPICS = home/power/l1, home/power/l2, home/power/l3
+```
+
+**Option 2: Single topic with multiple JSON paths** — one topic publishing a JSON message containing all phases:
+
+```ini
+[MQTT]
+BROKER = broker.example.com
+TOPIC = home/powermeter
+JSON_PATHS = $.phases[0].power, $.phases[1].power, $.phases[2].power
+```
+
+`TOPICS` takes precedence over `TOPIC`, and `JSON_PATHS` takes precedence over `JSON_PATH`. You can combine `TOPICS` with `JSON_PATH` (same path applied to each topic) or with `JSON_PATHS` (one path per topic, counts must match).
+
 ### JSON HTTP
 
 ```ini

--- a/config.ini.example
+++ b/config.ini.example
@@ -206,12 +206,13 @@ THROTTLE_INTERVAL = 0
 ## MQTT can have variable latency depending on broker and network
 #THROTTLE_INTERVAL = 1
 
-## Multi-phase option 1: one topic per phase (comma-separated)
+## Multi-phase: replace the [MQTT] section above with one of these alternatives
+## Option 1: one topic per phase (comma-separated)
 #[MQTT]
 #BROKER = broker.example.com
 #TOPICS = home/power/l1, home/power/l2, home/power/l3
 
-## Multi-phase option 2: single topic with multiple JSON paths
+## Option 2: single topic with multiple JSON paths
 #[MQTT]
 #BROKER = broker.example.com
 #TOPIC = home/powermeter

--- a/config.ini.example
+++ b/config.ini.example
@@ -206,6 +206,17 @@ THROTTLE_INTERVAL = 0
 ## MQTT can have variable latency depending on broker and network
 #THROTTLE_INTERVAL = 1
 
+## Multi-phase option 1: one topic per phase (comma-separated)
+#[MQTT]
+#BROKER = broker.example.com
+#TOPICS = home/power/l1, home/power/l2, home/power/l3
+
+## Multi-phase option 2: single topic with multiple JSON paths
+#[MQTT]
+#BROKER = broker.example.com
+#TOPIC = home/powermeter
+#JSON_PATHS = $.phases[0].power, $.phases[1].power, $.phases[2].power
+
 # [JSON_HTTP]
 #URL = http://example.com/api
 #JSON_PATHS = $.power

--- a/src/b2500_meter/config/config_loader.py
+++ b/src/b2500_meter/config/config_loader.py
@@ -235,11 +235,27 @@ def create_sml_powermeter(
 def create_mqtt_powermeter(
     section: str, config: configparser.ConfigParser
 ) -> Powermeter:
+    # Multi-topic: TOPICS takes precedence over TOPIC
+    topics_raw = config.get(section, "TOPICS", fallback=None)
+    if topics_raw:
+        topic: str | list[str] = [t.strip() for t in topics_raw.split(",") if t.strip()]
+    else:
+        topic = config.get(section, "TOPIC", fallback="")
+
+    # Multi-path: JSON_PATHS takes precedence over JSON_PATH
+    json_paths_raw = config.get(section, "JSON_PATHS", fallback=None)
+    if json_paths_raw:
+        json_path: str | list[str] | None = [
+            p.strip() for p in json_paths_raw.split(",") if p.strip()
+        ]
+    else:
+        json_path = config.get(section, "JSON_PATH", fallback=None)
+
     return MqttPowermeter(
         config.get(section, "BROKER", fallback=""),
         config.getint(section, "PORT", fallback=1883),
-        config.get(section, "TOPIC", fallback=""),
-        config.get(section, "JSON_PATH", fallback=None),
+        topic,
+        json_path,
         config.get(section, "USERNAME", fallback=None),
         config.get(section, "PASSWORD", fallback=None),
     )

--- a/src/b2500_meter/config/config_loader_test.py
+++ b/src/b2500_meter/config/config_loader_test.py
@@ -224,6 +224,51 @@ def test_create_mqtt_powermeter():
             raise
 
 
+def test_create_mqtt_powermeter_with_topics():
+    """Test MQTT powermeter creation with multi-phase TOPICS."""
+    config = configparser.ConfigParser()
+    config["MQTT"] = {
+        "BROKER": "127.0.0.1",
+        "TOPICS": "home/l1, home/l2, home/l3",
+    }
+    pm = create_mqtt_powermeter("MQTT", config)
+    assert len(pm._subscriptions) == 3
+    assert pm._subscriptions == [
+        ("home/l1", None),
+        ("home/l2", None),
+        ("home/l3", None),
+    ]
+
+
+def test_create_mqtt_powermeter_with_json_paths():
+    """Test MQTT powermeter creation with single TOPIC and multiple JSON_PATHS."""
+    config = configparser.ConfigParser()
+    config["MQTT"] = {
+        "BROKER": "127.0.0.1",
+        "TOPIC": "home/power",
+        "JSON_PATHS": "$.l1.power, $.l2.power, $.l3.power",
+    }
+    pm = create_mqtt_powermeter("MQTT", config)
+    assert len(pm._subscriptions) == 3
+    assert pm._subscriptions[0] == ("home/power", "$.l1.power")
+    assert pm._subscriptions[1] == ("home/power", "$.l2.power")
+    assert pm._subscriptions[2] == ("home/power", "$.l3.power")
+
+
+def test_create_mqtt_powermeter_topics_takes_precedence_over_topic():
+    """Test that TOPICS takes precedence over TOPIC when both are set."""
+    config = configparser.ConfigParser()
+    config["MQTT"] = {
+        "BROKER": "127.0.0.1",
+        "TOPIC": "ignored",
+        "TOPICS": "home/l1, home/l2",
+    }
+    pm = create_mqtt_powermeter("MQTT", config)
+    assert len(pm._subscriptions) == 2
+    assert pm._subscriptions[0][0] == "home/l1"
+    assert pm._subscriptions[1][0] == "home/l2"
+
+
 def test_create_json_http_powermeter():
     """Test JSON HTTP powermeter creation."""
     config = configparser.ConfigParser()

--- a/src/b2500_meter/powermeter/mqtt.py
+++ b/src/b2500_meter/powermeter/mqtt.py
@@ -48,9 +48,12 @@ class MqttPowermeter(Powermeter):
         # Handle single topic + multiple paths: replicate topic
         if len(topics) == 1 and len(paths) > 1:
             topics = topics * len(paths)
-        # Handle multiple topics + single/no path: already replicated above
+        # Handle multiple topics + single-element path list (e.g. json_path=["$.a"])
         elif len(topics) > 1 and len(paths) == 1:
             paths = paths * len(topics)
+
+        if not topics:
+            raise ValueError("At least one MQTT topic is required.")
 
         if len(topics) != len(paths):
             raise ValueError(
@@ -111,18 +114,20 @@ class MqttPowermeter(Powermeter):
                             continue
                         # Parse JSON once if any subscription for this topic needs it
                         parsed_json = None
-                        try:
-                            for i in indices:
-                                _, jp = self._subscriptions[i]
+                        for i in indices:
+                            _, jp = self._subscriptions[i]
+                            try:
                                 if jp:
                                     if parsed_json is None:
                                         parsed_json = json.loads(payload)
                                     self.values[i] = extract_json_value(parsed_json, jp)
                                 else:
                                     self.values[i] = float(payload)
-                            self._message_event.set()
-                        except (json.JSONDecodeError, ValueError) as e:
-                            logger.error(f"Failed to parse MQTT payload: {e}")
+                                self._message_event.set()
+                            except (json.JSONDecodeError, ValueError) as e:
+                                logger.error(
+                                    f"Failed to parse MQTT payload for index {i}: {e}"
+                                )
             except aiomqtt.MqttError as e:
                 self._connected_event.clear()
                 logger.warning(
@@ -139,15 +144,16 @@ class MqttPowermeter(Powermeter):
 
     async def get_powermeter_watts_async(self) -> list[float]:
         if all(v is not None for v in self.values):
-            return [v for v in self.values if v is not None]
+            return list(self.values)  # type: ignore[arg-type]
         raise ValueError("No value received from MQTT")
 
     async def wait_for_message_async(self, timeout=5):
         if all(v is not None for v in self.values):
             return
-        deadline = asyncio.get_event_loop().time() + timeout
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
         while True:
-            remaining = deadline - asyncio.get_event_loop().time()
+            remaining = deadline - loop.time()
             if remaining <= 0:
                 raise TimeoutError("Timeout waiting for MQTT message")
             self._message_event.clear()

--- a/src/b2500_meter/powermeter/mqtt.py
+++ b/src/b2500_meter/powermeter/mqtt.py
@@ -26,29 +26,69 @@ class MqttPowermeter(Powermeter):
         self,
         broker: str,
         port: int,
-        topic: str,
-        json_path: str | None = None,
+        topic: str | list[str],
+        json_path: str | list[str] | None = None,
         username: str | None = None,
         password: str | None = None,
     ):
         self.broker = broker
         self.port = port
-        self.topic = topic
-        self.json_path = json_path
         self.username = username
         self.password = password
-        self.value: float | None = None
+
+        # Normalize topic(s) and json_path(s) into subscription list
+        topics = [topic] if isinstance(topic, str) else list(topic)
+        if json_path is None:
+            paths: list[str | None] = [None] * len(topics)
+        elif isinstance(json_path, str):
+            paths = [json_path] * len(topics)
+        else:
+            paths = list(json_path)
+
+        # Handle single topic + multiple paths: replicate topic
+        if len(topics) == 1 and len(paths) > 1:
+            topics = topics * len(paths)
+        # Handle multiple topics + single/no path: already replicated above
+        elif len(topics) > 1 and len(paths) == 1:
+            paths = paths * len(topics)
+
+        if len(topics) != len(paths):
+            raise ValueError(
+                f"Topic count ({len(topics)}) and JSON path count ({len(paths)}) "
+                f"must match, or one of them must be a single value."
+            )
+
+        self._subscriptions: list[tuple[str, str | None]] = list(
+            zip(topics, paths, strict=True)
+        )
+
+        # Build O(1) topic -> subscription index mapping
+        self._topic_indices: dict[str, list[int]] = {}
+        for i, (t, _) in enumerate(self._subscriptions):
+            self._topic_indices.setdefault(t, []).append(i)
+
+        self.values: list[float | None] = [None] * len(self._subscriptions)
         self._run_task: asyncio.Task[None] | None = None
         self._message_event = asyncio.Event()
         self._connected_event = asyncio.Event()
 
+    @property
+    def value(self) -> float | None:
+        return self.values[0] if self.values else None
+
+    @value.setter
+    def value(self, v: float | None) -> None:
+        if self.values:
+            self.values[0] = v
+
     async def start(self) -> None:
-        self.value = None
+        self.values = [None] * len(self._subscriptions)
         self._message_event.clear()
         self._connected_event.clear()
         self._run_task = asyncio.create_task(self._run())
 
     async def _run(self) -> None:
+        unique_topics = list(self._topic_indices.keys())
         while True:
             try:
                 async with aiomqtt.Client(
@@ -59,17 +99,27 @@ class MqttPowermeter(Powermeter):
                     keepalive=60,
                 ) as client:
                     logger.info(f"Connected to MQTT broker {self.broker}:{self.port}")
-                    await client.subscribe(self.topic)
+                    for t in unique_topics:
+                        await client.subscribe(t)
                     self._connected_event.set()
                     async for message in client.messages:
                         raw = message.payload
                         payload = raw.decode() if isinstance(raw, bytes) else str(raw)
+                        topic_str = str(message.topic)
+                        indices = self._topic_indices.get(topic_str, [])
+                        if not indices:
+                            continue
+                        # Parse JSON once if any subscription for this topic needs it
+                        parsed_json = None
                         try:
-                            if self.json_path:
-                                data = json.loads(payload)
-                                self.value = extract_json_value(data, self.json_path)
-                            else:
-                                self.value = float(payload)
+                            for i in indices:
+                                _, jp = self._subscriptions[i]
+                                if jp:
+                                    if parsed_json is None:
+                                        parsed_json = json.loads(payload)
+                                    self.values[i] = extract_json_value(parsed_json, jp)
+                                else:
+                                    self.values[i] = float(payload)
                             self._message_event.set()
                         except (json.JSONDecodeError, ValueError) as e:
                             logger.error(f"Failed to parse MQTT payload: {e}")
@@ -88,14 +138,22 @@ class MqttPowermeter(Powermeter):
             self._run_task = None
 
     async def get_powermeter_watts_async(self) -> list[float]:
-        if self.value is not None:
-            return [self.value]
+        if all(v is not None for v in self.values):
+            return [v for v in self.values if v is not None]
         raise ValueError("No value received from MQTT")
 
     async def wait_for_message_async(self, timeout=5):
-        if self.value is not None:
+        if all(v is not None for v in self.values):
             return
-        try:
-            await asyncio.wait_for(self._message_event.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
-            raise TimeoutError("Timeout waiting for MQTT message") from None
+        deadline = asyncio.get_event_loop().time() + timeout
+        while True:
+            remaining = deadline - asyncio.get_event_loop().time()
+            if remaining <= 0:
+                raise TimeoutError("Timeout waiting for MQTT message")
+            self._message_event.clear()
+            try:
+                await asyncio.wait_for(self._message_event.wait(), timeout=remaining)
+            except asyncio.TimeoutError:
+                raise TimeoutError("Timeout waiting for MQTT message") from None
+            if all(v is not None for v in self.values):
+                return

--- a/src/b2500_meter/powermeter/mqtt_test.py
+++ b/src/b2500_meter/powermeter/mqtt_test.py
@@ -145,6 +145,11 @@ def test_multi_topic_multi_json_path_matching():
     assert pm._subscriptions == [("t1", "$.a"), ("t2", "$.b")]
 
 
+def test_empty_topic_list_raises():
+    with pytest.raises(ValueError, match="At least one MQTT topic"):
+        _make_pm(topic=[])
+
+
 def test_multi_topic_multi_json_path_length_mismatch():
     with pytest.raises(ValueError, match="must match"):
         _make_pm(topic=["t1", "t2"], json_path=["$.a", "$.b", "$.c"])

--- a/src/b2500_meter/powermeter/mqtt_test.py
+++ b/src/b2500_meter/powermeter/mqtt_test.py
@@ -52,8 +52,8 @@ TEST_TOPIC = "test/power"
 def _make_pm(
     broker: str = "localhost",
     port: int = 1883,
-    topic: str = TEST_TOPIC,
-    json_path: str | None = None,
+    topic: str | list[str] = TEST_TOPIC,
+    json_path: str | list[str] | None = None,
     username: str | None = None,
     password: str | None = None,
 ) -> MqttPowermeter:
@@ -103,6 +103,114 @@ async def test_wait_for_message_async_wakes_on_event():
     await pm.wait_for_message_async(timeout=2)
     await task
     assert pm.value == 99.0
+
+
+# ---------------------------------------------------------------------------
+# Multi-phase constructor unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_single_topic_backward_compat():
+    pm = _make_pm(topic="t1")
+    assert len(pm._subscriptions) == 1
+    assert pm._subscriptions[0] == ("t1", None)
+    assert len(pm.values) == 1
+
+
+def test_single_topic_with_json_path_backward_compat():
+    pm = _make_pm(topic="t1", json_path="$.power")
+    assert pm._subscriptions == [("t1", "$.power")]
+
+
+def test_multi_topic_constructor():
+    pm = _make_pm(topic=["t1", "t2", "t3"])
+    assert len(pm._subscriptions) == 3
+    assert len(pm.values) == 3
+    assert pm._subscriptions == [("t1", None), ("t2", None), ("t3", None)]
+
+
+def test_single_topic_multi_json_paths():
+    pm = _make_pm(topic="t", json_path=["$.a", "$.b", "$.c"])
+    assert len(pm._subscriptions) == 3
+    assert pm._subscriptions == [("t", "$.a"), ("t", "$.b"), ("t", "$.c")]
+
+
+def test_multi_topic_single_json_path():
+    pm = _make_pm(topic=["t1", "t2"], json_path="$.p")
+    assert pm._subscriptions == [("t1", "$.p"), ("t2", "$.p")]
+
+
+def test_multi_topic_multi_json_path_matching():
+    pm = _make_pm(topic=["t1", "t2"], json_path=["$.a", "$.b"])
+    assert pm._subscriptions == [("t1", "$.a"), ("t2", "$.b")]
+
+
+def test_multi_topic_multi_json_path_length_mismatch():
+    with pytest.raises(ValueError, match="must match"):
+        _make_pm(topic=["t1", "t2"], json_path=["$.a", "$.b", "$.c"])
+
+
+def test_topic_indices_mapping():
+    pm = _make_pm(topic="t", json_path=["$.a", "$.b"])
+    assert pm._topic_indices == {"t": [0, 1]}
+
+
+def test_multi_topic_indices_mapping():
+    pm = _make_pm(topic=["t1", "t2", "t3"])
+    assert pm._topic_indices == {"t1": [0], "t2": [1], "t3": [2]}
+
+
+# ---------------------------------------------------------------------------
+# Multi-phase get/wait unit tests
+# ---------------------------------------------------------------------------
+
+
+async def test_get_watts_raises_when_partial_values():
+    pm = _make_pm(topic=["t1", "t2"])
+    pm.values[0] = 100.0
+    with pytest.raises(ValueError, match="No value received"):
+        await pm.get_powermeter_watts_async()
+
+
+async def test_get_watts_returns_all_phases():
+    pm = _make_pm(topic=["t1", "t2", "t3"])
+    pm.values[0] = 100.0
+    pm.values[1] = 200.0
+    pm.values[2] = 300.0
+    assert await pm.get_powermeter_watts_async() == [100.0, 200.0, 300.0]
+
+
+async def test_wait_for_message_returns_when_all_set():
+    pm = _make_pm(topic=["t1", "t2"])
+
+    async def _set_later():
+        await asyncio.sleep(0.05)
+        pm.values[0] = 10.0
+        pm._message_event.set()
+        await asyncio.sleep(0.05)
+        pm.values[1] = 20.0
+        pm._message_event.set()
+
+    task = asyncio.create_task(_set_later())
+    await pm.wait_for_message_async(timeout=2)
+    await task
+    assert await pm.get_powermeter_watts_async() == [10.0, 20.0]
+
+
+async def test_wait_for_message_times_out_with_partial():
+    pm = _make_pm(topic=["t1", "t2"])
+    pm.values[0] = 10.0
+    # values[1] is still None
+    with pytest.raises(TimeoutError, match="Timeout waiting"):
+        await pm.wait_for_message_async(timeout=0.2)
+
+
+async def test_value_property_backward_compat():
+    pm = _make_pm()
+    assert pm.value is None
+    pm.value = 42.0
+    assert pm.values[0] == 42.0
+    assert pm.value == 42.0
 
 
 # ---------------------------------------------------------------------------
@@ -223,5 +331,51 @@ async def test_receives_multiple_messages_returns_latest(mqtt_broker):
         # Give the listener time to process all messages
         await asyncio.sleep(0.5)
         assert await pm.get_powermeter_watts_async() == [30.0]
+    finally:
+        await pm.stop()
+
+
+@_needs_mosquitto
+async def test_receives_multi_topic_values(mqtt_broker):
+    import aiomqtt
+
+    port = mqtt_broker
+    topics = ["test/phase/l1", "test/phase/l2", "test/phase/l3"]
+    pm = MqttPowermeter(broker="127.0.0.1", port=port, topic=topics)
+    await pm.start()
+    try:
+        await asyncio.wait_for(pm._connected_event.wait(), timeout=5)
+        async with aiomqtt.Client(hostname="127.0.0.1", port=port) as pub:
+            await pub.publish(topics[0], payload=b"100.0")
+            await pub.publish(topics[1], payload=b"200.0")
+            await pub.publish(topics[2], payload=b"300.0")
+        await pm.wait_for_message_async(timeout=5)
+        assert await pm.get_powermeter_watts_async() == [100.0, 200.0, 300.0]
+    finally:
+        await pm.stop()
+
+
+@_needs_mosquitto
+async def test_receives_single_topic_multi_json_paths(mqtt_broker):
+    import aiomqtt
+
+    port = mqtt_broker
+    topic = "test/multijson"
+    json_paths = ["$.l1.power", "$.l2.power", "$.l3.power"]
+    pm = MqttPowermeter(
+        broker="127.0.0.1", port=port, topic=topic, json_path=json_paths
+    )
+    await pm.start()
+    try:
+        await asyncio.wait_for(pm._connected_event.wait(), timeout=5)
+        payload = {
+            "l1": {"power": 110.5},
+            "l2": {"power": 220.3},
+            "l3": {"power": 330.1},
+        }
+        async with aiomqtt.Client(hostname="127.0.0.1", port=port) as pub:
+            await pub.publish(topic, payload=json.dumps(payload).encode())
+        await pm.wait_for_message_async(timeout=5)
+        assert await pm.get_powermeter_watts_async() == [110.5, 220.3, 330.1]
     finally:
         await pm.stop()


### PR DESCRIPTION
## Summary
Extended the MQTT powermeter to support multi-phase (3-phase) power measurements through either multiple MQTT topics or multiple JSON paths from a single topic.

## Key Changes

**Core Implementation (`mqtt.py`)**
- Modified constructor to accept `topic` and `json_path` as either strings or lists
- Introduced `_subscriptions` list to store (topic, json_path) tuples for each phase
- Added `_topic_indices` mapping for O(1) topic lookup to subscription indices
- Changed `value` property to `values` list to store per-phase measurements
- Implemented backward-compatible `value` property that proxies to `values[0]`
- Updated message handling to parse each MQTT message once and apply multiple JSON paths if needed
- Enhanced `wait_for_message_async()` to wait until all phases have received values (with proper timeout handling)
- Updated `get_powermeter_watts_async()` to return all phase values as a list

**Configuration (`config_loader.py`)**
- Added support for `TOPICS` (comma-separated) as alternative to `TOPIC`
- Added support for `JSON_PATHS` (comma-separated) as alternative to `JSON_PATH`
- Implemented precedence: `TOPICS` > `TOPIC` and `JSON_PATHS` > `JSON_PATH`

**Tests (`mqtt_test.py`)**
- Added comprehensive unit tests for all configuration combinations:
  - Single topic backward compatibility
  - Multiple topics with matching/mismatching JSON paths
  - Single topic with multiple JSON paths
  - Topic-to-subscription index mapping validation
- Added async tests for multi-phase value retrieval and timeout handling
- Added integration tests with real MQTT broker for multi-topic and multi-JSON-path scenarios

**Documentation**
- Updated README with multi-phase MQTT configuration examples
- Added example configurations in `config.ini.example`
- Updated CHANGELOG

## Implementation Details

The solution supports three configuration patterns:
1. **Multiple topics** (one per phase): `TOPICS = t1, t2, t3`
2. **Single topic + multiple JSON paths**: `TOPIC = t`, `JSON_PATHS = $.a, $.b, $.c`
3. **Multiple topics + single JSON path**: `TOPICS = t1, t2`, `JSON_PATH = $.power`

The implementation normalizes all inputs into a unified `_subscriptions` list and validates that topic and path counts are compatible (either matching or one being singular).

https://claude.ai/code/session_01XMddqRyiusHQSukPpu4fwb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-phase power meter support for MQTT, enabling extraction of multiple measurements either from separate MQTT topics or from multiple JSON paths within a single topic.

* **Documentation**
  * Added comprehensive multi-phase MQTT configuration documentation with two configuration alternatives and precedence rules.

* **Tests**
  * Added unit tests covering multi-phase MQTT configuration and message handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->