### PR TITLE
Add MQTT Insights: publish internal state with HA Device Discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Added MQTT Insights: optional `[MQTT_INSIGHTS]` section publishes internal state (grid power, targets, saturation, consumer topology) to MQTT with Home Assistant Device Discovery and per-consumer active/pause control; auto-configured in HA add-on when Mosquitto is installed
 - Added 3-phase support for Tasmota powermeter: comma-separated `JSON_POWER_MQTT_LABEL` / input / output labels ([#136](https://github.com/tomquist/b2500-meter/issues/136))
 - Added opt-in efficiency optimization for multi-battery setups: concentrates power on fewer batteries at low demand to avoid inefficient low-power operation, with hysteresis, time-based rotation for fairness, smooth fade transitions to prevent overshoot during switchovers, and saturation-aware forced rotation when an active battery is stuck at near-zero output (`MIN_EFFICIENT_POWER`, `EFFICIENCY_ROTATION_INTERVAL`, `EFFICIENCY_FADE_ALPHA`, `EFFICIENCY_SATURATION_THRESHOLD`, `SATURATION_DECAY_FACTOR`). `EFFICIENCY_SATURATION_THRESHOLD` now defaults to 0.4 (previously 0, disabled) so full/empty batteries are swapped out automatically; batteries that produce meaningful output but lag behind a fluctuating target are no longer falsely flagged as saturated.
 - Added multi-phase support for MQTT powermeter: multiple topics (`TOPICS`) or multiple JSON paths (`JSON_PATHS`) from a single topic ([#208](https://github.com/tomquist/b2500-meter/issues/208), [#280](https://github.com/tomquist/b2500-meter/pull/280))

--- a/README.md
+++ b/README.md
@@ -719,6 +719,49 @@ CURRENT_POWER_ENTITY = sensor.current_power
 # No NETMASK specified - will match all clients (0.0.0.0/0)
 ```
 
+### MQTT Insights
+
+Publishes internal state (grid power per phase, charge targets, saturation, consumer topology) to MQTT with optional Home Assistant auto-discovery.
+
+**Home Assistant Add-on**: When running as an HA add-on with the Mosquitto broker add-on installed, MQTT Insights is auto-configured — no manual setup needed. Entities appear automatically in HA.
+
+**Manual configuration**:
+
+```ini
+[MQTT_INSIGHTS]
+BROKER = 192.168.1.100
+PORT = 1883
+USERNAME = mqtt_user
+PASSWORD = mqtt_pass
+TLS = false
+BASE_TOPIC = b2500_meter
+HA_DISCOVERY = true
+HA_DISCOVERY_PREFIX = homeassistant
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `BROKER` | `localhost` | MQTT broker hostname/IP |
+| `PORT` | `1883` | MQTT broker port |
+| `USERNAME` / `PASSWORD` | — | Credentials (optional) |
+| `TLS` | `false` | Enable TLS encryption |
+| `BASE_TOPIC` | `b2500_meter` | Root topic for all published messages |
+| `HA_DISCOVERY` | `true` | Enable Home Assistant MQTT Device Discovery |
+| `HA_DISCOVERY_PREFIX` | `homeassistant` | HA discovery topic prefix |
+
+**Published entities** (per CT002 consumer):
+- Grid power (L1/L2/L3/total), charge target (L1/L2/L3), reported power, saturation
+- Diagnostic: phase, device type, battery IP, CT type, CT MAC, last seen
+- **Active switch**: pause/resume individual consumers (targets zeroed when inactive)
+
+**Published entities** (per CT002 device):
+- Smooth target, active control status, consumer count
+
+**Published entities** (per Shelly battery):
+- Grid power (L1/L2/L3/total), active status, last seen
+
+**Topics**: `{base}/ct002/{id}/consumer/{cid}`, `{base}/ct002/{id}/status`, `{base}/shelly/{id}/battery/{ip}`, `{base}/shelly/{id}/status`, `{base}/status` (LWT)
+
 # Frequently Asked Questions (FAQ)
 
 ## General Usage and Setup

--- a/config.ini.example
+++ b/config.ini.example
@@ -290,3 +290,21 @@ THROTTLE_INTERVAL = 0
 #OBIS_POWER_L1 = 0100240700ff
 #OBIS_POWER_L2 = 0100380700ff
 #OBIS_POWER_L3 = 01004c0700ff
+
+## --- MQTT Insights (optional) ---
+## Publishes internal state (grid power, targets, saturation, consumer topology)
+## to MQTT with Home Assistant Device Discovery support.
+## When running as a Home Assistant add-on with Mosquitto, this is auto-configured.
+#[MQTT_INSIGHTS]
+#BROKER = 192.168.1.100
+#PORT = 1883
+#USERNAME = mqtt_user
+#PASSWORD = mqtt_pass
+## Enable TLS (default: false)
+#TLS = false
+## Base topic for all MQTT Insights messages (default: b2500_meter)
+#BASE_TOPIC = b2500_meter
+## Enable Home Assistant MQTT Device Discovery (default: true)
+#HA_DISCOVERY = true
+## HA discovery prefix (default: homeassistant)
+#HA_DISCOVERY_PREFIX = homeassistant

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -14,6 +14,8 @@ startup: application
 boot: auto
 auto_restart: true
 watchdog: "http://[HOST]:[PORT:52500]/health"
+services:
+  - "mqtt:want"
 homeassistant_api: true
 hassio_api: true
 hassio_role: homeassistant

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -117,6 +117,17 @@ else
             echo "POWER_CALCULATE=False"
             echo "CURRENT_POWER_ENTITY=$(bashio::config 'power_input_alias')"
         fi
+
+        if bashio::services "mqtt"; then
+            echo ""
+            echo "[MQTT_INSIGHTS]"
+            echo "BROKER=$(bashio::services 'mqtt' 'host')"
+            echo "PORT=$(bashio::services 'mqtt' 'port')"
+            echo "USERNAME=$(bashio::services 'mqtt' 'username')"
+            echo "PASSWORD=$(bashio::services 'mqtt' 'password')"
+            echo "TLS=$(bashio::services 'mqtt' 'ssl')"
+            echo "HA_DISCOVERY=True"
+        fi
     } > "$CONFIG"
 fi
 

--- a/src/b2500_meter/config/config_loader.py
+++ b/src/b2500_meter/config/config_loader.py
@@ -461,8 +461,8 @@ def read_mqtt_insights_config(
             return MqttInsightsConfig(
                 broker=config.get(section, "BROKER", fallback="localhost"),
                 port=config.getint(section, "PORT", fallback=1883),
-                username=config.get(section, "USERNAME", fallback=None),
-                password=config.get(section, "PASSWORD", fallback=None),
+                username=config.get(section, "USERNAME", fallback=None) or None,
+                password=config.get(section, "PASSWORD", fallback=None) or None,
                 tls=config.getboolean(section, "TLS", fallback=False),
                 base_topic=config.get(section, "BASE_TOPIC", fallback="b2500_meter"),
                 ha_discovery=config.getboolean(section, "HA_DISCOVERY", fallback=True),

--- a/src/b2500_meter/config/config_loader.py
+++ b/src/b2500_meter/config/config_loader.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import configparser
 from ipaddress import IPv4Address, IPv4Network
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from b2500_meter.mqtt_insights import MqttInsightsConfig
 
 from b2500_meter.config.logger import logger
-from b2500_meter.mqtt_insights import MqttInsightsConfig
 from b2500_meter.powermeter import (
     AmisReader,
     Emlog,
@@ -456,6 +461,8 @@ def read_mqtt_insights_config(
     config: configparser.ConfigParser,
 ) -> MqttInsightsConfig | None:
     """Read [MQTT_INSIGHTS] section; return None if absent."""
+    from b2500_meter.mqtt_insights import MqttInsightsConfig
+
     for section in config.sections():
         if section.startswith(MQTT_INSIGHTS_SECTION):
             return MqttInsightsConfig(

--- a/src/b2500_meter/config/config_loader.py
+++ b/src/b2500_meter/config/config_loader.py
@@ -2,6 +2,7 @@ import configparser
 from ipaddress import IPv4Address, IPv4Network
 
 from b2500_meter.config.logger import logger
+from b2500_meter.mqtt_insights import MqttInsightsConfig
 from b2500_meter.powermeter import (
     AmisReader,
     Emlog,
@@ -45,6 +46,7 @@ JSON_HTTP_SECTION = "JSON_HTTP"
 TQ_EM_SECTION = "TQ_EM"
 HOMEWIZARD_SECTION = "HOMEWIZARD"
 SMA_ENERGY_METER_SECTION = "SMA_ENERGY_METER"
+MQTT_INSIGHTS_SECTION = "MQTT_INSIGHTS"
 
 
 class ClientFilter:
@@ -175,7 +177,7 @@ def create_powermeter(
         return create_homewizard_powermeter(section, config)
     elif section.startswith(SMA_ENERGY_METER_SECTION):
         return create_sma_energy_meter_powermeter(section, config)
-    elif section.startswith("MQTT"):
+    elif section.startswith("MQTT") and not section.startswith(MQTT_INSIGHTS_SECTION):
         return create_mqtt_powermeter(section, config)
     else:
         return None
@@ -448,3 +450,24 @@ def create_sma_energy_meter_powermeter(
         config.getint(section, "SERIAL_NUMBER", fallback=0),
         config.get(section, "INTERFACE", fallback=""),
     )
+
+
+def read_mqtt_insights_config(
+    config: configparser.ConfigParser,
+) -> MqttInsightsConfig | None:
+    """Read [MQTT_INSIGHTS] section; return None if absent."""
+    for section in config.sections():
+        if section.startswith(MQTT_INSIGHTS_SECTION):
+            return MqttInsightsConfig(
+                broker=config.get(section, "BROKER", fallback="localhost"),
+                port=config.getint(section, "PORT", fallback=1883),
+                username=config.get(section, "USERNAME", fallback=None),
+                password=config.get(section, "PASSWORD", fallback=None),
+                tls=config.getboolean(section, "TLS", fallback=False),
+                base_topic=config.get(section, "BASE_TOPIC", fallback="b2500_meter"),
+                ha_discovery=config.getboolean(section, "HA_DISCOVERY", fallback=True),
+                ha_discovery_prefix=config.get(
+                    section, "HA_DISCOVERY_PREFIX", fallback="homeassistant"
+                ),
+            )
+    return None

--- a/src/b2500_meter/conftest.py
+++ b/src/b2500_meter/conftest.py
@@ -1,0 +1,60 @@
+"""Shared test fixtures — Mosquitto broker for MQTT integration tests."""
+
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+needs_mosquitto = pytest.mark.skipif(
+    shutil.which("mosquitto") is None,
+    reason="mosquitto not installed",
+)
+
+
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def mqtt_broker():
+    if shutil.which("mosquitto") is None:
+        pytest.skip("mosquitto not installed")
+    port = find_free_port()
+    tmpdir = tempfile.mkdtemp()
+    config_path = Path(tmpdir) / "mosquitto.conf"
+    config_path.write_text(
+        f"listener {port} 127.0.0.1\nallow_anonymous true\npersistence false\n"
+    )
+    proc = subprocess.Popen(
+        ["mosquitto", "-c", str(config_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    # Wait for broker to be ready
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        proc.terminate()
+        raise RuntimeError("mosquitto did not start in time")
+
+    yield port
+
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    shutil.rmtree(tmpdir, ignore_errors=True)

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -288,6 +288,7 @@ class CT002:
             if now - report.get("timestamp", 0) > self.consumer_ttl
         ]
         for key in stale:
+            # Sentinel: {"_removed": True} signals consumer removal to the event listener
             self._call_event_listener(key, {"_removed": True})
             self._reports_by_consumer.pop(key, None)
             self._values_by_consumer.pop(key, None)

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -554,22 +554,6 @@ class CT002:
         if not self.active_control or not values or len(values) != 3:
             return values
 
-        # Paused consumer: actively steer its output to zero by sending
-        # target = -reported_power on its phase (same logic as efficiency
-        # deprioritization).  The consumer is excluded from fair distribution
-        # and efficiency rotation but the smooth target is still updated so
-        # remaining active consumers see an accurate grid residual.
-        if consumer_id and consumer_id in self._inactive_consumers:
-            reports = self._reports_by_consumer
-            reported = parse_int(reports.get(consumer_id, {}).get("power", 0))
-            self._last_target_by_consumer[consumer_id] = 0
-            if reported == 0:
-                return [0, 0, 0]
-            phase = (reports.get(consumer_id, {}).get("phase") or "A").upper()
-            result = [0.0, 0.0, 0.0]
-            result[{"A": 0, "B": 1, "C": 2}.get(phase, 0)] = float(-reported)
-            return result
-
         raw_total = sum(parse_int(v, 0) for v in values)
         alpha = self.smooth_target_alpha
 
@@ -595,6 +579,22 @@ class CT002:
                     min(self.max_smooth_step, delta),
                 )
             self._smoothed_target += delta
+
+        # Paused consumer: actively steer its output to zero by sending
+        # target = -reported_power on its phase (same logic as efficiency
+        # deprioritization).  The consumer is excluded from fair distribution
+        # and efficiency rotation.  Smoothing above is still updated so
+        # remaining active consumers see an accurate grid residual.
+        if consumer_id and consumer_id in self._inactive_consumers:
+            reports = self._reports_by_consumer
+            reported = parse_int(reports.get(consumer_id, {}).get("power", 0))
+            self._last_target_by_consumer[consumer_id] = 0
+            if reported == 0:
+                return [0, 0, 0]
+            phase = (reports.get(consumer_id, {}).get("phase") or "A").upper()
+            result = [0.0, 0.0, 0.0]
+            result[{"A": 0, "B": 1, "C": 2}.get(phase, 0)] = float(-reported)
+            return result
 
         reports = {
             cid: r

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -241,6 +241,10 @@ class CT002:
     def set_consumer_active(self, consumer_id: str, active: bool) -> None:
         if active:
             self._inactive_consumers.discard(consumer_id)
+            # Clear stale control state so the resumed consumer starts fresh
+            # and isn't immediately deprioritized by old saturation scores.
+            self._saturation_by_consumer.pop(consumer_id, None)
+            self._last_target_by_consumer.pop(consumer_id, None)
         else:
             self._inactive_consumers.add(consumer_id)
 
@@ -970,11 +974,12 @@ class CT002:
         values = self._get_consumer_value(consumer_id)
         if values is None:
             values = [0, 0, 0]
-        raw_values = list(values)
-        meter_value = sum(parse_int(v, 0) for v in values)
+        raw_values = ([*list(values), 0, 0, 0])[:3]
+        meter_value = sum(parse_int(v, 0) for v in raw_values)
         is_active = self.is_consumer_active(consumer_id)
         if self.active_control and not in_inspection_mode:
             values = self._compute_smooth_target(values, consumer_id)
+        values = ([*list(values), 0, 0, 0])[:3]
 
         try:
             response_fields = self._build_response_fields(fields, values)

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -170,6 +170,7 @@ class CT002:
         efficiency_fade_alpha=0.15,
         efficiency_saturation_threshold=0.4,
         saturation_decay_factor=0.995,
+        device_id="",
     ):
         self.udp_port = udp_port
         self.ct_mac = ct_mac
@@ -204,7 +205,7 @@ class CT002:
             Callable[[tuple, list, str], Awaitable[list[float] | None]] | None
         ) = None
         self.event_listener: Callable[[str, str, dict[str, Any]], None] | None = None
-        self._device_id = ""
+        self._device_id = device_id
         self._inactive_consumers: set[str] = set()
         self._info_idx_counter = 0
         self._values_by_consumer = {}

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -551,6 +551,23 @@ class CT002:
         """
         if not self.active_control or not values or len(values) != 3:
             return values
+
+        # Paused consumer: actively steer its output to zero by sending
+        # target = -reported_power on its phase (same logic as efficiency
+        # deprioritization).  The consumer is excluded from fair distribution
+        # and efficiency rotation but the smooth target is still updated so
+        # remaining active consumers see an accurate grid residual.
+        if consumer_id and consumer_id in self._inactive_consumers:
+            reports = self._reports_by_consumer
+            reported = parse_int(reports.get(consumer_id, {}).get("power", 0))
+            self._last_target_by_consumer[consumer_id] = 0
+            if reported == 0:
+                return [0, 0, 0]
+            phase = (reports.get(consumer_id, {}).get("phase") or "A").upper()
+            result = [0.0, 0.0, 0.0]
+            result[{"A": 0, "B": 1, "C": 2}.get(phase, 0)] = float(-reported)
+            return result
+
         raw_total = sum(parse_int(v, 0) for v in values)
         alpha = self.smooth_target_alpha
 
@@ -953,12 +970,8 @@ class CT002:
             values = [0, 0, 0]
         raw_values = list(values)
         meter_value = sum(parse_int(v, 0) for v in values)
-
         is_active = self.is_consumer_active(consumer_id)
-        if not is_active:
-            # Paused consumer: zero targets, skip smooth target & efficiency
-            values = [0, 0, 0]
-        elif self.active_control and not in_inspection_mode:
+        if self.active_control and not in_inspection_mode:
             values = self._compute_smooth_target(values, consumer_id)
 
         try:

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -404,8 +404,9 @@ class CT002:
             self._efficiency_priority.append(self._efficiency_priority.pop(0))
             self._efficiency_cache_sample = None  # force recompute
 
-        # Sync priority list with current consumers (prune stale, add new at end)
-        current = set(reports)
+        # Sync priority list with current active consumers
+        # (prune stale/inactive, add new at end)
+        current = set(reports) - self._inactive_consumers
         self._efficiency_priority = [
             c for c in self._efficiency_priority if c in current
         ]
@@ -576,7 +577,11 @@ class CT002:
                 )
             self._smoothed_target += delta
 
-        reports = dict(self._reports_by_consumer)
+        reports = {
+            cid: r
+            for cid, r in self._reports_by_consumer.items()
+            if cid not in self._inactive_consumers
+        }
         last_target = self._last_target_by_consumer.get(consumer_id)
 
         if consumer_id and consumer_id in reports:
@@ -948,13 +953,13 @@ class CT002:
             values = [0, 0, 0]
         raw_values = list(values)
         meter_value = sum(parse_int(v, 0) for v in values)
-        if self.active_control and not in_inspection_mode:
-            values = self._compute_smooth_target(values, consumer_id)
 
-        # Override targets to zero when consumer is paused
         is_active = self.is_consumer_active(consumer_id)
         if not is_active:
+            # Paused consumer: zero targets, skip smooth target & efficiency
             values = [0, 0, 0]
+        elif self.active_control and not in_inspection_mode:
+            values = self._compute_smooth_target(values, consumer_id)
 
         try:
             response_fields = self._build_response_fields(fields, values)

--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -4,6 +4,8 @@ import asyncio
 import contextlib
 import time
 from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from typing import Any
 
 from b2500_meter.config.logger import logger
 
@@ -201,6 +203,9 @@ class CT002:
         self.before_send: (
             Callable[[tuple, list, str], Awaitable[list[float] | None]] | None
         ) = None
+        self.event_listener: Callable[[str, str, dict[str, Any]], None] | None = None
+        self._device_id = ""
+        self._inactive_consumers: set[str] = set()
         self._info_idx_counter = 0
         self._values_by_consumer = {}
         self._reports_by_consumer = {}
@@ -231,6 +236,23 @@ class CT002:
 
     def _get_consumer_value(self, consumer_id):
         return self._values_by_consumer.get(consumer_id)
+
+    def set_consumer_active(self, consumer_id: str, active: bool) -> None:
+        if active:
+            self._inactive_consumers.discard(consumer_id)
+        else:
+            self._inactive_consumers.add(consumer_id)
+
+    def is_consumer_active(self, consumer_id: str) -> bool:
+        return consumer_id not in self._inactive_consumers
+
+    def _call_event_listener(self, consumer_id: str, data: dict[str, Any]) -> None:
+        if not self.event_listener:
+            return
+        try:
+            self.event_listener(self._device_id, consumer_id, data)
+        except Exception as exc:
+            logger.warning("event_listener failed for %s: %s", consumer_id, exc)
 
     def _update_consumer_report(self, consumer_id, phase, power, device_type=""):
         normalized_phase = str(phase).upper() if phase else "A"
@@ -266,10 +288,12 @@ class CT002:
             if now - report.get("timestamp", 0) > self.consumer_ttl
         ]
         for key in stale:
+            self._call_event_listener(key, {"_removed": True})
             self._reports_by_consumer.pop(key, None)
             self._values_by_consumer.pop(key, None)
             self._last_target_by_consumer.pop(key, None)
             self._saturation_by_consumer.pop(key, None)
+            self._inactive_consumers.discard(key)
             self._efficiency_deprioritized.discard(key)
             self._efficiency_fade_weights.pop(key, None)
             if key in self._efficiency_priority:
@@ -922,9 +946,16 @@ class CT002:
         values = self._get_consumer_value(consumer_id)
         if values is None:
             values = [0, 0, 0]
+        raw_values = list(values)
         meter_value = sum(parse_int(v, 0) for v in values)
         if self.active_control and not in_inspection_mode:
             values = self._compute_smooth_target(values, consumer_id)
+
+        # Override targets to zero when consumer is paused
+        is_active = self.is_consumer_active(consumer_id)
+        if not is_active:
+            values = [0, 0, 0]
+
         try:
             response_fields = self._build_response_fields(fields, values)
             response = build_payload(response_fields)
@@ -949,6 +980,41 @@ class CT002:
                 self._format_status(values, phase_values, consumer_id, meter_value),
             )
         transport.sendto(response, addr)
+
+        # Fire event listener after response is sent
+        if not in_inspection_mode:
+            report = self._reports_by_consumer.get(consumer_id, {})
+            self._call_event_listener(
+                consumer_id,
+                {
+                    "grid_power": {
+                        "l1": float(raw_values[0]),
+                        "l2": float(raw_values[1]),
+                        "l3": float(raw_values[2]),
+                        "total": sum(float(v) for v in raw_values),
+                    },
+                    "target": {
+                        "l1": float(values[0]),
+                        "l2": float(values[1]),
+                        "l3": float(values[2]),
+                    },
+                    "phase": report.get("phase", reported_phase),
+                    "reported_power": reported_power,
+                    "device_type": report.get("device_type", ""),
+                    "battery_ip": addr[0],
+                    "ct_type": fields[2] if len(fields) > 2 else "",
+                    "ct_mac": fields[3] if len(fields) > 3 else "",
+                    "saturation": self._saturation_by_consumer.get(consumer_id, 0.0),
+                    "last_target": self._last_target_by_consumer.get(consumer_id),
+                    "active": is_active,
+                    "last_seen": datetime.now(timezone.utc).isoformat(),
+                    "smooth_target": self._smoothed_target
+                    if self._smoothed_target is not None
+                    else 0.0,
+                    "active_control": self.active_control,
+                    "consumer_count": len(self._reports_by_consumer),
+                },
+            )
 
     async def _cleanup_loop(self):
         try:

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -218,9 +218,6 @@ async def run_device(
                     insights.on_ct002_response(dev_id, consumer_id, data)
 
             device.event_listener = _ct002_event_listener
-            insights.register_active_handler(
-                device_id or "", device.set_consumer_active
-            )
 
     elif device_type == "shellypro3em_old":
         logger.debug("Shelly Pro 3EM Settings:")
@@ -264,6 +261,12 @@ async def run_device(
                 "Device %s (%s) cleanup also failed", device_type, device_id
             )
         return
+
+    # Register active handler only after successful start so MQTT commands
+    # are never routed to a device that failed to come up.
+    if insights and isinstance(device, CT002):
+        insights.register_active_handler(device_id or "", device.set_consumer_active)
+
     try:
         await device.wait()
     finally:

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -5,7 +5,11 @@ import os
 import signal
 from collections import OrderedDict
 
-from b2500_meter.config.config_loader import ClientFilter, read_all_powermeter_configs
+from b2500_meter.config.config_loader import (
+    ClientFilter,
+    read_all_powermeter_configs,
+    read_mqtt_insights_config,
+)
 from b2500_meter.config.logger import logger, setLogLevel
 from b2500_meter.ct002 import CT002, UDP_PORT
 from b2500_meter.health_service import HealthCheckService
@@ -14,6 +18,7 @@ from b2500_meter.marstek_api import (
     MarstekConfig,
     ensure_managed_fake_device,
 )
+from b2500_meter.mqtt_insights import MqttInsightsService
 from b2500_meter.powermeter import Powermeter
 from b2500_meter.shelly import Shelly
 from b2500_meter.version_info import get_git_commit_sha
@@ -67,6 +72,7 @@ async def run_device(
     args: argparse.Namespace,
     powermeters: list[tuple[Powermeter, ClientFilter]],
     device_id: str | None = None,
+    insights: MqttInsightsService | None = None,
 ):
     logger.debug(f"Starting device: {device_type}")
 
@@ -200,6 +206,20 @@ async def run_device(
             return [value1, value2, value3]
 
         device.before_send = update_readings
+        device._device_id = device_id or ""
+
+        if insights:
+
+            def _ct002_event_listener(dev_id, consumer_id, data):
+                if data.get("_removed"):
+                    insights.on_ct002_consumer_removed(dev_id, consumer_id)
+                else:
+                    insights.on_ct002_response(dev_id, consumer_id, data)
+
+            device.event_listener = _ct002_event_listener
+            insights.register_active_handler(
+                device_id or "", device.set_consumer_active
+            )
 
     elif device_type == "shellypro3em_old":
         logger.debug("Shelly Pro 3EM Settings:")
@@ -223,6 +243,12 @@ async def run_device(
 
     else:
         raise ValueError(f"Unsupported device type: {device_type}")
+
+    # Wire Shelly event listener
+    if insights and isinstance(device, Shelly):
+        device.event_listener = lambda dev_id, battery_ip, data: (
+            insights.on_shelly_response(dev_id, battery_ip, data)
+        )
 
     try:
         await device.start()
@@ -271,6 +297,7 @@ async def async_main(
             health = None
 
     powermeters: list[tuple[Powermeter, ClientFilter]] = []
+    insights: MqttInsightsService | None = None
 
     try:
         # Create powermeters
@@ -284,13 +311,20 @@ async def async_main(
             for powermeter, client_filter in powermeters:
                 await test_powermeter(powermeter, client_filter)
 
+        # MQTT Insights (optional)
+        insights_cfg = read_mqtt_insights_config(cfg)
+        if insights_cfg:
+            insights = MqttInsightsService(insights_cfg)
+            await insights.start()
+            logger.info("MQTT Insights service started")
+
         if not device_types:
             logger.warning("No runnable device types configured after filtering.")
             return
 
         await asyncio.gather(
             *(
-                run_device(device_type, cfg, args, powermeters, device_id)
+                run_device(device_type, cfg, args, powermeters, device_id, insights)
                 for device_type, device_id in zip(
                     device_types, device_ids, strict=False
                 )
@@ -299,6 +333,12 @@ async def async_main(
     finally:
         # Best-effort shutdown: each resource gets a stop attempt even if
         # an earlier one fails.
+        if insights:
+            try:
+                await insights.stop()
+                logger.info("MQTT Insights service stopped")
+            except Exception:
+                logger.exception("Error stopping MQTT Insights service")
         for pm, _ in powermeters:
             try:
                 await pm.stop()

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -211,6 +211,7 @@ async def run_device(
         if insights:
 
             def _ct002_event_listener(dev_id, consumer_id, data):
+                # {"_removed": True} is a sentinel from _cleanup_consumers
                 if data.get("_removed"):
                     insights.on_ct002_consumer_removed(dev_id, consumer_id)
                 else:

--- a/src/b2500_meter/main.py
+++ b/src/b2500_meter/main.py
@@ -187,6 +187,7 @@ async def run_device(
             efficiency_fade_alpha=efficiency_fade_alpha,
             efficiency_saturation_threshold=efficiency_saturation_threshold,
             saturation_decay_factor=saturation_decay_factor,
+            device_id=device_id or "",
         )
 
         async def update_readings(addr, _fields=None, _consumer_id=None):
@@ -206,7 +207,6 @@ async def run_device(
             return [value1, value2, value3]
 
         device.before_send = update_readings
-        device._device_id = device_id or ""
 
         if insights:
 

--- a/src/b2500_meter/mqtt_insights/__init__.py
+++ b/src/b2500_meter/mqtt_insights/__init__.py
@@ -1,0 +1,5 @@
+"""MQTT Insights — publish internal state to MQTT with HA Discovery."""
+
+from .service import MqttInsightsConfig, MqttInsightsService
+
+__all__ = ["MqttInsightsConfig", "MqttInsightsService"]

--- a/src/b2500_meter/mqtt_insights/discovery.py
+++ b/src/b2500_meter/mqtt_insights/discovery.py
@@ -100,8 +100,6 @@ def build_ct002_consumer_discovery(
             "value_template": tmpl,
             "entity_category": "diagnostic",
         }
-        if key == "phase":
-            comp["options"] = ["A", "B", "C"]
         components[key] = comp
 
     # Last seen (timestamp)

--- a/src/b2500_meter/mqtt_insights/discovery.py
+++ b/src/b2500_meter/mqtt_insights/discovery.py
@@ -1,0 +1,337 @@
+"""Pure functions that build HA MQTT Device Discovery payloads (HA 2024.11+)."""
+
+from __future__ import annotations
+
+import re
+
+from b2500_meter.version_info import get_git_commit_sha
+
+_SAFE_ID_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def _sanitize_id(value: str) -> str:
+    return _SAFE_ID_RE.sub("_", value)
+
+
+def _origin() -> dict:
+    sha = get_git_commit_sha()
+    return {
+        "name": "b2500-meter",
+        "sw_version": sha or "unknown",
+        "support_url": "https://github.com/tomquist/b2500-meter",
+    }
+
+
+def _system_availability(base_topic: str) -> dict:
+    return {
+        "topic": f"{base_topic}/status",
+        "payload_available": "online",
+        "payload_not_available": "offline",
+    }
+
+
+# ── CT002 consumer (per-battery) ──────────────────────────────────────────
+
+
+def build_ct002_consumer_discovery(
+    base_topic: str,
+    device_id: str,
+    consumer_id: str,
+    ha_prefix: str,
+) -> tuple[str, dict]:
+    safe_dev = _sanitize_id(device_id)
+    safe_cid = _sanitize_id(consumer_id)
+    node_id = f"b2500_meter_ct002_{safe_dev}_{safe_cid}"
+    state_topic = f"{base_topic}/ct002/{device_id}/consumer/{consumer_id}"
+    avail_topic = f"{state_topic}/availability"
+    uid_prefix = f"b2500_meter_ct002_{safe_dev}_{safe_cid}"
+
+    components: dict[str, dict] = {}
+
+    # Power sensors
+    for key, label, tmpl in [
+        ("grid_power_total", "Grid Power", "{{ value_json.grid_power.total }}"),
+        ("grid_power_l1", "Grid Power L1", "{{ value_json.grid_power.l1 }}"),
+        ("grid_power_l2", "Grid Power L2", "{{ value_json.grid_power.l2 }}"),
+        ("grid_power_l3", "Grid Power L3", "{{ value_json.grid_power.l3 }}"),
+        ("target_l1", "Target L1", "{{ value_json.target.l1 }}"),
+        ("target_l2", "Target L2", "{{ value_json.target.l2 }}"),
+        ("target_l3", "Target L3", "{{ value_json.target.l3 }}"),
+        ("reported_power", "Reported Power", "{{ value_json.reported_power }}"),
+        ("last_target", "Last Target", "{{ value_json.last_target }}"),
+    ]:
+        comp: dict = {
+            "platform": "sensor",
+            "unique_id": f"{uid_prefix}_{key}",
+            "device_class": "power",
+            "unit_of_measurement": "W",
+            "state_topic": state_topic,
+            "value_template": tmpl,
+        }
+        if key == "grid_power_total":
+            comp["name"] = None  # primary entity
+        else:
+            comp["name"] = label
+        components[key] = comp
+
+    # Saturation
+    components["saturation"] = {
+        "platform": "sensor",
+        "unique_id": f"{uid_prefix}_saturation",
+        "name": "Saturation",
+        "unit_of_measurement": "%",
+        "state_topic": state_topic,
+        "value_template": "{{ (value_json.saturation * 100) | round(1) }}",
+    }
+
+    # Diagnostic sensors
+    for key, label, tmpl in [
+        ("phase", "Phase", "{{ value_json.phase }}"),
+        ("device_type", "Device Type", "{{ value_json.device_type }}"),
+        ("battery_ip", "Battery IP", "{{ value_json.battery_ip }}"),
+        ("ct_type", "CT Type", "{{ value_json.ct_type }}"),
+        ("ct_mac", "CT MAC", "{{ value_json.ct_mac }}"),
+    ]:
+        comp = {
+            "platform": "sensor",
+            "unique_id": f"{uid_prefix}_{key}",
+            "name": label,
+            "state_topic": state_topic,
+            "value_template": tmpl,
+            "entity_category": "diagnostic",
+        }
+        if key == "phase":
+            comp["options"] = ["A", "B", "C"]
+        components[key] = comp
+
+    # Last seen (timestamp)
+    components["last_seen"] = {
+        "platform": "sensor",
+        "unique_id": f"{uid_prefix}_last_seen",
+        "name": "Last Seen",
+        "device_class": "timestamp",
+        "state_topic": state_topic,
+        "value_template": "{{ value_json.last_seen }}",
+        "entity_category": "diagnostic",
+    }
+
+    # Active switch
+    components["active"] = {
+        "platform": "switch",
+        "unique_id": f"{uid_prefix}_active",
+        "name": "Active",
+        "state_topic": state_topic,
+        "command_topic": f"{state_topic}/set",
+        "value_template": "{{ value_json.active }}",
+        "payload_on": '{"active": true}',
+        "payload_off": '{"active": false}',
+        "state_on": "True",
+        "state_off": "False",
+        "optimistic": True,
+    }
+
+    payload = {
+        "device": {
+            "identifiers": node_id,
+            "name": f"CT002 {consumer_id}",
+            "manufacturer": "b2500-meter",
+        },
+        "origin": _origin(),
+        "components": components,
+        "availability_mode": "all",
+        "availability": [
+            _system_availability(base_topic),
+            {
+                "topic": avail_topic,
+                "payload_available": "online",
+                "payload_not_available": "offline",
+            },
+        ],
+        "state_topic": state_topic,
+    }
+
+    topic = f"{ha_prefix}/device/{node_id}/config"
+    return topic, payload
+
+
+# ── CT002 device-level ────────────────────────────────────────────────────
+
+
+def build_ct002_device_discovery(
+    base_topic: str,
+    device_id: str,
+    ha_prefix: str,
+) -> tuple[str, dict]:
+    safe_dev = _sanitize_id(device_id)
+    node_id = f"b2500_meter_ct002_{safe_dev}"
+    state_topic = f"{base_topic}/ct002/{device_id}/status"
+    uid_prefix = f"b2500_meter_ct002_{safe_dev}"
+
+    components: dict[str, dict] = {
+        "smooth_target": {
+            "platform": "sensor",
+            "unique_id": f"{uid_prefix}_smooth_target",
+            "name": None,  # primary
+            "device_class": "power",
+            "unit_of_measurement": "W",
+            "state_topic": state_topic,
+            "value_template": "{{ value_json.smooth_target }}",
+        },
+        "active_control": {
+            "platform": "binary_sensor",
+            "unique_id": f"{uid_prefix}_active_control",
+            "name": "Active Control",
+            "device_class": "running",
+            "state_topic": state_topic,
+            "value_template": "{{ value_json.active_control }}",
+            "payload_on": "True",
+            "payload_off": "False",
+        },
+        "consumer_count": {
+            "platform": "sensor",
+            "unique_id": f"{uid_prefix}_consumer_count",
+            "name": "Consumer Count",
+            "state_topic": state_topic,
+            "value_template": "{{ value_json.consumer_count }}",
+            "entity_category": "diagnostic",
+        },
+    }
+
+    payload = {
+        "device": {
+            "identifiers": node_id,
+            "name": f"CT002 {device_id}",
+            "manufacturer": "b2500-meter",
+        },
+        "origin": _origin(),
+        "components": components,
+        "availability": [_system_availability(base_topic)],
+        "state_topic": state_topic,
+    }
+
+    topic = f"{ha_prefix}/device/{node_id}/config"
+    return topic, payload
+
+
+# ── Shelly per-battery ────────────────────────────────────────────────────
+
+
+def build_shelly_battery_discovery(
+    base_topic: str,
+    device_id: str,
+    battery_ip: str,
+    ha_prefix: str,
+) -> tuple[str, dict]:
+    ip_slug = _sanitize_id(battery_ip)
+    safe_dev = _sanitize_id(device_id)
+    node_id = f"b2500_meter_shelly_{safe_dev}_{ip_slug}"
+    state_topic = f"{base_topic}/shelly/{device_id}/battery/{ip_slug}"
+    avail_topic = f"{state_topic}/availability"
+    uid_prefix = f"b2500_meter_shelly_{safe_dev}_{ip_slug}"
+
+    components: dict[str, dict] = {}
+
+    for key, label, tmpl in [
+        ("grid_power_total", "Grid Power", "{{ value_json.grid_power.total }}"),
+        ("grid_power_l1", "Grid Power L1", "{{ value_json.grid_power.l1 }}"),
+        ("grid_power_l2", "Grid Power L2", "{{ value_json.grid_power.l2 }}"),
+        ("grid_power_l3", "Grid Power L3", "{{ value_json.grid_power.l3 }}"),
+    ]:
+        comp: dict = {
+            "platform": "sensor",
+            "unique_id": f"{uid_prefix}_{key}",
+            "device_class": "power",
+            "unit_of_measurement": "W",
+            "state_topic": state_topic,
+            "value_template": tmpl,
+        }
+        if key == "grid_power_total":
+            comp["name"] = None
+        else:
+            comp["name"] = label
+        components[key] = comp
+
+    components["active"] = {
+        "platform": "binary_sensor",
+        "unique_id": f"{uid_prefix}_active",
+        "name": "Active",
+        "device_class": "connectivity",
+        "state_topic": state_topic,
+        "value_template": "{{ value_json.active }}",
+        "payload_on": "True",
+        "payload_off": "False",
+        "entity_category": "diagnostic",
+    }
+
+    components["last_seen"] = {
+        "platform": "sensor",
+        "unique_id": f"{uid_prefix}_last_seen",
+        "name": "Last Seen",
+        "device_class": "timestamp",
+        "state_topic": state_topic,
+        "value_template": "{{ value_json.last_seen }}",
+        "entity_category": "diagnostic",
+    }
+
+    payload = {
+        "device": {
+            "identifiers": node_id,
+            "name": f"Shelly Battery {battery_ip}",
+            "manufacturer": "b2500-meter",
+        },
+        "origin": _origin(),
+        "components": components,
+        "availability_mode": "all",
+        "availability": [
+            _system_availability(base_topic),
+            {
+                "topic": avail_topic,
+                "payload_available": "online",
+                "payload_not_available": "offline",
+            },
+        ],
+        "state_topic": state_topic,
+    }
+
+    topic = f"{ha_prefix}/device/{node_id}/config"
+    return topic, payload
+
+
+# ── Shelly device-level ───────────────────────────────────────────────────
+
+
+def build_shelly_device_discovery(
+    base_topic: str,
+    device_id: str,
+    ha_prefix: str,
+) -> tuple[str, dict]:
+    safe_dev = _sanitize_id(device_id)
+    node_id = f"b2500_meter_shelly_{safe_dev}"
+    state_topic = f"{base_topic}/shelly/{device_id}/status"
+    uid_prefix = f"b2500_meter_shelly_{safe_dev}"
+
+    components: dict[str, dict] = {
+        "battery_count": {
+            "platform": "sensor",
+            "unique_id": f"{uid_prefix}_battery_count",
+            "name": "Battery Count",
+            "state_topic": state_topic,
+            "value_template": "{{ value_json.battery_count }}",
+            "entity_category": "diagnostic",
+        },
+    }
+
+    payload = {
+        "device": {
+            "identifiers": node_id,
+            "name": f"Shelly {device_id}",
+            "manufacturer": "b2500-meter",
+        },
+        "origin": _origin(),
+        "components": components,
+        "availability": [_system_availability(base_topic)],
+        "state_topic": state_topic,
+    }
+
+    topic = f"{ha_prefix}/device/{node_id}/config"
+    return topic, payload

--- a/src/b2500_meter/mqtt_insights/mqtt_insights_test.py
+++ b/src/b2500_meter/mqtt_insights/mqtt_insights_test.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import configparser
+import contextlib
 import json
 import re
 
@@ -217,6 +218,30 @@ def test_queue_overflow_does_not_raise():
     # No exception raised
 
 
+# ── E2E helpers ──────────────────────────────────────────────────────────
+
+
+async def _collect_messages(sub, target, *, timeout=5, stop=None):
+    """Collect messages from *sub* into *target* list.
+
+    *stop* is an optional callable(msg) → bool that ends collection early.
+    Falls back to collecting a single message when *stop* is None.
+    Compatible with Python 3.10 (no asyncio.timeout).
+    """
+
+    async def _inner():
+        async for msg in sub.messages:
+            target.append(msg)
+            if stop is not None:
+                if stop(msg):
+                    return
+            else:
+                return  # single message
+
+    with contextlib.suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(_inner(), timeout=timeout)
+
+
 # ── E2E tests with Mosquitto ─────────────────────────────────────────────
 
 
@@ -280,14 +305,7 @@ async def test_publishes_state_on_ct002_event(mqtt_broker):
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
             await sub.subscribe(f"{base}/ct002/+/consumer/+")
             service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
-
-            try:
-                async with asyncio.timeout(5):
-                    async for msg in sub.messages:
-                        received.append(msg)
-                        break
-            except TimeoutError:
-                pass
+            await _collect_messages(sub, received)
 
         assert len(received) == 1
         payload = json.loads(received[0].payload)
@@ -316,14 +334,7 @@ async def test_publishes_device_status(mqtt_broker):
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
             await sub.subscribe(f"{base}/ct002/+/status")
             service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
-
-            try:
-                async with asyncio.timeout(5):
-                    async for msg in sub.messages:
-                        received.append(msg)
-                        break
-            except TimeoutError:
-                pass
+            await _collect_messages(sub, received)
 
         assert len(received) == 1
         payload = json.loads(received[0].payload)
@@ -356,14 +367,12 @@ async def test_publishes_ha_discovery_on_first_event(mqtt_broker):
             await asyncio.sleep(0.3)
             service.on_ct002_response("dev1", "consumer2", SAMPLE_CT002_DATA)
 
-            try:
-                async with asyncio.timeout(3):
-                    async for msg in sub.messages:
-                        discovery_msgs.append(msg)
-                        if len(discovery_msgs) >= 3:
-                            break
-            except TimeoutError:
-                pass
+            await _collect_messages(
+                sub,
+                discovery_msgs,
+                timeout=3,
+                stop=lambda _: len(discovery_msgs) >= 3,
+            )
 
         # Expect: device discovery + consumer1 discovery + consumer2 discovery = 3
         # (no duplicate for second consumer1 event)
@@ -431,15 +440,12 @@ async def test_consumer_removal_publishes_offline(mqtt_broker):
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
             await sub.subscribe(f"{base}/ct002/dev1/consumer/consumer1/availability")
             service.on_ct002_consumer_removed("dev1", "consumer1")
-
-            try:
-                async with asyncio.timeout(3):
-                    async for msg in sub.messages:
-                        received.append(msg)
-                        if msg.payload == b"offline":
-                            break
-            except TimeoutError:
-                pass
+            await _collect_messages(
+                sub,
+                received,
+                timeout=3,
+                stop=lambda m: m.payload == b"offline",
+            )
 
         assert any(m.payload == b"offline" for m in received)
     finally:
@@ -461,13 +467,7 @@ async def test_lwt_online_offline(mqtt_broker):
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
             await sub.subscribe(f"{base}/status")
             # The retained "online" message should arrive
-            try:
-                async with asyncio.timeout(2):
-                    async for msg in sub.messages:
-                        received.append(msg)
-                        break
-            except TimeoutError:
-                pass
+            await _collect_messages(sub, received, timeout=2)
 
         assert len(received) == 1
         assert received[0].payload == b"online"
@@ -489,14 +489,7 @@ async def test_shelly_event_flow(mqtt_broker):
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
             await sub.subscribe(f"{base}/shelly/+/battery/+")
             service.on_shelly_response("shelly1", "192.168.1.100", SAMPLE_SHELLY_DATA)
-
-            try:
-                async with asyncio.timeout(5):
-                    async for msg in sub.messages:
-                        received.append(msg)
-                        break
-            except TimeoutError:
-                pass
+            await _collect_messages(sub, received)
 
         assert len(received) == 1
         payload = json.loads(received[0].payload)

--- a/src/b2500_meter/mqtt_insights/mqtt_insights_test.py
+++ b/src/b2500_meter/mqtt_insights/mqtt_insights_test.py
@@ -1,0 +1,499 @@
+"""Tests for MQTT Insights — discovery, service, and E2E with Mosquitto."""
+
+from __future__ import annotations
+
+import asyncio
+import configparser
+import json
+import re
+
+import aiomqtt
+
+from b2500_meter.config.config_loader import (
+    create_powermeter,
+    read_mqtt_insights_config,
+)
+from b2500_meter.conftest import needs_mosquitto
+
+from .discovery import (
+    _sanitize_id,
+    build_ct002_consumer_discovery,
+    build_ct002_device_discovery,
+    build_shelly_battery_discovery,
+    build_shelly_device_discovery,
+)
+from .service import MqttInsightsConfig, MqttInsightsService
+
+# ── Discovery payload unit tests ──────────────────────────────────────────
+
+_SAFE_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _assert_valid_node_id(node_id: str) -> None:
+    assert _SAFE_ID_RE.match(node_id), f"Invalid node_id: {node_id!r}"
+
+
+def _assert_discovery_structure(topic: str, payload: dict) -> None:
+    """Validate HA Device Discovery required fields."""
+    assert "device" in payload
+    assert "identifiers" in payload["device"]
+    assert "origin" in payload
+    assert "name" in payload["origin"]
+    assert "components" in payload
+    for comp_key, comp in payload["components"].items():
+        assert "platform" in comp, f"Missing platform in {comp_key}"
+        assert "unique_id" in comp, f"Missing unique_id in {comp_key}"
+        _assert_valid_node_id(_sanitize_id(comp["unique_id"]))
+
+
+def test_ct002_consumer_discovery_structure():
+    topic, payload = build_ct002_consumer_discovery(
+        "b2500_meter", "dev1", "consumer1", "homeassistant"
+    )
+    _assert_discovery_structure(topic, payload)
+
+    assert "homeassistant/device/" in topic
+    assert topic.endswith("/config")
+
+    # Check two-level availability
+    assert payload["availability_mode"] == "all"
+    assert len(payload["availability"]) == 2
+
+    # Check key components exist
+    comps = payload["components"]
+    assert "grid_power_total" in comps
+    assert "active" in comps
+    assert "saturation" in comps
+    assert "phase" in comps
+    assert "battery_ip" in comps
+    assert "ct_type" in comps
+    assert "ct_mac" in comps
+    assert "last_seen" in comps
+
+    # Primary entity has name: null
+    assert comps["grid_power_total"]["name"] is None
+
+    # Switch has correct topics
+    switch = comps["active"]
+    assert switch["platform"] == "switch"
+    assert "command_topic" in switch
+    assert switch["state_on"] == "True"
+    assert switch["state_off"] == "False"
+
+
+def test_ct002_device_discovery_structure():
+    topic, payload = build_ct002_device_discovery(
+        "b2500_meter", "dev1", "homeassistant"
+    )
+    _assert_discovery_structure(topic, payload)
+    comps = payload["components"]
+    assert "smooth_target" in comps
+    assert "active_control" in comps
+    assert "consumer_count" in comps
+    assert comps["smooth_target"]["name"] is None  # primary
+
+
+def test_shelly_battery_discovery_structure():
+    topic, payload = build_shelly_battery_discovery(
+        "b2500_meter", "shelly1", "192.168.1.100", "homeassistant"
+    )
+    _assert_discovery_structure(topic, payload)
+    comps = payload["components"]
+    assert "grid_power_total" in comps
+    assert "active" in comps
+    assert "last_seen" in comps
+    assert payload["availability_mode"] == "all"
+    assert len(payload["availability"]) == 2
+
+
+def test_shelly_device_discovery_structure():
+    topic, payload = build_shelly_device_discovery(
+        "b2500_meter", "shelly1", "homeassistant"
+    )
+    _assert_discovery_structure(topic, payload)
+    assert "battery_count" in payload["components"]
+
+
+def test_unique_ids_are_unique():
+    """All unique_ids within a single discovery payload must be distinct."""
+    _, payload = build_ct002_consumer_discovery(
+        "b2500_meter", "dev1", "cons1", "homeassistant"
+    )
+    uids = [c["unique_id"] for c in payload["components"].values()]
+    assert len(uids) == len(set(uids))
+
+
+def test_sanitize_id():
+    assert _sanitize_id("192.168.1.100") == "192_168_1_100"
+    assert _sanitize_id("AA:BB:CC") == "AA_BB_CC"
+    assert _sanitize_id("normal-id_123") == "normal-id_123"
+
+
+# ── Config tests ──────────────────────────────────────────────────────────
+
+
+def test_config_guard_mqtt_vs_mqtt_insights():
+    """[MQTT] creates a powermeter, [MQTT_INSIGHTS] does not."""
+    cfg = configparser.ConfigParser()
+    cfg.read_string(
+        """
+[MQTT]
+BROKER = localhost
+PORT = 1883
+TOPIC = test/power
+
+[MQTT_INSIGHTS]
+BROKER = localhost
+PORT = 1883
+"""
+    )
+    # MQTT section should create a powermeter
+    pm = create_powermeter("MQTT", cfg)
+    assert pm is not None
+
+    # MQTT_INSIGHTS should NOT create a powermeter
+    pm2 = create_powermeter("MQTT_INSIGHTS", cfg)
+    assert pm2 is None
+
+
+def test_read_mqtt_insights_config_present():
+    cfg = configparser.ConfigParser()
+    cfg.read_string(
+        """
+[MQTT_INSIGHTS]
+BROKER = 10.0.0.1
+PORT = 8883
+USERNAME = user
+PASSWORD = pass
+TLS = true
+BASE_TOPIC = my_topic
+HA_DISCOVERY = true
+HA_DISCOVERY_PREFIX = ha
+"""
+    )
+    result = read_mqtt_insights_config(cfg)
+    assert result is not None
+    assert result.broker == "10.0.0.1"
+    assert result.port == 8883
+    assert result.username == "user"
+    assert result.password == "pass"
+    assert result.tls is True
+    assert result.base_topic == "my_topic"
+    assert result.ha_discovery is True
+    assert result.ha_discovery_prefix == "ha"
+
+
+def test_read_mqtt_insights_config_defaults():
+    cfg = configparser.ConfigParser()
+    cfg.read_string(
+        """
+[MQTT_INSIGHTS]
+BROKER = localhost
+"""
+    )
+    result = read_mqtt_insights_config(cfg)
+    assert result is not None
+    assert result.port == 1883
+    assert result.tls is False
+    assert result.base_topic == "b2500_meter"
+    assert result.ha_discovery is True
+    assert result.ha_discovery_prefix == "homeassistant"
+
+
+def test_read_mqtt_insights_config_absent():
+    cfg = configparser.ConfigParser()
+    cfg.read_string("[GENERAL]\nDEVICE_TYPE=ct002\n")
+    assert read_mqtt_insights_config(cfg) is None
+
+
+# ── Service unit tests (no broker) ───────────────────────────────────────
+
+
+def test_queue_overflow_does_not_raise():
+    """Overflowing the queue should not raise."""
+    service = MqttInsightsService(MqttInsightsConfig(broker="localhost"))
+    for i in range(200):
+        service.on_ct002_response("dev1", f"consumer{i}", {"grid_power": {}})
+    # No exception raised
+
+
+# ── E2E tests with Mosquitto ─────────────────────────────────────────────
+
+
+def _make_service(port: int, base_topic: str = "test_insights") -> MqttInsightsService:
+    return MqttInsightsService(
+        MqttInsightsConfig(
+            broker="127.0.0.1",
+            port=port,
+            base_topic=base_topic,
+            ha_discovery=True,
+            ha_discovery_prefix="homeassistant",
+        )
+    )
+
+
+SAMPLE_CT002_DATA = {
+    "grid_power": {"l1": 100.0, "l2": 200.0, "l3": 300.0, "total": 600.0},
+    "target": {"l1": 50.0, "l2": 100.0, "l3": 150.0},
+    "phase": "A",
+    "reported_power": 42,
+    "device_type": "HMG-50",
+    "battery_ip": "192.168.1.10",
+    "ct_type": "HME-4",
+    "ct_mac": "AA:BB:CC:DD:EE:FF",
+    "saturation": 0.5,
+    "last_target": 300.0,
+    "active": True,
+    "last_seen": "2026-01-01T00:00:00+00:00",
+    "smooth_target": 500.0,
+    "active_control": True,
+    "consumer_count": 2,
+}
+
+SAMPLE_SHELLY_DATA = {
+    "grid_power": {"l1": 100.0, "l2": 200.0, "l3": 300.0, "total": 600.0},
+    "active": True,
+    "last_seen": "2026-01-01T00:00:00+00:00",
+    "battery_count": 1,
+}
+
+
+@needs_mosquitto
+async def test_publishes_state_on_ct002_event(mqtt_broker):
+    port = mqtt_broker
+    service = _make_service(port)
+    await service.start()
+
+    try:
+        # Give service time to connect
+        await asyncio.sleep(0.5)
+
+        received = []
+        async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
+            await sub.subscribe("test_insights/ct002/+/consumer/+")
+            service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
+
+            try:
+                async with asyncio.timeout(5):
+                    async for msg in sub.messages:
+                        received.append(msg)
+                        break
+            except TimeoutError:
+                pass
+
+        assert len(received) == 1
+        payload = json.loads(received[0].payload)
+        assert payload["grid_power"]["total"] == 600.0
+        assert payload["phase"] == "A"
+        assert payload["battery_ip"] == "192.168.1.10"
+        assert payload["ct_type"] == "HME-4"
+        assert payload["ct_mac"] == "AA:BB:CC:DD:EE:FF"
+        assert payload["active"] is True
+        assert str(received[0].topic) == "test_insights/ct002/dev1/consumer/consumer1"
+        assert received[0].retain
+    finally:
+        await service.stop()
+
+
+@needs_mosquitto
+async def test_publishes_device_status(mqtt_broker):
+    port = mqtt_broker
+    service = _make_service(port)
+    await service.start()
+
+    try:
+        await asyncio.sleep(0.5)
+
+        received = []
+        async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
+            await sub.subscribe("test_insights/ct002/+/status")
+            service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
+
+            try:
+                async with asyncio.timeout(5):
+                    async for msg in sub.messages:
+                        received.append(msg)
+                        break
+            except TimeoutError:
+                pass
+
+        assert len(received) == 1
+        payload = json.loads(received[0].payload)
+        assert payload["smooth_target"] == 500.0
+        assert payload["active_control"] is True
+        assert payload["consumer_count"] == 2
+    finally:
+        await service.stop()
+
+
+@needs_mosquitto
+async def test_publishes_ha_discovery_on_first_event(mqtt_broker):
+    port = mqtt_broker
+    service = _make_service(port)
+    await service.start()
+
+    try:
+        await asyncio.sleep(0.5)
+
+        discovery_msgs = []
+        async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
+            await sub.subscribe("homeassistant/device/#")
+            # First event for consumer1
+            service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
+            # Second event for same consumer — should NOT trigger another discovery
+            await asyncio.sleep(0.3)
+            service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
+            # Third event for consumer2 — SHOULD trigger new discovery
+            await asyncio.sleep(0.3)
+            service.on_ct002_response("dev1", "consumer2", SAMPLE_CT002_DATA)
+
+            deadline = asyncio.get_event_loop().time() + 3
+            try:
+                while asyncio.get_event_loop().time() < deadline:
+                    async with asyncio.timeout(1):
+                        async for msg in sub.messages:
+                            discovery_msgs.append(msg)
+                            if len(discovery_msgs) >= 3:
+                                raise StopAsyncIteration
+            except (TimeoutError, StopAsyncIteration):
+                pass
+
+        # Expect: device discovery + consumer1 discovery + consumer2 discovery = 3
+        # (no duplicate for second consumer1 event)
+        assert len(discovery_msgs) == 3
+        topics = [str(m.topic) for m in discovery_msgs]
+        # Device-level discovery
+        assert any("b2500_meter_ct002_dev1/config" in t for t in topics)
+        # Consumer-level discoveries
+        assert any("consumer1" in t for t in topics)
+        assert any("consumer2" in t for t in topics)
+    finally:
+        await service.stop()
+
+
+@needs_mosquitto
+async def test_active_toggle_via_mqtt(mqtt_broker):
+    port = mqtt_broker
+    service = _make_service(port)
+    handler_calls = []
+
+    def mock_handler(consumer_id, active):
+        handler_calls.append((consumer_id, active))
+
+    service.register_active_handler("dev1", mock_handler)
+    await service.start()
+
+    try:
+        await asyncio.sleep(0.5)
+
+        async with aiomqtt.Client(hostname="127.0.0.1", port=port) as pub:
+            await pub.publish(
+                "test_insights/ct002/dev1/consumer/consumer1/set",
+                payload=json.dumps({"active": False}).encode(),
+            )
+            await asyncio.sleep(0.5)
+            await pub.publish(
+                "test_insights/ct002/dev1/consumer/consumer1/set",
+                payload=json.dumps({"active": True}).encode(),
+            )
+            await asyncio.sleep(0.5)
+
+        assert len(handler_calls) == 2
+        assert handler_calls[0] == ("consumer1", False)
+        assert handler_calls[1] == ("consumer1", True)
+    finally:
+        await service.stop()
+
+
+@needs_mosquitto
+async def test_consumer_removal_publishes_offline(mqtt_broker):
+    port = mqtt_broker
+    service = _make_service(port)
+    await service.start()
+
+    try:
+        await asyncio.sleep(0.5)
+
+        # First fire an event so the consumer is "discovered"
+        service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
+        await asyncio.sleep(0.5)
+
+        received = []
+        async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
+            await sub.subscribe(
+                "test_insights/ct002/dev1/consumer/consumer1/availability"
+            )
+            service.on_ct002_consumer_removed("dev1", "consumer1")
+
+            try:
+                async with asyncio.timeout(3):
+                    async for msg in sub.messages:
+                        received.append(msg)
+                        break
+            except TimeoutError:
+                pass
+
+        assert len(received) == 1
+        assert received[0].payload == b"offline"
+        assert received[0].retain
+    finally:
+        await service.stop()
+
+
+@needs_mosquitto
+async def test_lwt_online_offline(mqtt_broker):
+    port = mqtt_broker
+    service = _make_service(port)
+    await service.start()
+
+    try:
+        await asyncio.sleep(0.5)
+
+        # Check online status
+        received = []
+        async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
+            await sub.subscribe("test_insights/status")
+            # The retained "online" message should arrive
+            try:
+                async with asyncio.timeout(2):
+                    async for msg in sub.messages:
+                        received.append(msg)
+                        break
+            except TimeoutError:
+                pass
+
+        assert len(received) == 1
+        assert received[0].payload == b"online"
+    finally:
+        await service.stop()
+
+
+@needs_mosquitto
+async def test_shelly_event_flow(mqtt_broker):
+    port = mqtt_broker
+    service = _make_service(port)
+    await service.start()
+
+    try:
+        await asyncio.sleep(0.5)
+
+        received = []
+        async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
+            await sub.subscribe("test_insights/shelly/+/battery/+")
+            service.on_shelly_response("shelly1", "192.168.1.100", SAMPLE_SHELLY_DATA)
+
+            try:
+                async with asyncio.timeout(5):
+                    async for msg in sub.messages:
+                        received.append(msg)
+                        break
+            except TimeoutError:
+                pass
+
+        assert len(received) == 1
+        payload = json.loads(received[0].payload)
+        assert payload["grid_power"]["total"] == 600.0
+        assert payload["active"] is True
+        assert "192_168_1_100" in str(received[0].topic)
+    finally:
+        await service.stop()

--- a/src/b2500_meter/mqtt_insights/mqtt_insights_test.py
+++ b/src/b2500_meter/mqtt_insights/mqtt_insights_test.py
@@ -347,15 +347,13 @@ async def test_publishes_ha_discovery_on_first_event(mqtt_broker):
             await asyncio.sleep(0.3)
             service.on_ct002_response("dev1", "consumer2", SAMPLE_CT002_DATA)
 
-            deadline = asyncio.get_event_loop().time() + 3
             try:
-                while asyncio.get_event_loop().time() < deadline:
-                    async with asyncio.timeout(1):
-                        async for msg in sub.messages:
-                            discovery_msgs.append(msg)
-                            if len(discovery_msgs) >= 3:
-                                raise StopAsyncIteration
-            except (TimeoutError, StopAsyncIteration):
+                async with asyncio.timeout(3):
+                    async for msg in sub.messages:
+                        discovery_msgs.append(msg)
+                        if len(discovery_msgs) >= 3:
+                            break
+            except TimeoutError:
                 pass
 
         # Expect: device discovery + consumer1 discovery + consumer2 discovery = 3

--- a/src/b2500_meter/mqtt_insights/mqtt_insights_test.py
+++ b/src/b2500_meter/mqtt_insights/mqtt_insights_test.py
@@ -220,14 +220,21 @@ def test_queue_overflow_does_not_raise():
 # ── E2E tests with Mosquitto ─────────────────────────────────────────────
 
 
-def _make_service(port: int, base_topic: str = "test_insights") -> MqttInsightsService:
+_test_counter = 0
+
+
+def _make_service(port: int, base_topic: str | None = None) -> MqttInsightsService:
+    global _test_counter
+    _test_counter += 1
+    if base_topic is None:
+        base_topic = f"test_insights_{_test_counter}"
     return MqttInsightsService(
         MqttInsightsConfig(
             broker="127.0.0.1",
             port=port,
             base_topic=base_topic,
             ha_discovery=True,
-            ha_discovery_prefix="homeassistant",
+            ha_discovery_prefix=f"ha_disc_{_test_counter}",
         )
     )
 
@@ -262,6 +269,7 @@ SAMPLE_SHELLY_DATA = {
 async def test_publishes_state_on_ct002_event(mqtt_broker):
     port = mqtt_broker
     service = _make_service(port)
+    base = service._config.base_topic
     await service.start()
 
     try:
@@ -270,7 +278,7 @@ async def test_publishes_state_on_ct002_event(mqtt_broker):
 
         received = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
-            await sub.subscribe("test_insights/ct002/+/consumer/+")
+            await sub.subscribe(f"{base}/ct002/+/consumer/+")
             service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
 
             try:
@@ -289,8 +297,7 @@ async def test_publishes_state_on_ct002_event(mqtt_broker):
         assert payload["ct_type"] == "HME-4"
         assert payload["ct_mac"] == "AA:BB:CC:DD:EE:FF"
         assert payload["active"] is True
-        assert str(received[0].topic) == "test_insights/ct002/dev1/consumer/consumer1"
-        assert received[0].retain
+        assert str(received[0].topic) == f"{base}/ct002/dev1/consumer/consumer1"
     finally:
         await service.stop()
 
@@ -299,6 +306,7 @@ async def test_publishes_state_on_ct002_event(mqtt_broker):
 async def test_publishes_device_status(mqtt_broker):
     port = mqtt_broker
     service = _make_service(port)
+    base = service._config.base_topic
     await service.start()
 
     try:
@@ -306,7 +314,7 @@ async def test_publishes_device_status(mqtt_broker):
 
         received = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
-            await sub.subscribe("test_insights/ct002/+/status")
+            await sub.subscribe(f"{base}/ct002/+/status")
             service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
 
             try:
@@ -330,6 +338,7 @@ async def test_publishes_device_status(mqtt_broker):
 async def test_publishes_ha_discovery_on_first_event(mqtt_broker):
     port = mqtt_broker
     service = _make_service(port)
+    ha_prefix = service._config.ha_discovery_prefix
     await service.start()
 
     try:
@@ -337,7 +346,7 @@ async def test_publishes_ha_discovery_on_first_event(mqtt_broker):
 
         discovery_msgs = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
-            await sub.subscribe("homeassistant/device/#")
+            await sub.subscribe(f"{ha_prefix}/device/#")
             # First event for consumer1
             service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
             # Second event for same consumer — should NOT trigger another discovery
@@ -373,6 +382,7 @@ async def test_publishes_ha_discovery_on_first_event(mqtt_broker):
 async def test_active_toggle_via_mqtt(mqtt_broker):
     port = mqtt_broker
     service = _make_service(port)
+    base = service._config.base_topic
     handler_calls = []
 
     def mock_handler(consumer_id, active):
@@ -386,12 +396,12 @@ async def test_active_toggle_via_mqtt(mqtt_broker):
 
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as pub:
             await pub.publish(
-                "test_insights/ct002/dev1/consumer/consumer1/set",
+                f"{base}/ct002/dev1/consumer/consumer1/set",
                 payload=json.dumps({"active": False}).encode(),
             )
             await asyncio.sleep(0.5)
             await pub.publish(
-                "test_insights/ct002/dev1/consumer/consumer1/set",
+                f"{base}/ct002/dev1/consumer/consumer1/set",
                 payload=json.dumps({"active": True}).encode(),
             )
             await asyncio.sleep(0.5)
@@ -407,6 +417,7 @@ async def test_active_toggle_via_mqtt(mqtt_broker):
 async def test_consumer_removal_publishes_offline(mqtt_broker):
     port = mqtt_broker
     service = _make_service(port)
+    base = service._config.base_topic
     await service.start()
 
     try:
@@ -418,22 +429,19 @@ async def test_consumer_removal_publishes_offline(mqtt_broker):
 
         received = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
-            await sub.subscribe(
-                "test_insights/ct002/dev1/consumer/consumer1/availability"
-            )
+            await sub.subscribe(f"{base}/ct002/dev1/consumer/consumer1/availability")
             service.on_ct002_consumer_removed("dev1", "consumer1")
 
             try:
                 async with asyncio.timeout(3):
                     async for msg in sub.messages:
                         received.append(msg)
-                        break
+                        if msg.payload == b"offline":
+                            break
             except TimeoutError:
                 pass
 
-        assert len(received) == 1
-        assert received[0].payload == b"offline"
-        assert received[0].retain
+        assert any(m.payload == b"offline" for m in received)
     finally:
         await service.stop()
 
@@ -442,6 +450,7 @@ async def test_consumer_removal_publishes_offline(mqtt_broker):
 async def test_lwt_online_offline(mqtt_broker):
     port = mqtt_broker
     service = _make_service(port)
+    base = service._config.base_topic
     await service.start()
 
     try:
@@ -450,7 +459,7 @@ async def test_lwt_online_offline(mqtt_broker):
         # Check online status
         received = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
-            await sub.subscribe("test_insights/status")
+            await sub.subscribe(f"{base}/status")
             # The retained "online" message should arrive
             try:
                 async with asyncio.timeout(2):
@@ -470,6 +479,7 @@ async def test_lwt_online_offline(mqtt_broker):
 async def test_shelly_event_flow(mqtt_broker):
     port = mqtt_broker
     service = _make_service(port)
+    base = service._config.base_topic
     await service.start()
 
     try:
@@ -477,7 +487,7 @@ async def test_shelly_event_flow(mqtt_broker):
 
         received = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
-            await sub.subscribe("test_insights/shelly/+/battery/+")
+            await sub.subscribe(f"{base}/shelly/+/battery/+")
             service.on_shelly_response("shelly1", "192.168.1.100", SAMPLE_SHELLY_DATA)
 
             try:

--- a/src/b2500_meter/mqtt_insights/service.py
+++ b/src/b2500_meter/mqtt_insights/service.py
@@ -1,0 +1,387 @@
+"""MQTT Insights service — publishes internal state to MQTT with HA Discovery."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import ssl
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import aiomqtt
+
+from b2500_meter.config.logger import logger
+
+from .discovery import (
+    _sanitize_id,
+    build_ct002_consumer_discovery,
+    build_ct002_device_discovery,
+    build_shelly_battery_discovery,
+    build_shelly_device_discovery,
+)
+
+RECONNECT_DELAY = 5
+QUEUE_MAX_SIZE = 100
+
+
+@dataclass
+class MqttInsightsConfig:
+    broker: str
+    port: int = 1883
+    username: str | None = None
+    password: str | None = None
+    tls: bool = False
+    base_topic: str = "b2500_meter"
+    ha_discovery: bool = True
+    ha_discovery_prefix: str = "homeassistant"
+
+
+@dataclass
+class _Event:
+    kind: str  # "ct002", "ct002_status", "ct002_remove", "shelly", "shelly_status"
+    device_id: str
+    entity_id: str  # consumer_id / battery ip_slug
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+class MqttInsightsService:
+    def __init__(self, config: MqttInsightsConfig) -> None:
+        self._config = config
+        self._queue: asyncio.Queue[_Event] = asyncio.Queue(maxsize=QUEUE_MAX_SIZE)
+        self._task: asyncio.Task[None] | None = None
+        self._discovered_ct002_consumers: set[str] = set()
+        self._discovered_ct002_devices: set[str] = set()
+        self._discovered_shelly_batteries: set[str] = set()
+        self._discovered_shelly_devices: set[str] = set()
+        self._active_handlers: dict[str, Callable[[str, bool], None]] = {}
+
+    # ── Public API (called from device event listeners) ───────────────
+
+    def on_ct002_response(
+        self, device_id: str, consumer_id: str, data: dict[str, Any]
+    ) -> None:
+        """Queue CT002 consumer event (fire-and-forget)."""
+        evt = _Event(
+            kind="ct002", device_id=device_id, entity_id=consumer_id, data=data
+        )
+        self._put_nowait(evt)
+
+    def on_ct002_consumer_removed(self, device_id: str, consumer_id: str) -> None:
+        """Queue CT002 consumer removal event."""
+        evt = _Event(kind="ct002_remove", device_id=device_id, entity_id=consumer_id)
+        self._put_nowait(evt)
+
+    def on_shelly_response(
+        self, device_id: str, battery_ip: str, data: dict[str, Any]
+    ) -> None:
+        """Queue Shelly battery event (fire-and-forget)."""
+        ip_slug = _sanitize_id(battery_ip)
+        evt = _Event(kind="shelly", device_id=device_id, entity_id=ip_slug, data=data)
+        self._put_nowait(evt)
+
+    def register_active_handler(
+        self, device_id: str, handler: Callable[[str, bool], None]
+    ) -> None:
+        self._active_handlers[device_id] = handler
+
+    # ── Lifecycle ─────────────────────────────────────────────────────
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+
+    # ── Internal ──────────────────────────────────────────────────────
+
+    def _put_nowait(self, evt: _Event) -> None:
+        try:
+            self._queue.put_nowait(evt)
+        except asyncio.QueueFull:
+            # Drop oldest to make room
+            with contextlib.suppress(asyncio.QueueEmpty):
+                self._queue.get_nowait()
+            with contextlib.suppress(asyncio.QueueFull):
+                self._queue.put_nowait(evt)
+
+    async def _run(self) -> None:
+        cfg = self._config
+        tls_context = ssl.create_default_context() if cfg.tls else None
+
+        while True:
+            try:
+                async with aiomqtt.Client(
+                    hostname=cfg.broker,
+                    port=cfg.port,
+                    username=cfg.username,
+                    password=cfg.password,
+                    tls_context=tls_context,
+                    keepalive=60,
+                    will=aiomqtt.Will(
+                        topic=f"{cfg.base_topic}/status",
+                        payload=b"offline",
+                        qos=1,
+                        retain=True,
+                    ),
+                ) as client:
+                    logger.info(
+                        "MQTT Insights connected to %s:%s", cfg.broker, cfg.port
+                    )
+                    # Clear discovery sets on (re)connect so we re-publish
+                    self._discovered_ct002_consumers.clear()
+                    self._discovered_ct002_devices.clear()
+                    self._discovered_shelly_batteries.clear()
+                    self._discovered_shelly_devices.clear()
+
+                    # Publish online status
+                    await client.publish(
+                        f"{cfg.base_topic}/status",
+                        payload=b"online",
+                        qos=1,
+                        retain=True,
+                    )
+
+                    # Subscribe to command topics
+                    await client.subscribe(f"{cfg.base_topic}/ct002/+/consumer/+/set")
+
+                    # Run publish loop and message listener concurrently
+                    await asyncio.gather(
+                        self._publish_loop(client),
+                        self._listen_commands(client),
+                    )
+
+            except asyncio.CancelledError:
+                # Graceful shutdown: try to publish offline
+                try:
+                    async with aiomqtt.Client(
+                        hostname=cfg.broker,
+                        port=cfg.port,
+                        username=cfg.username,
+                        password=cfg.password,
+                        tls_context=tls_context,
+                    ) as client:
+                        await client.publish(
+                            f"{cfg.base_topic}/status",
+                            payload=b"offline",
+                            qos=1,
+                            retain=True,
+                        )
+                except Exception:
+                    pass
+                raise
+            except (aiomqtt.MqttError, OSError) as exc:
+                logger.warning(
+                    "MQTT Insights connection error: %s. Reconnecting in %ss...",
+                    exc,
+                    RECONNECT_DELAY,
+                )
+                await asyncio.sleep(RECONNECT_DELAY)
+
+    async def _publish_loop(self, client: aiomqtt.Client) -> None:
+        cfg = self._config
+        base = cfg.base_topic
+
+        while True:
+            evt = await self._queue.get()
+
+            try:
+                if evt.kind == "ct002":
+                    await self._handle_ct002_event(client, base, cfg, evt)
+                elif evt.kind == "ct002_remove":
+                    await self._handle_ct002_remove(client, base, cfg, evt)
+                elif evt.kind == "shelly":
+                    await self._handle_shelly_event(client, base, cfg, evt)
+            except aiomqtt.MqttError:
+                raise
+            except Exception:
+                logger.exception("Error publishing MQTT Insights event")
+
+    async def _handle_ct002_event(
+        self,
+        client: aiomqtt.Client,
+        base: str,
+        cfg: MqttInsightsConfig,
+        evt: _Event,
+    ) -> None:
+        did = evt.device_id
+        cid = evt.entity_id
+        data = evt.data
+
+        # Per-consumer state
+        consumer_key = f"{did}/{cid}"
+        state_topic = f"{base}/ct002/{did}/consumer/{cid}"
+        avail_topic = f"{state_topic}/availability"
+
+        # Extract consumer-level state
+        consumer_state = {
+            "grid_power": data.get("grid_power", {}),
+            "target": data.get("target", {}),
+            "phase": data.get("phase", ""),
+            "reported_power": data.get("reported_power", 0),
+            "device_type": data.get("device_type", ""),
+            "battery_ip": data.get("battery_ip", ""),
+            "ct_type": data.get("ct_type", ""),
+            "ct_mac": data.get("ct_mac", ""),
+            "saturation": data.get("saturation", 0.0),
+            "last_target": data.get("last_target"),
+            "active": data.get("active", True),
+            "last_seen": data.get("last_seen", ""),
+        }
+
+        await client.publish(
+            state_topic,
+            payload=json.dumps(consumer_state).encode(),
+            retain=True,
+        )
+        await client.publish(avail_topic, payload=b"online", retain=True)
+
+        # Device-level status
+        device_status = {
+            "smooth_target": data.get("smooth_target", 0),
+            "active_control": data.get("active_control", False),
+            "consumer_count": data.get("consumer_count", 0),
+        }
+        await client.publish(
+            f"{base}/ct002/{did}/status",
+            payload=json.dumps(device_status).encode(),
+            retain=True,
+        )
+
+        # Discovery on first sight
+        if cfg.ha_discovery:
+            if did not in self._discovered_ct002_devices:
+                self._discovered_ct002_devices.add(did)
+                topic, payload = build_ct002_device_discovery(
+                    base, did, cfg.ha_discovery_prefix
+                )
+                await client.publish(
+                    topic, payload=json.dumps(payload).encode(), retain=True
+                )
+
+            if consumer_key not in self._discovered_ct002_consumers:
+                self._discovered_ct002_consumers.add(consumer_key)
+                topic, payload = build_ct002_consumer_discovery(
+                    base, did, cid, cfg.ha_discovery_prefix
+                )
+                await client.publish(
+                    topic, payload=json.dumps(payload).encode(), retain=True
+                )
+
+    async def _handle_ct002_remove(
+        self,
+        client: aiomqtt.Client,
+        base: str,
+        cfg: MqttInsightsConfig,
+        evt: _Event,
+    ) -> None:
+        did = evt.device_id
+        cid = evt.entity_id
+        consumer_key = f"{did}/{cid}"
+        avail_topic = f"{base}/ct002/{did}/consumer/{cid}/availability"
+        await client.publish(avail_topic, payload=b"offline", retain=True)
+        self._discovered_ct002_consumers.discard(consumer_key)
+
+    async def _handle_shelly_event(
+        self,
+        client: aiomqtt.Client,
+        base: str,
+        cfg: MqttInsightsConfig,
+        evt: _Event,
+    ) -> None:
+        did = evt.device_id
+        ip_slug = evt.entity_id
+        data = evt.data
+
+        battery_key = f"{did}/{ip_slug}"
+        state_topic = f"{base}/shelly/{did}/battery/{ip_slug}"
+        avail_topic = f"{state_topic}/availability"
+
+        battery_state = {
+            "grid_power": data.get("grid_power", {}),
+            "active": data.get("active", True),
+            "last_seen": data.get("last_seen", ""),
+        }
+
+        await client.publish(
+            state_topic,
+            payload=json.dumps(battery_state).encode(),
+            retain=True,
+        )
+        await client.publish(avail_topic, payload=b"online", retain=True)
+
+        # Device-level status
+        device_status = {
+            "battery_count": data.get("battery_count", 0),
+        }
+        await client.publish(
+            f"{base}/shelly/{did}/status",
+            payload=json.dumps(device_status).encode(),
+            retain=True,
+        )
+
+        # Discovery
+        if cfg.ha_discovery:
+            if did not in self._discovered_shelly_devices:
+                self._discovered_shelly_devices.add(did)
+                topic, payload = build_shelly_device_discovery(
+                    base, did, cfg.ha_discovery_prefix
+                )
+                await client.publish(
+                    topic, payload=json.dumps(payload).encode(), retain=True
+                )
+
+            if battery_key not in self._discovered_shelly_batteries:
+                self._discovered_shelly_batteries.add(battery_key)
+                topic, payload = build_shelly_battery_discovery(
+                    base, did, ip_slug, cfg.ha_discovery_prefix
+                )
+                await client.publish(
+                    topic, payload=json.dumps(payload).encode(), retain=True
+                )
+
+    async def _listen_commands(self, client: aiomqtt.Client) -> None:
+        base = self._config.base_topic
+        prefix = f"{base}/ct002/"
+        suffix = "/set"
+
+        async for message in client.messages:
+            topic_str = str(message.topic)
+            if not topic_str.startswith(prefix) or not topic_str.endswith(suffix):
+                continue
+
+            # Parse: {base}/ct002/{device_id}/consumer/{consumer_id}/set
+            parts = topic_str[len(prefix) : -len(suffix)].split("/consumer/", 1)
+            if len(parts) != 2:
+                continue
+            device_id, consumer_id = parts
+
+            raw = message.payload
+            try:
+                payload_str = raw.decode() if isinstance(raw, bytes) else str(raw)
+                cmd = json.loads(payload_str)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                logger.warning("Invalid command payload on %s", topic_str)
+                continue
+
+            if "active" in cmd:
+                active = bool(cmd["active"])
+                handler = self._active_handlers.get(device_id)
+                if handler:
+                    try:
+                        handler(consumer_id, active)
+                    except Exception:
+                        logger.exception(
+                            "Active handler error for %s/%s", device_id, consumer_id
+                        )
+                else:
+                    logger.debug(
+                        "No active handler for device %s (consumer %s)",
+                        device_id,
+                        consumer_id,
+                    )

--- a/src/b2500_meter/mqtt_insights/service.py
+++ b/src/b2500_meter/mqtt_insights/service.py
@@ -157,23 +157,10 @@ class MqttInsightsService:
                     )
 
             except asyncio.CancelledError:
-                # Graceful shutdown: try to publish offline
-                try:
-                    async with aiomqtt.Client(
-                        hostname=cfg.broker,
-                        port=cfg.port,
-                        username=cfg.username,
-                        password=cfg.password,
-                        tls_context=tls_context,
-                    ) as client:
-                        await client.publish(
-                            f"{cfg.base_topic}/status",
-                            payload=b"offline",
-                            qos=1,
-                            retain=True,
-                        )
-                except Exception:
-                    pass
+                # Graceful shutdown: publish offline in a shielded scope
+                # so the pending cancellation doesn't abort the publish.
+                with contextlib.suppress(Exception):
+                    await asyncio.shield(self._publish_offline(cfg, tls_context))
                 raise
             except (aiomqtt.MqttError, OSError) as exc:
                 logger.warning(
@@ -182,6 +169,29 @@ class MqttInsightsService:
                     RECONNECT_DELAY,
                 )
                 await asyncio.sleep(RECONNECT_DELAY)
+            except Exception:
+                logger.exception(
+                    "MQTT Insights unexpected error, reconnecting in %ss...",
+                    RECONNECT_DELAY,
+                )
+                await asyncio.sleep(RECONNECT_DELAY)
+
+    async def _publish_offline(
+        self, cfg: MqttInsightsConfig, tls_context: ssl.SSLContext | None
+    ) -> None:
+        async with aiomqtt.Client(
+            hostname=cfg.broker,
+            port=cfg.port,
+            username=cfg.username,
+            password=cfg.password,
+            tls_context=tls_context,
+        ) as client:
+            await client.publish(
+                f"{cfg.base_topic}/status",
+                payload=b"offline",
+                qos=1,
+                retain=True,
+            )
 
     async def _publish_loop(self, client: aiomqtt.Client) -> None:
         cfg = self._config

--- a/src/b2500_meter/powermeter/mqtt_test.py
+++ b/src/b2500_meter/powermeter/mqtt_test.py
@@ -1,14 +1,9 @@
 import asyncio
 import json
-import shutil
-import signal
-import socket
-import subprocess
-import tempfile
-import time
-from pathlib import Path
 
 import pytest
+
+from b2500_meter.conftest import needs_mosquitto
 
 from .mqtt import MqttPowermeter, extract_json_value
 
@@ -222,55 +217,8 @@ async def test_value_property_backward_compat():
 # Integration tests (require mosquitto)
 # ---------------------------------------------------------------------------
 
-_needs_mosquitto = pytest.mark.skipif(
-    shutil.which("mosquitto") is None,
-    reason="mosquitto not installed",
-)
 
-
-def _find_free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-@pytest.fixture(scope="session")
-def mqtt_broker():
-    port = _find_free_port()
-    tmpdir = tempfile.mkdtemp()
-    config_path = Path(tmpdir) / "mosquitto.conf"
-    config_path.write_text(
-        f"listener {port} 127.0.0.1\nallow_anonymous true\npersistence false\n"
-    )
-    proc = subprocess.Popen(
-        ["mosquitto", "-c", str(config_path)],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    # Wait for broker to be ready
-    deadline = time.monotonic() + 5
-    while time.monotonic() < deadline:
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-                break
-        except OSError:
-            time.sleep(0.1)
-    else:
-        proc.terminate()
-        raise RuntimeError("mosquitto did not start in time")
-
-    yield port
-
-    proc.send_signal(signal.SIGTERM)
-    try:
-        proc.wait(timeout=2)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        proc.wait()
-    shutil.rmtree(tmpdir, ignore_errors=True)
-
-
-@_needs_mosquitto
+@needs_mosquitto
 async def test_receives_plain_value(mqtt_broker):
     import aiomqtt
 
@@ -288,7 +236,7 @@ async def test_receives_plain_value(mqtt_broker):
         await pm.stop()
 
 
-@_needs_mosquitto
+@needs_mosquitto
 async def test_receives_json_value(mqtt_broker):
     import aiomqtt
 
@@ -306,7 +254,7 @@ async def test_receives_json_value(mqtt_broker):
         await pm.stop()
 
 
-@_needs_mosquitto
+@needs_mosquitto
 async def test_wait_for_message_timeout_with_no_publish(mqtt_broker):
     port = mqtt_broker
     topic = "test/timeout"
@@ -320,7 +268,7 @@ async def test_wait_for_message_timeout_with_no_publish(mqtt_broker):
         await pm.stop()
 
 
-@_needs_mosquitto
+@needs_mosquitto
 async def test_receives_multiple_messages_returns_latest(mqtt_broker):
     import aiomqtt
 
@@ -340,7 +288,7 @@ async def test_receives_multiple_messages_returns_latest(mqtt_broker):
         await pm.stop()
 
 
-@_needs_mosquitto
+@needs_mosquitto
 async def test_receives_multi_topic_values(mqtt_broker):
     import aiomqtt
 
@@ -360,7 +308,7 @@ async def test_receives_multi_topic_values(mqtt_broker):
         await pm.stop()
 
 
-@_needs_mosquitto
+@needs_mosquitto
 async def test_receives_single_topic_multi_json_paths(mqtt_broker):
     import aiomqtt
 

--- a/src/b2500_meter/shelly/shelly.py
+++ b/src/b2500_meter/shelly/shelly.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import json
 import time
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Any
 
 from b2500_meter.config import ClientFilter
 from b2500_meter.config.logger import logger
@@ -11,7 +16,7 @@ BATTERY_INACTIVE_TIMEOUT_SECONDS = 120
 
 
 class _ShellyProtocol(asyncio.DatagramProtocol):
-    def __init__(self, shelly: "Shelly"):
+    def __init__(self, shelly: Shelly):
         self.shelly = shelly
         self._tasks: set[asyncio.Task] = set()
 
@@ -42,6 +47,7 @@ class Shelly:
         self._inactive_batteries: set[str] = set()
         self._stopped = asyncio.Event()
         self._inactive_check_task = None
+        self.event_listener: Callable[[str, str, dict[str, Any]], None] | None = None
 
     def _calculate_derived_values(self, power):
         decimal_point_enforcer = 0.001
@@ -141,6 +147,14 @@ class Shelly:
                 battery_ip,
             )
 
+    def _call_event_listener(self, battery_ip: str, data: dict[str, Any]) -> None:
+        if not self.event_listener:
+            return
+        try:
+            self.event_listener(self._device_id, battery_ip, data)
+        except Exception as exc:
+            logger.warning("event_listener failed for %s: %s", battery_ip, exc)
+
     async def _safe_handle_request(self, transport, data, addr):
         try:
             await self._handle_request(transport, data, addr)
@@ -185,6 +199,32 @@ class Shelly:
                 logger.debug(f"Sending response: {response_json}")
                 response_data = response_json.encode()
                 transport.sendto(response_data, addr)
+
+                battery_ip = addr[0]
+                if len(powers) == 1:
+                    grid_l1, grid_l2, grid_l3 = powers[0], 0.0, 0.0
+                elif len(powers) >= 3:
+                    grid_l1, grid_l2, grid_l3 = (
+                        float(powers[0]),
+                        float(powers[1]),
+                        float(powers[2]),
+                    )
+                else:
+                    grid_l1, grid_l2, grid_l3 = 0.0, 0.0, 0.0
+                self._call_event_listener(
+                    battery_ip,
+                    {
+                        "grid_power": {
+                            "l1": grid_l1,
+                            "l2": grid_l2,
+                            "l3": grid_l3,
+                            "total": grid_l1 + grid_l2 + grid_l3,
+                        },
+                        "active": battery_ip not in self._inactive_batteries,
+                        "last_seen": datetime.now(timezone.utc).isoformat(),
+                        "battery_count": len(self._battery_last_seen),
+                    },
+                )
         except json.JSONDecodeError:
             logger.error("Error: Invalid JSON")
         except Exception:

--- a/tests/test_ct002_active_control.py
+++ b/tests/test_ct002_active_control.py
@@ -1232,6 +1232,19 @@ class TestInactiveConsumers:
         device.set_consumer_active("x", True)
         assert device.is_consumer_active("x")
 
+    def test_reactivation_clears_stale_state(self):
+        """Re-enabling a consumer should clear saturation and last_target."""
+        device = CT002(active_control=True)
+        device._saturation_by_consumer["bat1"] = 0.8
+        device._last_target_by_consumer["bat1"] = 50
+        device.set_consumer_active("bat1", False)
+        # Stale state is preserved while inactive
+        assert "bat1" in device._saturation_by_consumer
+        # Reactivation clears it
+        device.set_consumer_active("bat1", True)
+        assert "bat1" not in device._saturation_by_consumer
+        assert "bat1" not in device._last_target_by_consumer
+
     def test_last_target_set_to_zero_for_inactive(self):
         """Inactive consumer's last_target should be recorded as 0."""
         device = CT002(active_control=True)

--- a/tests/test_ct002_active_control.py
+++ b/tests/test_ct002_active_control.py
@@ -1152,3 +1152,90 @@ class TestEfficiencySaturationSwap:
         device._compute_smooth_target([-200, 0, 0], "b")
         # Active consumer should now be deprioritized (swapped)
         assert active_cid in device._efficiency_deprioritized
+
+
+class TestInactiveConsumers:
+    """Tests for the active/pause flag (set_consumer_active)."""
+
+    def test_inactive_consumer_drives_to_zero_on_phase(self):
+        """An inactive consumer with non-zero reported power should get
+        target = -reported_power on its phase, not just [0,0,0]."""
+        device = CT002(active_control=True, fair_distribution=False)
+        device._update_consumer_report("bat1", "B", 250)
+        device.set_consumer_active("bat1", False)
+
+        result = device._compute_smooth_target([400, 0, 0], "bat1")
+
+        # Phase B → index 1, target should be -250 to steer output to zero
+        assert result == [0.0, -250.0, 0.0]
+
+    def test_inactive_consumer_already_at_zero_returns_zeros(self):
+        """An inactive consumer reporting 0W should get [0,0,0]."""
+        device = CT002(active_control=True, fair_distribution=False)
+        device._update_consumer_report("bat1", "A", 0)
+        device.set_consumer_active("bat1", False)
+
+        result = device._compute_smooth_target([400, 0, 0], "bat1")
+        assert result == [0, 0, 0]
+
+    def test_inactive_consumer_excluded_from_fair_distribution(self):
+        """Fair share should only count active consumers."""
+        device = CT002(active_control=True, fair_distribution=False)
+        device._update_consumer_report("bat1", "A", 0)
+        device._update_consumer_report("bat2", "A", 0)
+        device.set_consumer_active("bat1", False)
+
+        # Only bat2 is active → gets the full target, not half
+        result = device._compute_smooth_target([400, 0, 0], "bat2")
+        assert result[0] == 400
+
+    def test_inactive_consumer_excluded_from_efficiency_rotation(self):
+        """Inactive consumers should not appear in the efficiency priority list."""
+        device = CT002(
+            active_control=True,
+            fair_distribution=False,
+            min_efficient_power=200,
+        )
+        device._update_consumer_report("bat1", "A", 50)
+        device._update_consumer_report("bat2", "A", 50)
+        device._update_consumer_report("bat3", "A", 50)
+        device.set_consumer_active("bat2", False)
+
+        device._compute_smooth_target([100, 0, 0], "bat1")
+
+        assert "bat2" not in device._efficiency_priority
+        assert "bat1" in device._efficiency_priority
+        assert "bat3" in device._efficiency_priority
+
+    def test_reactivated_consumer_rejoins_distribution(self):
+        """After re-activating, consumer should participate normally."""
+        device = CT002(active_control=True, fair_distribution=False)
+        device._update_consumer_report("bat1", "A", 0)
+        device._update_consumer_report("bat2", "A", 0)
+
+        # Pause bat1
+        device.set_consumer_active("bat1", False)
+        result = device._compute_smooth_target([400, 0, 0], "bat2")
+        assert result[0] == 400  # bat2 gets full share
+
+        # Reactivate bat1
+        device.set_consumer_active("bat1", True)
+        device._last_smooth_sample = None  # force re-evaluation
+        result = device._compute_smooth_target([400, 0, 0], "bat1")
+        assert result[0] == 200  # now split between two
+
+    def test_set_consumer_active_toggle(self):
+        device = CT002()
+        assert device.is_consumer_active("x")
+        device.set_consumer_active("x", False)
+        assert not device.is_consumer_active("x")
+        device.set_consumer_active("x", True)
+        assert device.is_consumer_active("x")
+
+    def test_last_target_set_to_zero_for_inactive(self):
+        """Inactive consumer's last_target should be recorded as 0."""
+        device = CT002(active_control=True)
+        device._update_consumer_report("bat1", "A", 100)
+        device.set_consumer_active("bat1", False)
+        device._compute_smooth_target([400, 0, 0], "bat1")
+        assert device._last_target_by_consumer["bat1"] == 0


### PR DESCRIPTION
## Summary

Adds MQTT Insights, an optional feature that publishes internal device state (grid power per phase, charge targets, saturation, consumer topology) to MQTT with Home Assistant MQTT Device Discovery support. Includes per-consumer active/pause control via MQTT commands.

## Key Changes

- **New `mqtt_insights` module** with three core components:
  - `discovery.py`: Pure functions building HA MQTT Device Discovery payloads (HA 2024.11+ format) for CT002 devices, consumers, and Shelly batteries
  - `service.py`: `MqttInsightsService` that manages MQTT connection, publishes state updates, handles HA discovery on first event, and processes incoming command topics
  - `mqtt_insights_test.py`: Comprehensive test suite (497 lines) covering discovery structure validation, config parsing, queue overflow handling, and E2E integration tests with Mosquitto

- **CT002 device enhancements**:
  - Added `event_listener` callback to emit consumer state on updates
  - Added `set_consumer_active()` / `is_consumer_active()` to track inactive consumers
  - Inactive consumers are excluded from fair distribution and efficiency rotation, and receive target = -reported_power to steer output to zero
  - Consumer removal triggers event listener with sentinel `{"_removed": True}`

- **Shelly device enhancements**:
  - Added `event_listener` callback for battery state updates
  - Tracks battery IP and last-seen timestamp

- **Configuration**:
  - New `[MQTT_INSIGHTS]` section in config.ini with options: `BROKER`, `PORT`, `USERNAME`, `PASSWORD`, `TLS`, `BASE_TOPIC`, `HA_DISCOVERY`, `HA_DISCOVERY_PREFIX`
  - `read_mqtt_insights_config()` in config_loader.py parses settings with sensible defaults
  - Home Assistant add-on auto-configures MQTT Insights when Mosquitto service is available

- **Main loop integration**:
  - `MqttInsightsService` started alongside device event loop
  - CT002 and Shelly devices register event listeners to push state updates
  - Active handler registered to receive consumer pause/resume commands from MQTT

- **Test infrastructure**:
  - Extracted shared Mosquitto fixture (`mqtt_broker`) to `conftest.py` for reuse across test modules
  - Added `needs_mosquitto` marker for integration tests requiring broker

## Notable Implementation Details

- **Discovery on first event**: HA discovery payloads are published only once per device/consumer, tracked via `_discovered_*` sets that clear on reconnect
- **Queue overflow handling**: Event queue (max 100) drops oldest event if full, preventing blocking on slow MQTT publishes
- **Two-level availability**: Consumer entities use both system-level (service online/offline) and per-consumer availability topics
- **Graceful shutdown**: Publishes offline status in shielded scope to ensure LWT is sent even during cancellation
- **Inactive consumer logic**: Drives output to zero by setting target = -reported_power on the consumer's phase, not just [0,0,0]
- **Unique ID sanitization**: All HA unique_ids are sanitized to match `[a-zA-Z0-9_-]` pattern for HA compatibility

https://claude.ai/code/session_01L2mua4xXq6t183gTCr1LKX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MQTT Insights: optional publisher of device, per-consumer and battery state to MQTT with Home Assistant discovery
  * Per-consumer active/pause control via MQTT commands
  * Auto-configuration of MQTT Insights when an MQTT broker is available in the add-on

* **Documentation**
  * Added MQTT Insights docs and example configuration (broker, TLS, topics, HA discovery)

* **Tests**
  * Added unit and integration tests for MQTT Insights, HA discovery, and consumer active-control behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->