### PR TITLE
Add threshold parameter to active_battery_count() calls in tests

### DIFF
--- a/tests/test_efficiency_e2e.py
+++ b/tests/test_efficiency_e2e.py
@@ -215,7 +215,7 @@ class TestEfficiencyE2E:
         try:
             # Low demand: only 1 battery active
             await h.settle(5.0)
-            assert h.active_battery_count() == 1, (
+            assert h.active_battery_count(threshold=30.0) == 1, (
                 f"Low demand: expected 1 active. Powers: {h.battery_powers()}"
             )
 
@@ -340,7 +340,7 @@ class TestEfficiencyE2E:
         try:
             # Low demand: 1 active battery.
             await h.settle(5.0)
-            assert h.active_battery_count() == 1, (
+            assert h.active_battery_count(threshold=30.0) == 1, (
                 f"Low demand: expected 1 active. Powers: {h.battery_powers()}"
             )
 


### PR DESCRIPTION
## Summary
Updated test assertions to explicitly pass a `threshold=30.0` parameter to `active_battery_count()` method calls, ensuring consistent and explicit threshold configuration in battery activation tests.

## Key Changes
- Modified `test_demand_increase_activates_second_battery()` to pass `threshold=30.0` to `active_battery_count()` assertion
- Modified `test_smooth_transition_no_overshoot()` to pass `threshold=30.0` to `active_battery_count()` assertion

## Details
These changes make the threshold value explicit in the test assertions rather than relying on default behavior. This improves test clarity and ensures the battery activation logic is tested with a well-defined threshold of 30.0 watts for determining when batteries should be considered active.

https://claude.ai/code/session_01Hbg8ZBTRaMe5SGMer3Yv51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated E2E test assertions to improve battery detection validation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->