### PR TITLE
Complete asyncio migration: remove legacy sync interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Next
 - Added multi-phase support for MQTT powermeter: multiple topics (`TOPICS`) or multiple JSON paths (`JSON_PATHS`) from a single topic ([#208](https://github.com/tomquist/b2500-meter/issues/208), [#280](https://github.com/tomquist/b2500-meter/pull/280))
-- **Breaking:** removed the legacy blocking powermeter API and the `_async` method suffix. All powermeter methods are now async-only: `get_powermeter_watts_async()` → `get_powermeter_watts()`, `wait_for_message_async()` → `wait_for_message()`. The former sync `get_powermeter_watts()` / `wait_for_message()` methods and the `asyncio.to_thread` wrappers have been removed. Downstream consumers should `await` the renamed methods and remove any `_async` suffixes from their calls
 - Added support for emulating a *CT002/CT003*, which is recommended to steer multiple devices
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))
 - Added SMA Energy Meter / Sunny Home Manager support via Speedwire multicast protocol with auto-detection and per-phase power readings ([#231](https://github.com/tomquist/b2500-meter/pull/252))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 - Added multi-phase support for MQTT powermeter: multiple topics (`TOPICS`) or multiple JSON paths (`JSON_PATHS`) from a single topic ([#208](https://github.com/tomquist/b2500-meter/issues/208), [#280](https://github.com/tomquist/b2500-meter/pull/280))
-- Completed asyncio migration: removed the legacy blocking powermeter API and `_async` suffix, making the async interface the sole API
+- **Breaking:** removed the legacy blocking powermeter API and the `_async` method suffix. All powermeter methods are now async-only: `get_powermeter_watts_async()` → `get_powermeter_watts()`, `wait_for_message_async()` → `wait_for_message()`. The former sync `get_powermeter_watts()` / `wait_for_message()` methods and the `asyncio.to_thread` wrappers have been removed. Downstream consumers should `await` the renamed methods and remove any `_async` suffixes from their calls
 - Added support for emulating a *CT002/CT003*, which is recommended to steer multiple devices
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))
 - Added SMA Energy Meter / Sunny Home Manager support via Speedwire multicast protocol with auto-detection and per-phase power readings ([#231](https://github.com/tomquist/b2500-meter/pull/252))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 - Added multi-phase support for MQTT powermeter: multiple topics (`TOPICS`) or multiple JSON paths (`JSON_PATHS`) from a single topic ([#208](https://github.com/tomquist/b2500-meter/issues/208), [#280](https://github.com/tomquist/b2500-meter/pull/280))
-- Migrated powermeters to native asyncio, replacing blocking `requests`/threading with `aiohttp` and async lifecycle management for improved concurrency
+- Completed asyncio migration: removed the legacy blocking powermeter API and `_async` suffix, making the async interface the sole API
 - Added support for emulating a *CT002/CT003*, which is recommended to steer multiple devices
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))
 - Added SMA Energy Meter / Sunny Home Manager support via Speedwire multicast protocol with auto-detection and per-phase power readings ([#231](https://github.com/tomquist/b2500-meter/pull/252))

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -38,8 +38,8 @@ async def test_powermeter(powermeter: Powermeter, client_filter: ClientFilter):
             logger.debug(
                 f"Testing powermeter configuration... (attempt {attempt + 1}/{max_retries + 1})"
             )
-            await powermeter.wait_for_message_async(timeout=30)
-            value = await powermeter.get_powermeter_watts_async()
+            await powermeter.wait_for_message(timeout=30)
+            value = await powermeter.get_powermeter_watts()
             value_with_units = " | ".join([f"{v}W" for v in value])
             powermeter_name = powermeter.__class__.__name__
             filter_description = ", ".join([str(n) for n in client_filter.netmasks])
@@ -172,7 +172,7 @@ async def run_device(
             if powermeter is None:
                 logger.debug(f"No powermeter found for client {addr[0]}")
                 return None
-            values = await powermeter.get_powermeter_watts_async()
+            values = await powermeter.get_powermeter_watts()
             value1 = values[0] if len(values) > 0 else 0
             value2 = values[1] if len(values) > 1 else 0
             value3 = values[2] if len(values) > 2 else 0

--- a/src/b2500_meter/powermeter/amisreader.py
+++ b/src/b2500_meter/powermeter/amisreader.py
@@ -25,6 +25,6 @@ class AmisReader(Powermeter):
         async with self.session.get(url) as resp:
             return await resp.json(content_type=None)
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         response = await self.get_json("/rest")
         return [int(response["saldo"])]

--- a/src/b2500_meter/powermeter/amisreader_test.py
+++ b/src/b2500_meter/powermeter/amisreader_test.py
@@ -8,5 +8,5 @@ async def test_amisreader_get_powermeter_watts(mock_aiohttp_session):
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         amisreader = AmisReader("192.168.1.10")
         await amisreader.start()
-        assert await amisreader.get_powermeter_watts_async() == [1200]
+        assert await amisreader.get_powermeter_watts() == [1200]
         await amisreader.stop()

--- a/src/b2500_meter/powermeter/base.py
+++ b/src/b2500_meter/powermeter/base.py
@@ -1,27 +1,10 @@
-import asyncio
-
-
 # Powermeter classes
 class Powermeter:
-    # --- Sync interface (kept for non-migrated powermeter subclasses) ---
-
-    def get_powermeter_watts(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         raise NotImplementedError()
 
-    def wait_for_message(self, timeout=5):
+    async def wait_for_message(self, timeout=5):
         pass
-
-    # --- Async interface (used by the main application) ---
-    # Default implementations wrap the sync methods via asyncio.to_thread().
-    # Subclasses migrated to native async override these directly.
-    # Once all subclasses are converted, the sync methods and the _async
-    # suffix will be removed.
-
-    async def get_powermeter_watts_async(self) -> list[float]:
-        return await asyncio.to_thread(self.get_powermeter_watts)
-
-    async def wait_for_message_async(self, timeout=5):
-        return await asyncio.to_thread(self.wait_for_message, timeout)
 
     # --- Lifecycle (no-op by default, override for push-based powermeters) ---
 

--- a/src/b2500_meter/powermeter/emlog.py
+++ b/src/b2500_meter/powermeter/emlog.py
@@ -27,7 +27,7 @@ class Emlog(Powermeter):
         async with self.session.get(url) as resp:
             return await resp.json(content_type=None)
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         response = await self.get_json(
             f"/pages/getinformation.php?heute&meterindex={self.meterindex}"
         )

--- a/src/b2500_meter/powermeter/emlog_test.py
+++ b/src/b2500_meter/powermeter/emlog_test.py
@@ -8,7 +8,7 @@ async def test_get_powermeter_watts_no_calculate(mock_aiohttp_session):
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         emlog = Emlog("127.0.0.1", "1", json_power_calculate=False)
         await emlog.start()
-        assert await emlog.get_powermeter_watts_async() == [200]
+        assert await emlog.get_powermeter_watts() == [200]
         await emlog.stop()
 
 
@@ -17,5 +17,5 @@ async def test_get_powermeter_watts_with_calculate(mock_aiohttp_session):
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         emlog = Emlog("127.0.0.1", "1", json_power_calculate=True)
         await emlog.start()
-        assert await emlog.get_powermeter_watts_async() == [250]
+        assert await emlog.get_powermeter_watts() == [250]
         await emlog.stop()

--- a/src/b2500_meter/powermeter/esphome.py
+++ b/src/b2500_meter/powermeter/esphome.py
@@ -28,6 +28,6 @@ class ESPHome(Powermeter):
         async with self.session.get(url) as resp:
             return await resp.json(content_type=None)
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         parsed_data = await self.get_json(f"/{self.domain}/{self.id}")
         return [int(parsed_data["value"])]

--- a/src/b2500_meter/powermeter/esphome_test.py
+++ b/src/b2500_meter/powermeter/esphome_test.py
@@ -8,5 +8,5 @@ async def test_esphome_get_powermeter_watts(mock_aiohttp_session):
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         esphome = ESPHome("192.168.1.4", "80", "sensor", "power")
         await esphome.start()
-        assert await esphome.get_powermeter_watts_async() == [234]
+        assert await esphome.get_powermeter_watts() == [234]
         await esphome.stop()

--- a/src/b2500_meter/powermeter/homeassistant.py
+++ b/src/b2500_meter/powermeter/homeassistant.py
@@ -214,7 +214,7 @@ class HomeAssistant(Powermeter):
             raise ValueError(f"Home Assistant sensor {entity_id} has no state")
         return val
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         if not self.power_calculate:
             return [
                 self._get_entity_value(entity) for entity in self.current_power_entity
@@ -234,7 +234,7 @@ class HomeAssistant(Powermeter):
                 results.append(power_in - power_out)
             return results
 
-    async def wait_for_message_async(self, timeout: float = 5) -> None:
+    async def wait_for_message(self, timeout: float = 5) -> None:
         try:
             await asyncio.wait_for(self._entities_ready.wait(), timeout=timeout)
         except asyncio.TimeoutError:

--- a/src/b2500_meter/powermeter/homeassistant_test.py
+++ b/src/b2500_meter/powermeter/homeassistant_test.py
@@ -95,7 +95,7 @@ async def test_initial_snapshot_populates_value():
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "1000"}]
     )
-    assert await pm.get_powermeter_watts_async() == [1000.0]
+    assert await pm.get_powermeter_watts() == [1000.0]
 
 
 async def test_no_initial_event_leaves_values_missing():
@@ -105,7 +105,7 @@ async def test_no_initial_event_leaves_values_missing():
     await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
 
     with pytest.raises(ValueError):
-        await pm.get_powermeter_watts_async()
+        await pm.get_powermeter_watts()
 
 
 async def test_initial_snapshot_only_updates_tracked_entities():
@@ -117,7 +117,7 @@ async def test_initial_snapshot_only_updates_tracked_entities():
             {"entity_id": "sensor.temperature", "state": "22"},
         ],
     )
-    assert await pm.get_powermeter_watts_async() == [500.0]
+    assert await pm.get_powermeter_watts() == [500.0]
 
 
 # Trigger event tests
@@ -128,7 +128,7 @@ async def test_trigger_event_updates_value():
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "100"}]
     )
-    assert await pm.get_powermeter_watts_async() == [100.0]
+    assert await pm.get_powermeter_watts() == [100.0]
 
     ws = AsyncMock()
     await pm._handle_message(
@@ -147,7 +147,7 @@ async def test_trigger_event_updates_value():
             }
         ),
     )
-    assert await pm.get_powermeter_watts_async() == [200.0]
+    assert await pm.get_powermeter_watts() == [200.0]
 
 
 async def test_trigger_event_ignores_untracked_entity():
@@ -173,7 +173,7 @@ async def test_trigger_event_ignores_untracked_entity():
             }
         ),
     )
-    assert await pm.get_powermeter_watts_async() == [100.0]
+    assert await pm.get_powermeter_watts() == [100.0]
 
 
 # Error condition tests
@@ -182,7 +182,7 @@ async def test_trigger_event_ignores_untracked_entity():
 async def test_sensor_has_no_state():
     pm = _create_powermeter()
     with pytest.raises(ValueError) as exc_info:
-        await pm.get_powermeter_watts_async()
+        await pm.get_powermeter_watts()
 
     assert (
         str(exc_info.value) == "Home Assistant sensor sensor.current_power has no state"
@@ -196,7 +196,7 @@ async def test_sensor_state_none():
     )
 
     with pytest.raises(ValueError) as exc_info:
-        await pm.get_powermeter_watts_async()
+        await pm.get_powermeter_watts()
 
     assert (
         str(exc_info.value) == "Home Assistant sensor sensor.current_power has no state"
@@ -211,7 +211,7 @@ async def test_sensor_state_not_numeric():
     )
 
     with pytest.raises(ValueError) as exc_info:
-        await pm.get_powermeter_watts_async()
+        await pm.get_powermeter_watts()
 
     assert (
         str(exc_info.value) == "Home Assistant sensor sensor.current_power has no state"
@@ -224,7 +224,7 @@ async def test_malformed_json_message():
     await pm._handle_message(ws, "not valid json")
     # Should not raise; value stays absent
     with pytest.raises(ValueError):
-        await pm.get_powermeter_watts_async()
+        await pm.get_powermeter_watts()
 
 
 # Three-phase tests
@@ -246,7 +246,7 @@ async def test_three_phase_direct():
             {"entity_id": "sensor.power_phase3", "state": "300"},
         ],
     )
-    assert await pm.get_powermeter_watts_async() == [100.0, 200.0, 300.0]
+    assert await pm.get_powermeter_watts() == [100.0, 200.0, 300.0]
 
 
 # Power calculate tests
@@ -266,7 +266,7 @@ async def test_power_calculate_mode():
             {"entity_id": "sensor.power_output", "state": "200"},
         ],
     )
-    assert await pm.get_powermeter_watts_async() == [800.0]
+    assert await pm.get_powermeter_watts() == [800.0]
 
 
 async def test_three_phase_calculated():
@@ -295,7 +295,7 @@ async def test_three_phase_calculated():
             {"entity_id": "sensor.power_out_3", "state": "400"},
         ],
     )
-    assert await pm.get_powermeter_watts_async() == [800.0, 1700.0, 2600.0]
+    assert await pm.get_powermeter_watts() == [800.0, 1700.0, 2600.0]
 
 
 async def test_power_alias_length_mismatch():
@@ -315,7 +315,7 @@ async def test_power_alias_length_mismatch():
     )
 
     with pytest.raises(ValueError) as exc_info:
-        await pm.get_powermeter_watts_async()
+        await pm.get_powermeter_watts()
 
     assert (
         str(exc_info.value)
@@ -350,13 +350,13 @@ async def test_wait_for_message_returns_when_data_available():
         pm, [{"entity_id": "sensor.current_power", "state": "100"}]
     )
     # Should return immediately, not raise
-    await pm.wait_for_message_async(timeout=1)
+    await pm.wait_for_message(timeout=1)
 
 
 async def test_wait_for_message_timeout():
     pm = _create_powermeter()
     with pytest.raises(TimeoutError):
-        await pm.wait_for_message_async(timeout=0)
+        await pm.wait_for_message(timeout=0)
 
 
 # subscribe_entities entity list test

--- a/src/b2500_meter/powermeter/homewizard.py
+++ b/src/b2500_meter/powermeter/homewizard.py
@@ -137,12 +137,12 @@ class HomeWizardPowermeter(Powermeter):
         self.values = values
         self._message_event.set()
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         if self.values is not None:
             return list(self.values)
         raise ValueError("No value received from HomeWizard")
 
-    async def wait_for_message_async(self, timeout: float = 5) -> None:
+    async def wait_for_message(self, timeout: float = 5) -> None:
         try:
             await asyncio.wait_for(self._message_event.wait(), timeout=timeout)
         except asyncio.TimeoutError:

--- a/src/b2500_meter/powermeter/homewizard_test.py
+++ b/src/b2500_meter/powermeter/homewizard_test.py
@@ -136,7 +136,7 @@ async def test_measurement_message_stores_values():
         ws,
         json.dumps({"type": "measurement", "data": {"power_w": 500}}),
     )
-    assert await pm.get_powermeter_watts_async() == [500]
+    assert await pm.get_powermeter_watts() == [500]
 
 
 # --- Category C: SSL context ---
@@ -156,36 +156,36 @@ def test_ssl_context_verify_disabled():
     assert ctx.check_hostname is False
 
 
-# --- Category D: get_powermeter_watts_async ---
+# --- Category D: get_powermeter_watts ---
 
 
 async def test_get_watts_no_data_raises():
     pm = _create_powermeter()
     with pytest.raises(ValueError):
-        await pm.get_powermeter_watts_async()
+        await pm.get_powermeter_watts()
 
 
 async def test_get_watts_returns_copy():
     pm = _create_powermeter()
     pm._handle_measurement({"power_w": 100})
-    result = await pm.get_powermeter_watts_async()
+    result = await pm.get_powermeter_watts()
     result.append(999)
-    assert await pm.get_powermeter_watts_async() == [100]
+    assert await pm.get_powermeter_watts() == [100]
 
 
-# --- Category E: wait_for_message_async ---
+# --- Category E: wait_for_message ---
 
 
 async def test_wait_for_message_returns_when_data_available():
     pm = _create_powermeter()
     pm._handle_measurement({"power_w": 100})
-    await pm.wait_for_message_async(timeout=1)
+    await pm.wait_for_message(timeout=1)
 
 
 async def test_wait_for_message_timeout():
     pm = _create_powermeter()
     with pytest.raises(TimeoutError):
-        await pm.wait_for_message_async(timeout=0)
+        await pm.wait_for_message(timeout=0)
 
 
 # --- Category F: Lifecycle ---
@@ -272,7 +272,7 @@ async def test_full_auth_subscribe_measurement_flow():
 
     ws.send_json.assert_any_call({"type": "authorization", "data": "ABCD1234"})
     ws.send_json.assert_any_call({"type": "subscribe", "data": "measurement"})
-    assert await pm.get_powermeter_watts_async() == [500]
+    assert await pm.get_powermeter_watts() == [500]
 
 
 async def test_close_message_exits_iteration():

--- a/src/b2500_meter/powermeter/iobroker.py
+++ b/src/b2500_meter/powermeter/iobroker.py
@@ -38,7 +38,7 @@ class IoBroker(Powermeter):
         async with self.session.get(url) as resp:
             return await resp.json(content_type=None)
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         if not self.power_calculate:
             response = await self.get_json(f"/getBulk/{self.current_power_alias}")
             for item in response:

--- a/src/b2500_meter/powermeter/iobroker_test.py
+++ b/src/b2500_meter/powermeter/iobroker_test.py
@@ -15,7 +15,7 @@ async def test_get_powermeter_watts_no_calculate(mock_aiohttp_session):
             power_output_alias="output_alias",
         )
         await iobroker.start()
-        assert await iobroker.get_powermeter_watts_async() == [100]
+        assert await iobroker.get_powermeter_watts() == [100]
         await iobroker.stop()
 
 
@@ -36,5 +36,5 @@ async def test_get_powermeter_watts_with_calculate(mock_aiohttp_session):
             power_output_alias="output_alias",
         )
         await iobroker.start()
-        assert await iobroker.get_powermeter_watts_async() == [150]
+        assert await iobroker.get_powermeter_watts() == [150]
         await iobroker.stop()

--- a/src/b2500_meter/powermeter/json_http.py
+++ b/src/b2500_meter/powermeter/json_http.py
@@ -63,7 +63,7 @@ class JsonHttpPowermeter(Powermeter):
             logger.error(f"HTTP request error: {e}")
             raise ValueError(f"HTTP request error: {e}") from e
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         data = await self.get_json()
         values = []
         for path in self.json_paths:

--- a/src/b2500_meter/powermeter/json_http_test.py
+++ b/src/b2500_meter/powermeter/json_http_test.py
@@ -10,7 +10,7 @@ async def test_single_phase(mock_aiohttp_session):
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         meter = JsonHttpPowermeter("http://localhost", "$.power")
         await meter.start()
-        assert await meter.get_powermeter_watts_async() == [100.0]
+        assert await meter.get_powermeter_watts() == [100.0]
         await meter.stop()
 
 
@@ -19,7 +19,7 @@ async def test_three_phase(mock_aiohttp_session):
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         meter = JsonHttpPowermeter("http://localhost", ["$.p1", "$.p2", "$.p3"])
         await meter.start()
-        assert await meter.get_powermeter_watts_async() == [100.0, 200.0, 300.0]
+        assert await meter.get_powermeter_watts() == [100.0, 200.0, 300.0]
         await meter.stop()
 
 
@@ -39,7 +39,7 @@ async def test_headers_and_auth(mock_aiohttp_session):
             headers={"X-Test": "1"},
             timeout=ClientTimeout(total=10),
         )
-        result = await meter.get_powermeter_watts_async()
+        result = await meter.get_powermeter_watts()
         assert result == [50.0]
         mock_aiohttp_session.get.assert_called_once_with("http://localhost")
         await meter.stop()

--- a/src/b2500_meter/powermeter/modbus.py
+++ b/src/b2500_meter/powermeter/modbus.py
@@ -72,7 +72,7 @@ class ModbusPowermeter(Powermeter):
             self.client.close()
             self.client = None
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         if not self.client:
             raise RuntimeError("Client not started; call start() first")
         read = getattr(self.client, self._read_method)

--- a/src/b2500_meter/powermeter/modbus_test.py
+++ b/src/b2500_meter/powermeter/modbus_test.py
@@ -29,7 +29,7 @@ async def test_get_powermeter_watts():
 
         pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
         await pm.start()
-        assert await pm.get_powermeter_watts_async() == [500.0]
+        assert await pm.get_powermeter_watts() == [500.0]
         MockClient.assert_called_with("192.168.1.14", port=502)
         mock_client.read_holding_registers.assert_called_once_with(0, 1, slave=1)
         await pm.stop()
@@ -57,7 +57,7 @@ async def test_float32():
             word_order="BIG",
         )
         await pm.start()
-        assert await pm.get_powermeter_watts_async() == [10.0]
+        assert await pm.get_powermeter_watts() == [10.0]
         mock_client.read_holding_registers.assert_called_once_with(0, 2, slave=1)
         await pm.stop()
 
@@ -75,7 +75,7 @@ async def test_input_registers():
 
         pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1, register_type="INPUT")
         await pm.start()
-        assert await pm.get_powermeter_watts_async() == [500.0]
+        assert await pm.get_powermeter_watts() == [500.0]
         mock_client.read_input_registers.assert_called_once_with(0, 1, slave=1)
         await pm.stop()
 
@@ -95,7 +95,7 @@ async def test_start_creates_client_and_connects():
 async def test_read_before_start_raises():
     pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
     with pytest.raises(RuntimeError, match="Client not started"):
-        await pm.get_powermeter_watts_async()
+        await pm.get_powermeter_watts()
 
 
 # ---------------------------------------------------------------------------
@@ -141,7 +141,7 @@ async def test_read_error_raises():
         pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
         await pm.start()
         with pytest.raises(Exception, match="Error reading Modbus data"):
-            await pm.get_powermeter_watts_async()
+            await pm.get_powermeter_watts()
         await pm.stop()
 
 
@@ -188,7 +188,7 @@ async def test_e2e_uint16_holding(modbus_server: int):
     pm = ModbusPowermeter("127.0.0.1", modbus_server, 1, 0, 1)
     await pm.start()
     try:
-        result = await pm.get_powermeter_watts_async()
+        result = await pm.get_powermeter_watts()
         assert result == [500.0]
     finally:
         await pm.stop()
@@ -207,7 +207,7 @@ async def test_e2e_float32(modbus_server: int):
     )
     await pm.start()
     try:
-        result = await pm.get_powermeter_watts_async()
+        result = await pm.get_powermeter_watts()
         assert result == [10.0]
     finally:
         await pm.stop()
@@ -224,7 +224,7 @@ async def test_e2e_input_registers(modbus_server: int):
     )
     await pm.start()
     try:
-        result = await pm.get_powermeter_watts_async()
+        result = await pm.get_powermeter_watts()
         assert result == [750.0]
     finally:
         await pm.stop()

--- a/src/b2500_meter/powermeter/mqtt.py
+++ b/src/b2500_meter/powermeter/mqtt.py
@@ -142,12 +142,12 @@ class MqttPowermeter(Powermeter):
                 await self._run_task
             self._run_task = None
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         if all(v is not None for v in self.values):
             return list(self.values)  # type: ignore[arg-type]
         raise ValueError("No value received from MQTT")
 
-    async def wait_for_message_async(self, timeout=5):
+    async def wait_for_message(self, timeout=5):
         if all(v is not None for v in self.values):
             return
         loop = asyncio.get_running_loop()

--- a/src/b2500_meter/powermeter/mqtt_test.py
+++ b/src/b2500_meter/powermeter/mqtt_test.py
@@ -67,31 +67,31 @@ def _make_pm(
     )
 
 
-async def test_get_powermeter_watts_async_returns_value():
+async def test_get_powermeter_watts_returns_value():
     pm = _make_pm()
     pm.value = 42.0
-    assert await pm.get_powermeter_watts_async() == [42.0]
+    assert await pm.get_powermeter_watts() == [42.0]
 
 
-async def test_get_powermeter_watts_async_raises_when_no_value():
+async def test_get_powermeter_watts_raises_when_no_value():
     pm = _make_pm()
     with pytest.raises(ValueError, match="No value received"):
-        await pm.get_powermeter_watts_async()
+        await pm.get_powermeter_watts()
 
 
-async def test_wait_for_message_async_returns_immediately():
+async def test_wait_for_message_returns_immediately():
     pm = _make_pm()
     pm.value = 1.0
-    await pm.wait_for_message_async(timeout=0.1)
+    await pm.wait_for_message(timeout=0.1)
 
 
-async def test_wait_for_message_async_times_out():
+async def test_wait_for_message_times_out():
     pm = _make_pm()
     with pytest.raises(TimeoutError, match="Timeout waiting"):
-        await pm.wait_for_message_async(timeout=0.1)
+        await pm.wait_for_message(timeout=0.1)
 
 
-async def test_wait_for_message_async_wakes_on_event():
+async def test_wait_for_message_wakes_on_event():
     pm = _make_pm()
 
     async def _set_later():
@@ -100,7 +100,7 @@ async def test_wait_for_message_async_wakes_on_event():
         pm._message_event.set()
 
     task = asyncio.create_task(_set_later())
-    await pm.wait_for_message_async(timeout=2)
+    await pm.wait_for_message(timeout=2)
     await task
     assert pm.value == 99.0
 
@@ -174,7 +174,7 @@ async def test_get_watts_raises_when_partial_values():
     pm = _make_pm(topic=["t1", "t2"])
     pm.values[0] = 100.0
     with pytest.raises(ValueError, match="No value received"):
-        await pm.get_powermeter_watts_async()
+        await pm.get_powermeter_watts()
 
 
 async def test_get_watts_returns_all_phases():
@@ -182,7 +182,7 @@ async def test_get_watts_returns_all_phases():
     pm.values[0] = 100.0
     pm.values[1] = 200.0
     pm.values[2] = 300.0
-    assert await pm.get_powermeter_watts_async() == [100.0, 200.0, 300.0]
+    assert await pm.get_powermeter_watts() == [100.0, 200.0, 300.0]
 
 
 async def test_wait_for_message_returns_when_all_set():
@@ -197,9 +197,9 @@ async def test_wait_for_message_returns_when_all_set():
         pm._message_event.set()
 
     task = asyncio.create_task(_set_later())
-    await pm.wait_for_message_async(timeout=2)
+    await pm.wait_for_message(timeout=2)
     await task
-    assert await pm.get_powermeter_watts_async() == [10.0, 20.0]
+    assert await pm.get_powermeter_watts() == [10.0, 20.0]
 
 
 async def test_wait_for_message_times_out_with_partial():
@@ -207,7 +207,7 @@ async def test_wait_for_message_times_out_with_partial():
     pm.values[0] = 10.0
     # values[1] is still None
     with pytest.raises(TimeoutError, match="Timeout waiting"):
-        await pm.wait_for_message_async(timeout=0.2)
+        await pm.wait_for_message(timeout=0.2)
 
 
 async def test_value_property_backward_compat():
@@ -282,8 +282,8 @@ async def test_receives_plain_value(mqtt_broker):
         await asyncio.wait_for(pm._connected_event.wait(), timeout=5)
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as pub:
             await pub.publish(topic, payload=b"42.5")
-        await pm.wait_for_message_async(timeout=5)
-        assert await pm.get_powermeter_watts_async() == [42.5]
+        await pm.wait_for_message(timeout=5)
+        assert await pm.get_powermeter_watts() == [42.5]
     finally:
         await pm.stop()
 
@@ -300,8 +300,8 @@ async def test_receives_json_value(mqtt_broker):
         await asyncio.wait_for(pm._connected_event.wait(), timeout=5)
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as pub:
             await pub.publish(topic, payload=json.dumps({"power": 123.4}).encode())
-        await pm.wait_for_message_async(timeout=5)
-        assert await pm.get_powermeter_watts_async() == [123.4]
+        await pm.wait_for_message(timeout=5)
+        assert await pm.get_powermeter_watts() == [123.4]
     finally:
         await pm.stop()
 
@@ -315,7 +315,7 @@ async def test_wait_for_message_timeout_with_no_publish(mqtt_broker):
     try:
         await asyncio.wait_for(pm._connected_event.wait(), timeout=5)
         with pytest.raises(TimeoutError):
-            await pm.wait_for_message_async(timeout=0.5)
+            await pm.wait_for_message(timeout=0.5)
     finally:
         await pm.stop()
 
@@ -335,7 +335,7 @@ async def test_receives_multiple_messages_returns_latest(mqtt_broker):
                 await pub.publish(topic, payload=str(val).encode())
         # Give the listener time to process all messages
         await asyncio.sleep(0.5)
-        assert await pm.get_powermeter_watts_async() == [30.0]
+        assert await pm.get_powermeter_watts() == [30.0]
     finally:
         await pm.stop()
 
@@ -354,8 +354,8 @@ async def test_receives_multi_topic_values(mqtt_broker):
             await pub.publish(topics[0], payload=b"100.0")
             await pub.publish(topics[1], payload=b"200.0")
             await pub.publish(topics[2], payload=b"300.0")
-        await pm.wait_for_message_async(timeout=5)
-        assert await pm.get_powermeter_watts_async() == [100.0, 200.0, 300.0]
+        await pm.wait_for_message(timeout=5)
+        assert await pm.get_powermeter_watts() == [100.0, 200.0, 300.0]
     finally:
         await pm.stop()
 
@@ -380,7 +380,7 @@ async def test_receives_single_topic_multi_json_paths(mqtt_broker):
         }
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as pub:
             await pub.publish(topic, payload=json.dumps(payload).encode())
-        await pm.wait_for_message_async(timeout=5)
-        assert await pm.get_powermeter_watts_async() == [110.5, 220.3, 330.1]
+        await pm.wait_for_message(timeout=5)
+        assert await pm.get_powermeter_watts() == [110.5, 220.3, 330.1]
     finally:
         await pm.stop()

--- a/src/b2500_meter/powermeter/script.py
+++ b/src/b2500_meter/powermeter/script.py
@@ -7,7 +7,7 @@ class Script(Powermeter):
     def __init__(self, command: str):
         self.script = command
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         proc = await asyncio.create_subprocess_shell(
             self.script,
             stdout=asyncio.subprocess.PIPE,

--- a/src/b2500_meter/powermeter/script_test.py
+++ b/src/b2500_meter/powermeter/script_test.py
@@ -3,9 +3,9 @@ from .script import Script
 
 async def test_script_get_powermeter_watts_integer():
     script = Script('echo "456"')
-    assert await script.get_powermeter_watts_async() == [456]
+    assert await script.get_powermeter_watts() == [456]
 
 
 async def test_script_get_powermeter_watts_float():
     script = Script('echo "456.7"')
-    assert await script.get_powermeter_watts_async() == [456.7]
+    assert await script.get_powermeter_watts() == [456.7]

--- a/src/b2500_meter/powermeter/shelly.py
+++ b/src/b2500_meter/powermeter/shelly.py
@@ -44,12 +44,12 @@ class Shelly(Powermeter):
             resp.raise_for_status()
             return await resp.json(content_type=None)
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         raise NotImplementedError()
 
 
 class Shelly1PM(Shelly):
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         if self.emeterindex:
             meter = await self._get_json(f"/meter/{self.emeterindex}")
             return [int(meter["power"])]
@@ -59,13 +59,13 @@ class Shelly1PM(Shelly):
 
 
 class ShellyPlus1PM(Shelly):
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         response = await self._get_rpc_json("/Switch.GetStatus?id=0")
         return [int(response["apower"])]
 
 
 class ShellyEM(Shelly):
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         if self.emeterindex:
             emeter = await self._get_json(f"/emeter/{self.emeterindex}")
             return [int(emeter["power"])]
@@ -75,12 +75,12 @@ class ShellyEM(Shelly):
 
 
 class Shelly3EM(Shelly):
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         status = await self._get_json("/status")
         return [int(emeter["power"]) for emeter in status["emeters"]]
 
 
 class Shelly3EMPro(Shelly):
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         response = await self._get_rpc_json("/EM.GetStatus?id=0")
         return [int(response["total_act_power"])]

--- a/src/b2500_meter/powermeter/shelly_test.py
+++ b/src/b2500_meter/powermeter/shelly_test.py
@@ -28,7 +28,7 @@ async def test_shelly1pm_get_powermeter_watts() -> None:
     shelly = Shelly1PM("192.168.1.2", "user", "pass", "")
     shelly._session = _mock_session({"meters": [{"power": 456}]})
 
-    assert await shelly.get_powermeter_watts_async() == [456]
+    assert await shelly.get_powermeter_watts() == [456]
 
 
 async def test_shellyem_get_powermeter_watts() -> None:
@@ -37,14 +37,14 @@ async def test_shellyem_get_powermeter_watts() -> None:
         {"emeters": [{"power": 789}, {"power": 1011}, {"power": 1213}]}
     )
 
-    assert await shelly.get_powermeter_watts_async() == [789, 1011, 1213]
+    assert await shelly.get_powermeter_watts() == [789, 1011, 1213]
 
 
 async def test_shellyplus1pm_get_powermeter_watts() -> None:
     shelly = ShellyPlus1PM("192.168.1.11", "user", "pass", "")
     shelly._rpc_session = _mock_session({"apower": 150})
 
-    assert await shelly.get_powermeter_watts_async() == [150]
+    assert await shelly.get_powermeter_watts() == [150]
 
 
 async def test_shelly3em_get_powermeter_watts() -> None:
@@ -53,25 +53,25 @@ async def test_shelly3em_get_powermeter_watts() -> None:
         {"emeters": [{"power": 100}, {"power": 200}, {"power": 300}]}
     )
 
-    assert await shelly.get_powermeter_watts_async() == [100, 200, 300]
+    assert await shelly.get_powermeter_watts() == [100, 200, 300]
 
 
 async def test_shelly1pm_get_powermeter_watts_indexed() -> None:
     shelly = Shelly1PM("192.168.1.2", "user", "pass", "0")
     shelly._session = _mock_session({"power": 789})
 
-    assert await shelly.get_powermeter_watts_async() == [789]
+    assert await shelly.get_powermeter_watts() == [789]
 
 
 async def test_shellyem_get_powermeter_watts_indexed() -> None:
     shelly = ShellyEM("192.168.1.3", "user", "pass", "1")
     shelly._session = _mock_session({"power": 555})
 
-    assert await shelly.get_powermeter_watts_async() == [555]
+    assert await shelly.get_powermeter_watts() == [555]
 
 
 async def test_shelly3empro_get_powermeter_watts() -> None:
     shelly = Shelly3EMPro("192.168.1.13", "user", "pass", "")
     shelly._rpc_session = _mock_session({"total_act_power": 450})
 
-    assert await shelly.get_powermeter_watts_async() == [450]
+    assert await shelly.get_powermeter_watts() == [450]

--- a/src/b2500_meter/powermeter/shrdzm.py
+++ b/src/b2500_meter/powermeter/shrdzm.py
@@ -31,4 +31,4 @@ class Shrdzm(Powermeter):
         response = await self.get_json(
             f"/getLastData?user={self.user}&password={self.password}"
         )
-        return [int(int(response["1.7.0"]) - int(response["2.7.0"]))]
+        return [int(response["1.7.0"]) - int(response["2.7.0"])]

--- a/src/b2500_meter/powermeter/shrdzm.py
+++ b/src/b2500_meter/powermeter/shrdzm.py
@@ -27,7 +27,7 @@ class Shrdzm(Powermeter):
         async with self.session.get(url) as resp:
             return await resp.json(content_type=None)
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         response = await self.get_json(
             f"/getLastData?user={self.user}&password={self.password}"
         )

--- a/src/b2500_meter/powermeter/shrdzm_test.py
+++ b/src/b2500_meter/powermeter/shrdzm_test.py
@@ -8,5 +8,5 @@ async def test_shrdzm_get_powermeter_watts(mock_aiohttp_session):
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         shrdzm = Shrdzm("192.168.1.5", "user", "pass")
         await shrdzm.start()
-        assert await shrdzm.get_powermeter_watts_async() == [3000]
+        assert await shrdzm.get_powermeter_watts() == [3000]
         await shrdzm.stop()

--- a/src/b2500_meter/powermeter/sma_energy_meter.py
+++ b/src/b2500_meter/powermeter/sma_energy_meter.py
@@ -226,14 +226,14 @@ class SmaEnergyMeter(Powermeter):
         if self._async_message_event is not None:
             self._async_message_event.set()
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         if self.values is not None:
             return list(self.values)
         raise ValueError("No value received from SMA Energy Meter")
 
-    async def wait_for_message_async(self, timeout=5):
+    async def wait_for_message(self, timeout=5):
         if self._async_message_event is None:
-            raise RuntimeError("start() must be called before wait_for_message_async()")
+            raise RuntimeError("start() must be called before wait_for_message()")
         try:
             await asyncio.wait_for(self._async_message_event.wait(), timeout)
         except asyncio.TimeoutError:

--- a/src/b2500_meter/powermeter/sma_energy_meter_test.py
+++ b/src/b2500_meter/powermeter/sma_energy_meter_test.py
@@ -285,12 +285,12 @@ class TestGetPowermeterWattsAsync:
     async def test_no_data_raises(self):
         meter = _create_meter()
         with pytest.raises(ValueError):
-            await meter.get_powermeter_watts_async()
+            await meter.get_powermeter_watts()
 
     async def test_returns_copy(self):
         meter = _create_meter()
         meter.values = [100.0, 200.0, 300.0]
-        result = await meter.get_powermeter_watts_async()
+        result = await meter.get_powermeter_watts()
         result[0] = 999
         assert meter.values[0] == 100.0
 
@@ -300,7 +300,7 @@ class TestWaitForMessageAsync:
         meter = _create_meter()
         meter._async_message_event = asyncio.Event()
         with pytest.raises(TimeoutError):
-            await meter.wait_for_message_async(timeout=0)
+            await meter.wait_for_message(timeout=0)
 
     async def test_returns_when_data_available(self):
         meter = _create_meter()
@@ -312,14 +312,14 @@ class TestWaitForMessageAsync:
             ]
         )
         meter._handle_packet(packet)
-        await meter.wait_for_message_async(timeout=1)
-        result = await meter.get_powermeter_watts_async()
+        await meter.wait_for_message(timeout=1)
+        result = await meter.get_powermeter_watts()
         assert result == [100.0]
 
     async def test_not_started_raises(self):
         meter = _create_meter()
         with pytest.raises(RuntimeError):
-            await meter.wait_for_message_async(timeout=0)
+            await meter.wait_for_message(timeout=0)
 
 
 class TestLifecycle:

--- a/src/b2500_meter/powermeter/sml.py
+++ b/src/b2500_meter/powermeter/sml.py
@@ -118,7 +118,7 @@ class Sml(Powermeter):
             self._reader = None
             self._writer = None
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         if self._lock.locked():
             return [float(x) for x in self._current.powers]
         async with self._lock:

--- a/src/b2500_meter/powermeter/sml_test.py
+++ b/src/b2500_meter/powermeter/sml_test.py
@@ -139,7 +139,7 @@ async def test_async_read_returns_updated_powers():
         sml._current = EnergyStats(powers=[500])
 
     with patch.object(sml, "_read_serial", side_effect=fake_read):
-        result = await sml.get_powermeter_watts_async()
+        result = await sml.get_powermeter_watts()
     assert result == [500.0]
 
 
@@ -157,7 +157,7 @@ async def test_async_skip_if_busy_returns_cached():
         # Hold the lock externally to simulate a read in progress
         await sml._lock.acquire()
         try:
-            result = await sml.get_powermeter_watts_async()
+            result = await sml.get_powermeter_watts()
         finally:
             sml._lock.release()
 
@@ -179,7 +179,7 @@ async def test_async_lock_released_on_exception():
         patch.object(sml, "_read_serial", side_effect=failing_read),
         pytest.raises(OSError, match="serial port error"),
     ):
-        await sml.get_powermeter_watts_async()
+        await sml.get_powermeter_watts()
 
     # Lock should be released; current should be unchanged
     assert not sml._lock.locked()
@@ -187,7 +187,7 @@ async def test_async_lock_released_on_exception():
 
     # Subsequent call should succeed
     with patch.object(sml, "_read_serial", side_effect=successful_read):
-        result = await sml.get_powermeter_watts_async()
+        result = await sml.get_powermeter_watts()
     assert result == [42.0]
 
 
@@ -195,7 +195,7 @@ async def test_async_cold_start_skip_returns_zero():
     sml = Sml("/dev/ttyUSB0")
     await sml._lock.acquire()
     try:
-        result = await sml.get_powermeter_watts_async()
+        result = await sml.get_powermeter_watts()
     finally:
         sml._lock.release()
     assert result == [0.0]
@@ -217,7 +217,7 @@ async def test_async_concurrent_callers():
     with patch.object(sml, "_read_serial", side_effect=slow_read):
         # Launch 3 concurrent callers
         async def caller():
-            return await sml.get_powermeter_watts_async()
+            return await sml.get_powermeter_watts()
 
         task1 = asyncio.create_task(caller())
         # Wait for the first caller to acquire the lock and start reading
@@ -349,7 +349,7 @@ async def test_e2e_pty_serial_read():
     sml = Sml(slave_name)
     try:
         await sml.start()
-        result = await sml.get_powermeter_watts_async()
+        result = await sml.get_powermeter_watts()
         # 3-phase preferred over aggregate when all three present
         assert result == [400.0, 500.0, 334.0]
     finally:

--- a/src/b2500_meter/powermeter/tasmota.py
+++ b/src/b2500_meter/powermeter/tasmota.py
@@ -48,7 +48,7 @@ class Tasmota(Powermeter):
             resp.raise_for_status()
             return await resp.json(content_type=None)
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         if not self.user:
             response = await self.get_json("/cm?cmnd=status%2010")
         else:

--- a/src/b2500_meter/powermeter/tasmota_test.py
+++ b/src/b2500_meter/powermeter/tasmota_test.py
@@ -18,7 +18,7 @@ async def test_tasmota_get_powermeter_watts(mock_aiohttp_session):
             False,
         )
         await tasmota.start()
-        assert await tasmota.get_powermeter_watts_async() == [123]
+        assert await tasmota.get_powermeter_watts() == [123]
         mock_aiohttp_session.get.assert_called_with(
             "http://192.168.1.1/cm?user=user&password=pass&cmnd=status+10"
         )
@@ -40,7 +40,7 @@ async def test_tasmota_unauthenticated(mock_aiohttp_session):
             False,
         )
         await tasmota.start()
-        assert await tasmota.get_powermeter_watts_async() == [123]
+        assert await tasmota.get_powermeter_watts() == [123]
         mock_aiohttp_session.get.assert_called_with(
             "http://192.168.1.1/cm?cmnd=status%2010"
         )

--- a/src/b2500_meter/powermeter/throttling.py
+++ b/src/b2500_meter/powermeter/throttling.py
@@ -1,5 +1,4 @@
 import asyncio
-import threading
 import time
 
 from b2500_meter.config.logger import logger
@@ -22,72 +21,15 @@ class ThrottledPowermeter(Powermeter):
         self.wrapped_powermeter = wrapped_powermeter
         self.throttle_interval = throttle_interval
 
-        # Sync path state (protected by self.lock).
-        self.last_update_time = 0.0
-        self._sync_last_values: list[float] | None = None
-        self.lock = threading.Lock()
-
-        # Async path state (single-threaded in the event loop).
         # Coalescing fetch pattern: when a fetch is in flight (including the
         # throttle sleep), concurrent callers await the same future so every
         # consumer gets fresh data without hammering the source.
-        self._async_last_update_time = 0.0
-        self._async_last_values: list[float] | None = None
+        self._last_update_time = 0.0
+        self._last_values: list[float] | None = None
         self._pending_fetch: asyncio.Future[list[float]] | None = None
 
-    # --- Sync path (unchanged, for non-migrated callers / tests) ---
-
-    def wait_for_message(self, timeout=5):
-        return self.wrapped_powermeter.wait_for_message(timeout)
-
-    def get_powermeter_watts(self) -> list[float]:
-        with self.lock:
-            current_time = time.time()
-
-            if self.throttle_interval <= 0:
-                values = self.wrapped_powermeter.get_powermeter_watts()
-                self._sync_last_values = values
-                self.last_update_time = current_time
-                return values
-
-            time_since_last_update = current_time - self.last_update_time
-
-            if time_since_last_update < self.throttle_interval:
-                wait_time = self.throttle_interval - time_since_last_update
-                logger.debug(
-                    "Throttling: Waiting %.1fs before fetching fresh values...",
-                    wait_time,
-                )
-                time.sleep(wait_time)
-                current_time = time.time()
-
-            try:
-                values = self.wrapped_powermeter.get_powermeter_watts()
-                self._sync_last_values = values
-                prev_update_time = self.last_update_time
-                self.last_update_time = current_time
-                total_interval = current_time - prev_update_time
-                logger.debug(
-                    "Throttling: Fetched fresh values after %.1fs interval: %s",
-                    total_interval,
-                    values,
-                )
-                return values
-            except Exception as e:
-                if self._sync_last_values is not None:
-                    logger.warning("Throttling: Error getting fresh values: %s", e)
-                    logger.debug(
-                        "Throttling: Using cached values due to error: %s",
-                        self._sync_last_values,
-                    )
-                    return self._sync_last_values
-                logger.error("Throttling: Error getting fresh values: %s", e)
-                raise
-
-    # --- Async path (used by the main application) ---
-
-    async def wait_for_message_async(self, timeout=5):
-        return await self.wrapped_powermeter.wait_for_message_async(timeout)
+    async def wait_for_message(self, timeout=5):
+        return await self.wrapped_powermeter.wait_for_message(timeout)
 
     async def start(self):
         await self.wrapped_powermeter.start()
@@ -95,9 +37,9 @@ class ThrottledPowermeter(Powermeter):
     async def stop(self):
         await self.wrapped_powermeter.stop()
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         if self.throttle_interval <= 0:
-            return await self.wrapped_powermeter.get_powermeter_watts_async()
+            return await self.wrapped_powermeter.get_powermeter_watts()
 
         # If a fetch (including its throttle sleep) is already in progress,
         # coalesce: wait for the same result so every consumer gets fresh
@@ -110,7 +52,7 @@ class ThrottledPowermeter(Powermeter):
         self._pending_fetch = asyncio.get_running_loop().create_future()
         try:
             now = time.time()
-            remaining = self.throttle_interval - (now - self._async_last_update_time)
+            remaining = self.throttle_interval - (now - self._last_update_time)
             if remaining > 0:
                 logger.debug(
                     "Throttling: Waiting %.1fs before fetching fresh values...",
@@ -118,25 +60,25 @@ class ThrottledPowermeter(Powermeter):
                 )
                 await asyncio.sleep(remaining)
 
-            values = await self.wrapped_powermeter.get_powermeter_watts_async()
-            self._async_last_values = values
-            self._async_last_update_time = time.time()
+            values = await self.wrapped_powermeter.get_powermeter_watts()
+            self._last_values = values
+            self._last_update_time = time.time()
             logger.debug("Throttling: Fetched fresh values: %s", values)
             self._pending_fetch.set_result(values)
             return list(values)
         except BaseException as e:
             # Update timestamp even on failure so we respect the throttle
             # interval before retrying — avoids hammering a failing source.
-            self._async_last_update_time = time.time()
-            if self._async_last_values is not None and not isinstance(
+            self._last_update_time = time.time()
+            if self._last_values is not None and not isinstance(
                 e, (KeyboardInterrupt, SystemExit)
             ):
                 logger.warning("Throttling: Error getting fresh values: %s", e)
                 logger.debug(
                     "Throttling: Using cached values due to error: %s",
-                    self._async_last_values,
+                    self._last_values,
                 )
-                cached = list(self._async_last_values)
+                cached = list(self._last_values)
                 if not self._pending_fetch.done():
                     self._pending_fetch.set_result(cached)
                 return cached

--- a/src/b2500_meter/powermeter/throttling.py
+++ b/src/b2500_meter/powermeter/throttling.py
@@ -24,7 +24,7 @@ class ThrottledPowermeter(Powermeter):
         # Coalescing fetch pattern: when a fetch is in flight (including the
         # throttle sleep), concurrent callers await the same future so every
         # consumer gets fresh data without hammering the source.
-        self._last_update_time = 0.0
+        self._last_update_time = time.monotonic()
         self._last_values: list[float] | None = None
         self._pending_fetch: asyncio.Future[list[float]] | None = None
 
@@ -51,7 +51,7 @@ class ThrottledPowermeter(Powermeter):
         # fetch will coalesce behind our future.
         self._pending_fetch = asyncio.get_running_loop().create_future()
         try:
-            now = time.time()
+            now = time.monotonic()
             remaining = self.throttle_interval - (now - self._last_update_time)
             if remaining > 0:
                 logger.debug(
@@ -62,17 +62,19 @@ class ThrottledPowermeter(Powermeter):
 
             values = await self.wrapped_powermeter.get_powermeter_watts()
             self._last_values = values
-            self._last_update_time = time.time()
+            self._last_update_time = time.monotonic()
             logger.debug("Throttling: Fetched fresh values: %s", values)
             self._pending_fetch.set_result(values)
             return list(values)
-        except BaseException as e:
+        except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
+            if not self._pending_fetch.done():
+                self._pending_fetch.cancel()
+            raise
+        except Exception as e:
             # Update timestamp even on failure so we respect the throttle
             # interval before retrying — avoids hammering a failing source.
-            self._last_update_time = time.time()
-            if self._last_values is not None and not isinstance(
-                e, (KeyboardInterrupt, SystemExit)
-            ):
+            self._last_update_time = time.monotonic()
+            if self._last_values is not None:
                 logger.warning("Throttling: Error getting fresh values: %s", e)
                 logger.debug(
                     "Throttling: Using cached values due to error: %s",

--- a/src/b2500_meter/powermeter/throttling.py
+++ b/src/b2500_meter/powermeter/throttling.py
@@ -24,7 +24,7 @@ class ThrottledPowermeter(Powermeter):
         # Coalescing fetch pattern: when a fetch is in flight (including the
         # throttle sleep), concurrent callers await the same future so every
         # consumer gets fresh data without hammering the source.
-        self._last_update_time = time.monotonic()
+        self._last_update_time: float | None = None
         self._last_values: list[float] | None = None
         self._pending_fetch: asyncio.Future[list[float]] | None = None
 
@@ -51,8 +51,11 @@ class ThrottledPowermeter(Powermeter):
         # fetch will coalesce behind our future.
         self._pending_fetch = asyncio.get_running_loop().create_future()
         try:
-            now = time.monotonic()
-            remaining = self.throttle_interval - (now - self._last_update_time)
+            if self._last_update_time is not None:
+                now = time.monotonic()
+                remaining = self.throttle_interval - (now - self._last_update_time)
+            else:
+                remaining = 0.0
             if remaining > 0:
                 logger.debug(
                     "Throttling: Waiting %.1fs before fetching fresh values...",

--- a/src/b2500_meter/powermeter/throttling_test.py
+++ b/src/b2500_meter/powermeter/throttling_test.py
@@ -26,14 +26,14 @@ async def test_throttling_waits_for_interval():
     mock_pm.get_powermeter_watts = AsyncMock(return_value=[100.0, 200.0, 300.0])
     throttled = ThrottledPowermeter(mock_pm, throttle_interval=0.2)
 
-    loop = asyncio.get_running_loop()
-    start_time = loop.time()
     result1 = await throttled.get_powermeter_watts()
     assert result1 == [100.0, 200.0, 300.0]
     assert mock_pm.get_powermeter_watts.call_count == 1
 
     mock_pm.get_powermeter_watts.return_value = [400.0, 500.0, 600.0]
 
+    loop = asyncio.get_running_loop()
+    start_time = loop.time()
     result2 = await throttled.get_powermeter_watts()
     elapsed = loop.time() - start_time
 

--- a/src/b2500_meter/powermeter/throttling_test.py
+++ b/src/b2500_meter/powermeter/throttling_test.py
@@ -1,5 +1,4 @@
-import time
-import unittest
+import asyncio
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -7,134 +6,97 @@ import pytest
 from .throttling import ThrottledPowermeter
 
 
-class TestThrottledPowermeter(unittest.TestCase):
-    def setUp(self):
-        self.mock_powermeter = Mock()
-        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+async def test_no_throttling_always_fetches_fresh_values():
+    """Test that when throttling is disabled, fresh values are always fetched."""
+    mock_pm = Mock()
+    mock_pm.get_powermeter_watts = AsyncMock(return_value=[100.0, 200.0, 300.0])
+    throttled = ThrottledPowermeter(mock_pm, throttle_interval=0)
 
-    def test_no_throttling_always_fetches_fresh_values(self):
-        """Test that when throttling is disabled, fresh values are always fetched."""
-        throttled = ThrottledPowermeter(self.mock_powermeter, throttle_interval=0)
+    result1 = await throttled.get_powermeter_watts()
+    result2 = await throttled.get_powermeter_watts()
 
-        # Multiple calls should all fetch fresh values
-        result1 = throttled.get_powermeter_watts()
-        result2 = throttled.get_powermeter_watts()
-
-        self.assertEqual(result1, [100.0, 200.0, 300.0])
-        self.assertEqual(result2, [100.0, 200.0, 300.0])
-        self.assertEqual(self.mock_powermeter.get_powermeter_watts.call_count, 2)
-
-    def test_throttling_waits_for_interval(self):
-        """Test that throttling waits for remaining time before fetching new values."""
-        throttled = ThrottledPowermeter(self.mock_powermeter, throttle_interval=0.2)
-
-        # First call should fetch fresh values
-        start_time = time.time()
-        result1 = throttled.get_powermeter_watts()
-        self.assertEqual(result1, [100.0, 200.0, 300.0])
-        self.assertEqual(self.mock_powermeter.get_powermeter_watts.call_count, 1)
-
-        # Change the mock return value for next call
-        self.mock_powermeter.get_powermeter_watts.return_value = [400.0, 500.0, 600.0]
-
-        # Second call immediately should wait and then fetch new values
-        result2 = throttled.get_powermeter_watts()
-        elapsed_time = time.time() - start_time
-
-        # Should have fetched new values after waiting
-        self.assertEqual(result2, [400.0, 500.0, 600.0])
-        self.assertEqual(self.mock_powermeter.get_powermeter_watts.call_count, 2)
-        # Should have waited approximately the throttle interval
-        self.assertGreaterEqual(elapsed_time, 0.2)
-
-    def test_throttling_fetches_fresh_after_interval(self):
-        """Test that fresh values are fetched after throttling interval passes."""
-        throttled = ThrottledPowermeter(self.mock_powermeter, throttle_interval=0.1)
-
-        # First call
-        result1 = throttled.get_powermeter_watts()
-        self.assertEqual(result1, [100.0, 200.0, 300.0])
-        self.assertEqual(self.mock_powermeter.get_powermeter_watts.call_count, 1)
-
-        # Change the mock return value
-        self.mock_powermeter.get_powermeter_watts.return_value = [400.0, 500.0, 600.0]
-
-        # Wait for throttling interval to pass
-        time.sleep(0.2)
-
-        # Should fetch fresh values now
-        result2 = throttled.get_powermeter_watts()
-        self.assertEqual(result2, [400.0, 500.0, 600.0])
-        self.assertEqual(self.mock_powermeter.get_powermeter_watts.call_count, 2)
-
-    def test_wait_for_message_passthrough(self):
-        """Test that wait_for_message is passed through to wrapped powermeter."""
-        throttled = ThrottledPowermeter(self.mock_powermeter, throttle_interval=1.0)
-
-        throttled.wait_for_message(timeout=30)
-        # Check that the call was made with the timeout parameter
-        self.mock_powermeter.wait_for_message.assert_called_once()
-        call_args = self.mock_powermeter.wait_for_message.call_args
-        # The timeout is passed as a keyword argument
-        if call_args[1]:  # Check if there are keyword arguments
-            self.assertEqual(call_args[1]["timeout"], 30)
-        else:  # If passed as positional argument
-            self.assertEqual(call_args[0][0], 30)
-
-    def test_exception_handling(self):
-        """Test that exceptions are handled gracefully with cached fallback."""
-        throttled = ThrottledPowermeter(self.mock_powermeter, throttle_interval=0.1)
-
-        # First successful call to populate cache
-        result1 = throttled.get_powermeter_watts()
-        self.assertEqual(result1, [100.0, 200.0, 300.0])
-
-        # Make the mock raise an exception on next call
-        self.mock_powermeter.get_powermeter_watts.side_effect = Exception(
-            "Network error"
-        )
-
-        # Next call should wait for interval, then fail and return cached values
-        result2 = throttled.get_powermeter_watts()
-        self.assertEqual(result2, [100.0, 200.0, 300.0])
+    assert result1 == [100.0, 200.0, 300.0]
+    assert result2 == [100.0, 200.0, 300.0]
+    assert mock_pm.get_powermeter_watts.call_count == 2
 
 
-async def test_async_exception_handling_with_cache():
-    """Test that async path returns cached values on error, matching sync behavior."""
+async def test_throttling_waits_for_interval():
+    """Test that throttling waits for remaining time before fetching new values."""
+    mock_pm = Mock()
+    mock_pm.get_powermeter_watts = AsyncMock(return_value=[100.0, 200.0, 300.0])
+    throttled = ThrottledPowermeter(mock_pm, throttle_interval=0.2)
+
+    loop = asyncio.get_running_loop()
+    start_time = loop.time()
+    result1 = await throttled.get_powermeter_watts()
+    assert result1 == [100.0, 200.0, 300.0]
+    assert mock_pm.get_powermeter_watts.call_count == 1
+
+    mock_pm.get_powermeter_watts.return_value = [400.0, 500.0, 600.0]
+
+    result2 = await throttled.get_powermeter_watts()
+    elapsed = loop.time() - start_time
+
+    assert result2 == [400.0, 500.0, 600.0]
+    assert mock_pm.get_powermeter_watts.call_count == 2
+    assert elapsed >= 0.2
+
+
+async def test_throttling_fetches_fresh_after_interval():
+    """Test that fresh values are fetched after throttling interval passes."""
+    mock_pm = Mock()
+    mock_pm.get_powermeter_watts = AsyncMock(return_value=[100.0, 200.0, 300.0])
+    throttled = ThrottledPowermeter(mock_pm, throttle_interval=0.1)
+
+    result1 = await throttled.get_powermeter_watts()
+    assert result1 == [100.0, 200.0, 300.0]
+    assert mock_pm.get_powermeter_watts.call_count == 1
+
+    mock_pm.get_powermeter_watts.return_value = [400.0, 500.0, 600.0]
+
+    await asyncio.sleep(0.2)
+
+    result2 = await throttled.get_powermeter_watts()
+    assert result2 == [400.0, 500.0, 600.0]
+    assert mock_pm.get_powermeter_watts.call_count == 2
+
+
+async def test_wait_for_message_passthrough():
+    """Test that wait_for_message is passed through to wrapped powermeter."""
+    mock_pm = Mock()
+    mock_pm.wait_for_message = AsyncMock()
+    throttled = ThrottledPowermeter(mock_pm, throttle_interval=1.0)
+
+    await throttled.wait_for_message(timeout=30)
+    mock_pm.wait_for_message.assert_called_once_with(30)
+
+
+async def test_exception_handling_with_cache():
+    """Test that cached values are returned on error after a successful fetch."""
     mock_pm = Mock()
     mock_pm.start = AsyncMock()
     mock_pm.stop = AsyncMock()
-    mock_pm.get_powermeter_watts_async = AsyncMock(return_value=[100.0, 200.0])
+    mock_pm.get_powermeter_watts = AsyncMock(return_value=[100.0, 200.0])
 
     throttled = ThrottledPowermeter(mock_pm, throttle_interval=0.1)
 
-    # First successful call to populate cache
-    result1 = await throttled.get_powermeter_watts_async()
+    result1 = await throttled.get_powermeter_watts()
     assert result1 == [100.0, 200.0]
 
-    # Make the mock raise on next call
-    mock_pm.get_powermeter_watts_async.side_effect = Exception("Network error")
+    mock_pm.get_powermeter_watts.side_effect = Exception("Network error")
 
-    # Should return cached values instead of raising
-    result2 = await throttled.get_powermeter_watts_async()
+    result2 = await throttled.get_powermeter_watts()
     assert result2 == [100.0, 200.0]
 
 
-async def test_async_exception_raises_without_cache():
-    """Test that async path raises if no cached values exist."""
+async def test_exception_raises_without_cache():
+    """Test that exceptions propagate if no cached values exist."""
     mock_pm = Mock()
     mock_pm.start = AsyncMock()
     mock_pm.stop = AsyncMock()
-    mock_pm.get_powermeter_watts_async = AsyncMock(
-        side_effect=Exception("Network error")
-    )
+    mock_pm.get_powermeter_watts = AsyncMock(side_effect=Exception("Network error"))
 
     throttled = ThrottledPowermeter(mock_pm, throttle_interval=0.1)
 
-    # No cached values -- should raise
     with pytest.raises(Exception, match="Network error"):
-        await throttled.get_powermeter_watts_async()
-
-
-if __name__ == "__main__":
-    unittest.main()
+        await throttled.get_powermeter_watts()

--- a/src/b2500_meter/powermeter/tq_em.py
+++ b/src/b2500_meter/powermeter/tq_em.py
@@ -57,7 +57,7 @@ class TQEnergyManager(Powermeter):
     # ------------------------------------------------------------------ #
     # PUBLIC                                                             #
     # ------------------------------------------------------------------ #
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         if not self._sess:
             raise RuntimeError("Session not started; call start() first")
         async with self._auth_lock:

--- a/src/b2500_meter/powermeter/tq_em_test.py
+++ b/src/b2500_meter/powermeter/tq_em_test.py
@@ -44,7 +44,7 @@ async def test_three_phase():
     with patch("aiohttp.ClientSession", return_value=session):
         meter = TQEnergyManager("192.168.0.10")
         await meter.start()
-        assert await meter.get_powermeter_watts_async() == [1.0, 2.0, 3.0]
+        assert await meter.get_powermeter_watts() == [1.0, 2.0, 3.0]
         await meter.stop()
 
 
@@ -59,7 +59,7 @@ async def test_total_only():
     with patch("aiohttp.ClientSession", return_value=session):
         meter = TQEnergyManager("192.168.0.12")
         await meter.start()
-        assert await meter.get_powermeter_watts_async() == [9.0]
+        assert await meter.get_powermeter_watts() == [9.0]
         await meter.stop()
 
 
@@ -79,7 +79,7 @@ async def test_relogin_on_expired_session():
     with patch("aiohttp.ClientSession", return_value=session):
         meter = TQEnergyManager("192.168.0.11")
         await meter.start()
-        assert await meter.get_powermeter_watts_async() == [5.0]
+        assert await meter.get_powermeter_watts() == [5.0]
         await meter.stop()
 
 
@@ -94,7 +94,7 @@ async def test_missing_export():
     with patch("aiohttp.ClientSession", return_value=session):
         meter = TQEnergyManager("192.168.0.15")
         await meter.start()
-        assert await meter.get_powermeter_watts_async() == [4.0]
+        assert await meter.get_powermeter_watts() == [4.0]
         await meter.stop()
 
 
@@ -113,5 +113,5 @@ async def test_three_phase_missing_export():
     with patch("aiohttp.ClientSession", return_value=session):
         meter = TQEnergyManager("192.168.0.16")
         await meter.start()
-        assert await meter.get_powermeter_watts_async() == [1.0, 2.0, 3.0]
+        assert await meter.get_powermeter_watts() == [1.0, 2.0, 3.0]
         await meter.stop()

--- a/src/b2500_meter/powermeter/transform.py
+++ b/src/b2500_meter/powermeter/transform.py
@@ -31,11 +31,8 @@ class TransformedPowermeter(Powermeter):
         self._offsets_mismatch_warned = False
         self._multipliers_mismatch_warned = False
 
-    def wait_for_message(self, timeout=5):
-        return self.wrapped_powermeter.wait_for_message(timeout)
-
-    async def wait_for_message_async(self, timeout=5):
-        return await self.wrapped_powermeter.wait_for_message_async(timeout)
+    async def wait_for_message(self, timeout=5):
+        return await self.wrapped_powermeter.wait_for_message(timeout)
 
     async def start(self):
         await self.wrapped_powermeter.start()
@@ -74,10 +71,6 @@ class TransformedPowermeter(Powermeter):
 
         return result
 
-    def get_powermeter_watts(self) -> list[float]:
-        values = self.wrapped_powermeter.get_powermeter_watts()
-        return self._apply_transform(values)
-
-    async def get_powermeter_watts_async(self) -> list[float]:
-        values = await self.wrapped_powermeter.get_powermeter_watts_async()
+    async def get_powermeter_watts(self) -> list[float]:
+        values = await self.wrapped_powermeter.get_powermeter_watts()
         return self._apply_transform(values)

--- a/src/b2500_meter/powermeter/transform_test.py
+++ b/src/b2500_meter/powermeter/transform_test.py
@@ -1,110 +1,116 @@
-import unittest
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
+
+import pytest
 
 from .transform import TransformedPowermeter
 
 
-class TestTransformedPowermeter(unittest.TestCase):
-    def setUp(self):
-        self.mock_powermeter = Mock()
-
-    def test_identity_single_phase(self):
-        self.mock_powermeter.get_powermeter_watts.return_value = [500.0]
-        t = TransformedPowermeter(self.mock_powermeter, [0.0], [1.0])
-        self.assertEqual(t.get_powermeter_watts(), [500.0])
-
-    def test_identity_three_phase(self):
-        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
-        t = TransformedPowermeter(self.mock_powermeter, [0.0], [1.0])
-        self.assertEqual(t.get_powermeter_watts(), [100.0, 200.0, 300.0])
-
-    def test_offset_only_broadcast(self):
-        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
-        t = TransformedPowermeter(self.mock_powermeter, [10.0], [1.0])
-        self.assertEqual(t.get_powermeter_watts(), [110.0, 210.0, 310.0])
-
-    def test_negative_offset(self):
-        self.mock_powermeter.get_powermeter_watts.return_value = [1050.0]
-        t = TransformedPowermeter(self.mock_powermeter, [-50.0], [1.0])
-        self.assertEqual(t.get_powermeter_watts(), [1000.0])
-
-    def test_multiplier_only_broadcast(self):
-        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
-        t = TransformedPowermeter(self.mock_powermeter, [0.0], [2.0])
-        self.assertEqual(t.get_powermeter_watts(), [200.0, 400.0, 600.0])
-
-    def test_both_offset_and_multiplier(self):
-        # 1050 * 0.95 + (-50) = 947.5
-        self.mock_powermeter.get_powermeter_watts.return_value = [1050.0]
-        t = TransformedPowermeter(self.mock_powermeter, [-50.0], [0.95])
-        result = t.get_powermeter_watts()
-        self.assertAlmostEqual(result[0], 947.5)
-
-    def test_negative_meter_values_with_multiplier(self):
-        self.mock_powermeter.get_powermeter_watts.return_value = [-100.0]
-        t = TransformedPowermeter(self.mock_powermeter, [0.0], [2.0])
-        self.assertEqual(t.get_powermeter_watts(), [-200.0])
-
-    def test_per_phase_offsets(self):
-        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
-        t = TransformedPowermeter(self.mock_powermeter, [-10.0, -20.0, -30.0], [1.0])
-        self.assertEqual(t.get_powermeter_watts(), [90.0, 180.0, 270.0])
-
-    def test_per_phase_multipliers(self):
-        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
-        t = TransformedPowermeter(self.mock_powermeter, [0.0], [1.05, 1.02, 1.03])
-        result = t.get_powermeter_watts()
-        self.assertAlmostEqual(result[0], 105.0)
-        self.assertAlmostEqual(result[1], 204.0)
-        self.assertAlmostEqual(result[2], 309.0)
-
-    def test_mixed_single_offset_per_phase_multipliers(self):
-        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
-        t = TransformedPowermeter(self.mock_powermeter, [10.0], [1.0, 2.0, 3.0])
-        self.assertEqual(t.get_powermeter_watts(), [110.0, 410.0, 910.0])
-
-    def test_phase_count_mismatch_does_not_crash(self):
-        """Per-phase count != returned value count should warn, not raise."""
-        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
-        t = TransformedPowermeter(self.mock_powermeter, [10.0, 20.0, 30.0], [1.0])
-        # Should not raise; uses cyclic indexing
-        result = t.get_powermeter_watts()
-        self.assertEqual(result, [110.0])
-
-    def test_int_values_from_powermeter(self):
-        """Many powermeters return int values; transform should handle them."""
-        self.mock_powermeter.get_powermeter_watts.return_value = [100, 200]
-        t = TransformedPowermeter(self.mock_powermeter, [0.5], [1.0])
-        self.assertEqual(t.get_powermeter_watts(), [100.5, 200.5])
-
-    def test_wait_for_message_passthrough(self):
-        t = TransformedPowermeter(self.mock_powermeter, [0.0], [1.0])
-        t.wait_for_message(timeout=30)
-        self.mock_powermeter.wait_for_message.assert_called_once()
-        call_args = self.mock_powermeter.wait_for_message.call_args
-        if call_args[1]:
-            self.assertEqual(call_args[1]["timeout"], 30)
-        else:
-            self.assertEqual(call_args[0][0], 30)
-
-    def test_empty_offsets_raises(self):
-        with self.assertRaises(ValueError, msg="offsets must be a non-empty list"):
-            TransformedPowermeter(self.mock_powermeter, [], [1.0])
-
-    def test_empty_multipliers_raises(self):
-        with self.assertRaises(ValueError, msg="multipliers must be a non-empty list"):
-            TransformedPowermeter(self.mock_powermeter, [0.0], [])
-
-    def test_wait_for_message_default_timeout(self):
-        t = TransformedPowermeter(self.mock_powermeter, [0.0], [1.0])
-        t.wait_for_message()
-        self.mock_powermeter.wait_for_message.assert_called_once()
-        call_args = self.mock_powermeter.wait_for_message.call_args
-        if call_args[1]:
-            self.assertEqual(call_args[1]["timeout"], 5)
-        else:
-            self.assertEqual(call_args[0][0], 5)
+@pytest.fixture
+def mock_powermeter():
+    pm = Mock()
+    pm.get_powermeter_watts = AsyncMock()
+    pm.wait_for_message = AsyncMock()
+    return pm
 
 
-if __name__ == "__main__":
-    unittest.main()
+async def test_identity_single_phase(mock_powermeter):
+    mock_powermeter.get_powermeter_watts.return_value = [500.0]
+    t = TransformedPowermeter(mock_powermeter, [0.0], [1.0])
+    assert await t.get_powermeter_watts() == [500.0]
+
+
+async def test_identity_three_phase(mock_powermeter):
+    mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+    t = TransformedPowermeter(mock_powermeter, [0.0], [1.0])
+    assert await t.get_powermeter_watts() == [100.0, 200.0, 300.0]
+
+
+async def test_offset_only_broadcast(mock_powermeter):
+    mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+    t = TransformedPowermeter(mock_powermeter, [10.0], [1.0])
+    assert await t.get_powermeter_watts() == [110.0, 210.0, 310.0]
+
+
+async def test_negative_offset(mock_powermeter):
+    mock_powermeter.get_powermeter_watts.return_value = [1050.0]
+    t = TransformedPowermeter(mock_powermeter, [-50.0], [1.0])
+    assert await t.get_powermeter_watts() == [1000.0]
+
+
+async def test_multiplier_only_broadcast(mock_powermeter):
+    mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+    t = TransformedPowermeter(mock_powermeter, [0.0], [2.0])
+    assert await t.get_powermeter_watts() == [200.0, 400.0, 600.0]
+
+
+async def test_both_offset_and_multiplier(mock_powermeter):
+    # 1050 * 0.95 + (-50) = 947.5
+    mock_powermeter.get_powermeter_watts.return_value = [1050.0]
+    t = TransformedPowermeter(mock_powermeter, [-50.0], [0.95])
+    result = await t.get_powermeter_watts()
+    assert result[0] == pytest.approx(947.5)
+
+
+async def test_negative_meter_values_with_multiplier(mock_powermeter):
+    mock_powermeter.get_powermeter_watts.return_value = [-100.0]
+    t = TransformedPowermeter(mock_powermeter, [0.0], [2.0])
+    assert await t.get_powermeter_watts() == [-200.0]
+
+
+async def test_per_phase_offsets(mock_powermeter):
+    mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+    t = TransformedPowermeter(mock_powermeter, [-10.0, -20.0, -30.0], [1.0])
+    assert await t.get_powermeter_watts() == [90.0, 180.0, 270.0]
+
+
+async def test_per_phase_multipliers(mock_powermeter):
+    mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+    t = TransformedPowermeter(mock_powermeter, [0.0], [1.05, 1.02, 1.03])
+    result = await t.get_powermeter_watts()
+    assert result[0] == pytest.approx(105.0)
+    assert result[1] == pytest.approx(204.0)
+    assert result[2] == pytest.approx(309.0)
+
+
+async def test_mixed_single_offset_per_phase_multipliers(mock_powermeter):
+    mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+    t = TransformedPowermeter(mock_powermeter, [10.0], [1.0, 2.0, 3.0])
+    assert await t.get_powermeter_watts() == [110.0, 410.0, 910.0]
+
+
+async def test_phase_count_mismatch_does_not_crash(mock_powermeter):
+    """Per-phase count != returned value count should warn, not raise."""
+    mock_powermeter.get_powermeter_watts.return_value = [100.0]
+    t = TransformedPowermeter(mock_powermeter, [10.0, 20.0, 30.0], [1.0])
+    # Should not raise; uses cyclic indexing
+    result = await t.get_powermeter_watts()
+    assert result == [110.0]
+
+
+async def test_int_values_from_powermeter(mock_powermeter):
+    """Many powermeters return int values; transform should handle them."""
+    mock_powermeter.get_powermeter_watts.return_value = [100, 200]
+    t = TransformedPowermeter(mock_powermeter, [0.5], [1.0])
+    assert await t.get_powermeter_watts() == [100.5, 200.5]
+
+
+async def test_wait_for_message_passthrough(mock_powermeter):
+    t = TransformedPowermeter(mock_powermeter, [0.0], [1.0])
+    await t.wait_for_message(timeout=30)
+    mock_powermeter.wait_for_message.assert_called_once_with(30)
+
+
+async def test_wait_for_message_default_timeout(mock_powermeter):
+    t = TransformedPowermeter(mock_powermeter, [0.0], [1.0])
+    await t.wait_for_message()
+    mock_powermeter.wait_for_message.assert_called_once_with(5)
+
+
+def test_empty_offsets_raises(mock_powermeter):
+    with pytest.raises(ValueError, match="offsets must be a non-empty list"):
+        TransformedPowermeter(mock_powermeter, [], [1.0])
+
+
+def test_empty_multipliers_raises(mock_powermeter):
+    with pytest.raises(ValueError, match="multipliers must be a non-empty list"):
+        TransformedPowermeter(mock_powermeter, [0.0], [])

--- a/src/b2500_meter/powermeter/vzlogger.py
+++ b/src/b2500_meter/powermeter/vzlogger.py
@@ -27,5 +27,5 @@ class VZLogger(Powermeter):
         async with self.session.get(url) as resp:
             return await resp.json(content_type=None)
 
-    async def get_powermeter_watts_async(self) -> list[float]:
+    async def get_powermeter_watts(self) -> list[float]:
         return [int((await self.get_json())["data"][0]["tuples"][0][1])]

--- a/src/b2500_meter/powermeter/vzlogger_test.py
+++ b/src/b2500_meter/powermeter/vzlogger_test.py
@@ -8,5 +8,5 @@ async def test_vzlogger_get_powermeter_watts(mock_aiohttp_session):
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         vzlogger = VZLogger("192.168.1.9", "8088", "uuid")
         await vzlogger.start()
-        assert await vzlogger.get_powermeter_watts_async() == [900]
+        assert await vzlogger.get_powermeter_watts() == [900]
         await vzlogger.stop()

--- a/src/b2500_meter/shelly/shelly.py
+++ b/src/b2500_meter/shelly/shelly.py
@@ -172,7 +172,7 @@ class Shelly:
                     logger.warning(f"No powermeter found for client {addr[0]}")
                     return
 
-                powers = await powermeter.get_powermeter_watts_async()
+                powers = await powermeter.get_powermeter_watts()
 
                 if request.get("method") == "EM.GetStatus":
                     response = self._create_em_response(request["id"], powers)

--- a/src/b2500_meter/shelly/shelly_udp_test.py
+++ b/src/b2500_meter/shelly/shelly_udp_test.py
@@ -12,7 +12,7 @@ class DummyPowermeter(Powermeter):
     def __init__(self):
         self.call_count = 0
 
-    def get_powermeter_watts(self):
+    async def get_powermeter_watts(self):
         self.call_count += 1
         return [1.0]
 


### PR DESCRIPTION
## Summary
This PR completes the asyncio migration by removing the legacy synchronous interface from the powermeter base class and all implementations. The `_async` suffix has been removed from all async methods, making them the primary interface. All tests have been converted to use pytest with async/await syntax.

## Key Changes

### Base Class (`base.py`)
- Removed sync methods `get_powermeter_watts()` and `wait_for_message()`
- Renamed `get_powermeter_watts_async()` → `get_powermeter_watts()`
- Renamed `wait_for_message_async()` → `wait_for_message()`
- Removed `asyncio.to_thread()` wrapper implementations

### Powermeter Implementations
All powermeter subclasses updated to use the new async-only interface:
- `mqtt.py`, `modbus.py`, `script.py`, `shelly.py`, `sml.py`, `tasmota.py`, `tq_em.py`
- HTTP-based meters: `json_http.py`, `emlog.py`, `esphome.py`, `iobroker.py`, `shrdzm.py`, `vzlogger.py`, `amisreader.py`
- `homeassistant.py`, `homewizard.py`, `sma_energy_meter.py`

### Wrapper Classes
- **`transform.py`**: Removed sync `get_powermeter_watts()`, kept only async version
- **`throttling.py`**: 
  - Removed sync path with threading lock
  - Removed `get_powermeter_watts()` and `wait_for_message()` sync methods
  - Simplified to async-only with coalescing fetch pattern
  - Removed `threading` import

### Test Migration
- **`transform_test.py`**: Converted from `unittest.TestCase` to pytest with `@pytest.fixture` and async test functions
- **`throttling_test.py`**: Converted to pytest async tests, removed `time.time()` in favor of `asyncio.get_running_loop().time()`
- **All other test files**: Updated method calls from `get_powermeter_watts_async()` to `get_powermeter_watts()`
- Updated assertions to use `pytest.approx()` and `pytest.raises()`

### Main Application
- Updated `main.py` to call async methods without `_async` suffix

## Implementation Details
- All async methods now use native `async`/`await` syntax throughout the codebase
- Throttling implementation simplified by removing thread-safety concerns (single-threaded event loop)
- Tests use pytest's async support with proper fixture management
- No functional changes to business logic, only interface cleanup

https://claude.ai/code/session_013z6SxSCHYxwNjRp62mo9in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Completed migration: powermeter APIs are now async-only and legacy blocking interfaces removed; method names no longer use the _async suffix (callers must await the renamed methods).
* **Documentation**
  * Changelog updated to document the breaking change and the required call-site updates.
* **Tests**
  * Test suites updated to the new async method names and async test styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->