### PR TITLE
Fix asyncio event loop usage and add test timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-cov>=5.0.0",
     "pytest-asyncio>=0.23.0",
+    "pytest-timeout>=2.0.0",
     "mypy>=1.13.0",
 ]
 sim = [
@@ -45,6 +46,7 @@ testpaths = ["tests", "src"]
 python_files = ["test_*.py", "*_test.py"]
 addopts = "-ra -q"
 asyncio_mode = "auto"
+timeout = 90
 
 [tool.ruff]
 target-version = "py310"

--- a/src/b2500_meter/simulator/battery.py
+++ b/src/b2500_meter/simulator/battery.py
@@ -218,7 +218,9 @@ class _UDPClient(asyncio.DatagramProtocol):
     """Minimal asyncio datagram protocol for a single request/response."""
 
     def __init__(self) -> None:
-        self.received: asyncio.Future[bytes] = asyncio.get_event_loop().create_future()
+        self.received: asyncio.Future[bytes] = (
+            asyncio.get_running_loop().create_future()
+        )
 
     def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
         if not self.received.done():

--- a/uv.lock
+++ b/uv.lock
@@ -200,6 +200,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 sim = [
@@ -218,6 +219,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "requests" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "smllib" },
@@ -1354,6 +1356,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR updates the asyncio event loop handling in the battery simulator and adds test timeout configuration to prevent hanging tests.

## Key Changes
- **Event loop fix**: Changed `asyncio.get_event_loop()` to `asyncio.get_running_loop()` in the `_UDPClient` class. This is the correct API to use within an async context and aligns with modern asyncio best practices.
- **Test timeout**: Added `pytest-timeout>=2.0.0` as a dev dependency and configured a 90-second timeout for all pytest runs to catch hanging or deadlocked tests.

## Implementation Details
The `_UDPClient.__init__()` method now uses `asyncio.get_running_loop()` instead of `asyncio.get_event_loop()`. The latter is deprecated for use in async contexts and can cause issues in certain scenarios. Using `get_running_loop()` ensures we're always getting the currently running event loop, which is the correct behavior when the protocol is instantiated during async execution.

The pytest timeout configuration is added to `[tool.pytest.ini_options]` with a 90-second limit, providing a safety net against tests that may hang or deadlock.

https://claude.ai/code/session_01Pr3EtjhQDKjtaViVCgCk2y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a 90-second global timeout limit for test execution. Tests will now automatically stop and fail if they run longer than this duration, effectively preventing hung tests from blocking the test suite.
  * Improved simulator event loop handling to properly align with the currently active event loop, enhancing overall stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->