### PR TITLE
Fix MQTT service availability check in Home Assistant addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## Next
-- Fixed Home Assistant add-on writing an empty `[MQTT_INSIGHTS]` section when no Mosquitto service is available; the section is now only generated when the add-on actually has an MQTT service
 - **Breaking:** Rebrand project from "B2500 Meter" to "AstraMeter" (formerly b2500-meter). Package renamed to `astrameter`, CLI commands are now `astrameter` and `astra-sim`. Docker image moved from `ghcr.io/tomquist/b2500-meter` to `ghcr.io/tomquist/astrameter`. Home Assistant users must update their app repository URL to `https://github.com/tomquist/astrameter#main`.
 - Added CT002/CT003 emulation for steering multiple Marstek storage devices over the Marstek CT UDP protocol, with opt-in efficiency optimization that concentrates power on fewer batteries at low demand and rotates fairly over time (`MIN_EFFICIENT_POWER`, `EFFICIENCY_ROTATION_INTERVAL`, and related tuning options)
 - Added MQTT Insights: optional `[MQTT_INSIGHTS]` section publishes internal state (grid power, targets, saturation, consumer topology) to MQTT with Home Assistant Device Discovery, per-consumer active/pause control, manual target override, and Shelly battery offline availability; auto-configured in the HA app when Mosquitto is installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Fixed Home Assistant add-on writing an empty `[MQTT_INSIGHTS]` section when no Mosquitto service is available; the section is now only generated when the add-on actually has an MQTT service
 - **Breaking:** Rebrand project from "B2500 Meter" to "AstraMeter" (formerly b2500-meter). Package renamed to `astrameter`, CLI commands are now `astrameter` and `astra-sim`. Docker image moved from `ghcr.io/tomquist/b2500-meter` to `ghcr.io/tomquist/astrameter`. Home Assistant users must update their app repository URL to `https://github.com/tomquist/astrameter#main`.
 - Added CT002/CT003 emulation for steering multiple Marstek storage devices over the Marstek CT UDP protocol, with opt-in efficiency optimization that concentrates power on fewer batteries at low demand and rotates fairly over time (`MIN_EFFICIENT_POWER`, `EFFICIENCY_ROTATION_INTERVAL`, and related tuning options)
 - Added MQTT Insights: optional `[MQTT_INSIGHTS]` section publishes internal state (grid power, targets, saturation, consumer topology) to MQTT with Home Assistant Device Discovery, per-consumer active/pause control, manual target override, and Shelly battery offline availability; auto-configured in the HA app when Mosquitto is installed

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -131,7 +131,7 @@ else
             echo "CURRENT_POWER_ENTITY=$(bashio::config 'power_input_alias')"
         fi
 
-        if bashio::services "mqtt"; then
+        if bashio::services.available "mqtt"; then
             echo ""
             echo "[MQTT_INSIGHTS]"
             echo "BROKER=$(bashio::services 'mqtt' 'host')"


### PR DESCRIPTION
## Summary
Updated the MQTT service availability check to use the correct Home Assistant bashio function.

## Changes
- Changed `bashio::services "mqtt"` to `bashio::services.available "mqtt"` to properly check if the MQTT service is available before attempting to access its configuration

## Details
The original code was using an incorrect bashio function syntax. The `bashio::services.available` function is the proper way to check if a service is available in Home Assistant before attempting to retrieve its configuration details. This prevents potential errors when the MQTT service is not installed or available on the system.

https://claude.ai/code/session_019CfQvHfhZLrbnThz63fDW9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT service availability detection to ensure the MQTT configuration section and broker settings are only displayed when the service is actually available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->