### PR TITLE
Add MQTT URI support for broker configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## Next
-- Added support for configuring the MQTT broker via a single `URI` (e.g. `mqtt://user:pass@host:1883` or `mqtts://...`) for both the `[MQTT]` powermeter and `[MQTT_INSIGHTS]` sections, plus a matching `mqtt_uri` option in the Home Assistant add-on for users who want to point MQTT Insights at an external broker instead of the bundled Mosquitto service
 - **Breaking:** Rebrand project from "B2500 Meter" to "AstraMeter" (formerly b2500-meter). Package renamed to `astrameter`, CLI commands are now `astrameter` and `astra-sim`. Docker image moved from `ghcr.io/tomquist/b2500-meter` to `ghcr.io/tomquist/astrameter` (the legacy `ghcr.io/tomquist/b2500-meter` image is still published in parallel for backward compatibility). Home Assistant users must update their app repository URL to `https://github.com/tomquist/astrameter#main`.
 - Added CT002/CT003 emulation for steering multiple Marstek storage devices over the Marstek CT UDP protocol, with opt-in efficiency optimization that concentrates power on fewer batteries at low demand and rotates fairly over time (`MIN_EFFICIENT_POWER`, `EFFICIENCY_ROTATION_INTERVAL`, and related tuning options)
 - Added MQTT Insights: optional `[MQTT_INSIGHTS]` section publishes internal state (grid power, targets, saturation, consumer topology) to MQTT with Home Assistant Device Discovery, per-consumer active/pause control, manual target override, and Shelly battery offline availability; auto-configured in the HA app when Mosquitto is installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Added support for configuring the MQTT broker via a single `URI` (e.g. `mqtt://user:pass@host:1883` or `mqtts://...`) for both the `[MQTT]` powermeter and `[MQTT_INSIGHTS]` sections, plus a matching `mqtt_uri` option in the Home Assistant add-on for users who want to point MQTT Insights at an external broker instead of the bundled Mosquitto service
 - **Breaking:** Rebrand project from "B2500 Meter" to "AstraMeter" (formerly b2500-meter). Package renamed to `astrameter`, CLI commands are now `astrameter` and `astra-sim`. Docker image moved from `ghcr.io/tomquist/b2500-meter` to `ghcr.io/tomquist/astrameter` (the legacy `ghcr.io/tomquist/b2500-meter` image is still published in parallel for backward compatibility). Home Assistant users must update their app repository URL to `https://github.com/tomquist/astrameter#main`.
 - Added CT002/CT003 emulation for steering multiple Marstek storage devices over the Marstek CT UDP protocol, with opt-in efficiency optimization that concentrates power on fewer batteries at low demand and rotates fairly over time (`MIN_EFFICIENT_POWER`, `EFFICIENCY_ROTATION_INTERVAL`, and related tuning options)
 - Added MQTT Insights: optional `[MQTT_INSIGHTS]` section publishes internal state (grid power, targets, saturation, consumer topology) to MQTT with Home Assistant Device Discovery, per-consumer active/pause control, manual target override, and Shelly battery offline availability; auto-configured in the HA app when Mosquitto is installed

--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ PASSWORD = mqtt_pass (Optional)
 # THROTTLE_INTERVAL = 2
 ```
 
-Instead of `BROKER`/`PORT`/`USERNAME`/`PASSWORD`/`TLS`, you can provide a single `URI` of the form `mqtt://user:pass@host:port` (or `mqtts://...` for TLS). When `URI` is set, the individual broker fields are ignored.
+Instead of `BROKER`/`PORT`/`USERNAME`/`PASSWORD`/`TLS`, you can provide a single `URI` of the form `mqtt[s]://[user[:pass]@]host[:port]` (use `mqtts://` for TLS; credentials and port are optional). When `URI` is set, the individual `BROKER`/`PORT`/`USERNAME`/`PASSWORD`/`TLS` fields are ignored.
 
 ```ini
 [MQTT]

--- a/README.md
+++ b/README.md
@@ -595,8 +595,18 @@ TOPIC = home/powermeter
 JSON_PATH = $.path.to.value (Optional for JSON payloads)
 USERNAME = mqtt_user (Optional)
 PASSWORD = mqtt_pass (Optional)
+# Optional: connect over TLS (mqtts://) — default false
+# TLS = false
 # Per-powermeter throttling override
 # THROTTLE_INTERVAL = 2
+```
+
+Instead of `BROKER`/`PORT`/`USERNAME`/`PASSWORD`/`TLS`, you can provide a single `URI` of the form `mqtt://user:pass@host:port` (or `mqtts://...` for TLS). When `URI` is set, the individual broker fields are ignored.
+
+```ini
+[MQTT]
+URI = mqtts://user:pass@broker.example.com:8883
+TOPIC = home/powermeter
 ```
 
 The `JSON_PATH` option is used to extract the power value from a JSON payload. The path must be a [valid JSONPath expression](https://goessner.net/articles/JsonPath/).
@@ -768,6 +778,7 @@ HA_DISCOVERY_PREFIX = homeassistant
 
 | Option | Default | Description |
 |---|---|---|
+| `URI` | — | MQTT URI (`mqtt[s]://user:pass@host:port`); when set, overrides `BROKER`/`PORT`/`USERNAME`/`PASSWORD`/`TLS` |
 | `BROKER` | `localhost` | MQTT broker hostname/IP |
 | `PORT` | `1883` | MQTT broker port |
 | `USERNAME` / `PASSWORD` | — | Credentials (optional) |

--- a/config.ini.example
+++ b/config.ini.example
@@ -231,6 +231,12 @@ THROTTLE_INTERVAL = 0
 #[MQTT]
 #BROKER = broker.example.com
 #PORT = 1883
+## Optional: enable TLS to connect over mqtts:// (default false)
+#TLS = false
+## Alternatively, provide a single MQTT URI in place of BROKER/PORT/USERNAME/PASSWORD/TLS:
+##   mqtt://user:pass@broker.example.com:1883
+##   mqtts://user:pass@broker.example.com:8883
+#URI = mqtt://user:pass@broker.example.com:1883
 #TOPIC = home/powermeter
 #JSON_PATH = path.to.value (Optional)
 #USERNAME = mqtt_user (Optional)
@@ -315,6 +321,10 @@ THROTTLE_INTERVAL = 0
 #PASSWORD = mqtt_pass
 ## Enable TLS (default: false)
 #TLS = false
+## Alternatively, provide a single MQTT URI in place of BROKER/PORT/USERNAME/PASSWORD/TLS:
+##   mqtt://user:pass@broker.example.com:1883
+##   mqtts://user:pass@broker.example.com:8883
+#URI = mqtt://user:pass@192.168.1.100:1883
 ## Base topic for all MQTT Insights messages (default: astrameter)
 #BASE_TOPIC = astrameter
 ## Enable Home Assistant MQTT Device Discovery (default: true)

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -56,3 +56,4 @@ schema:
   power_offset: str?
   power_multiplier: str?
   custom_config: str?
+  mqtt_uri: str?

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -35,6 +35,7 @@ CONFIG="/app/config.ini"
 print_redacted_config() {
     sed -E \
         -e 's/^((MAILBOX|PASSWORD|ACCESSTOKEN|TOKEN|SECRET))\s*=\s*.*/\1 = REDACTED/i' \
+        -e 's#^(URI\s*=\s*[a-zA-Z][a-zA-Z0-9+.-]*://)[^/@[:space:]]+@#\1***:***@#i' \
         "$1"
 }
 

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -44,6 +44,9 @@ if bashio::config.has_value 'custom_config' && [ -f "/config/$(bashio::config 'c
     if bashio::config.has_value 'marstek_mailbox' || bashio::config.has_value 'marstek_password' || bashio::config.has_value 'marstek_auto_register_ct_device'; then
         bashio::log.warning "App UI Marstek settings are ignored when custom_config is used; values from custom config file take precedence"
     fi
+    if bashio::config.has_value 'mqtt_uri'; then
+        bashio::log.warning "App UI mqtt_uri is ignored when custom_config is used; the custom config file controls MQTT settings"
+    fi
     cp "/config/$(bashio::config 'custom_config')" "$CONFIG"
 else
     device_types="$(bashio::config 'device_types')"
@@ -139,7 +142,14 @@ else
             echo "POWER_MULTIPLIER=$power_multiplier"
         fi
 
-        if bashio::services.available "mqtt"; then
+        if bashio::config.has_value 'mqtt_uri'; then
+            bashio::log.info "Using custom MQTT broker URL from configuration"
+            echo ""
+            echo "[MQTT_INSIGHTS]"
+            echo "URI=$(bashio::config 'mqtt_uri')"
+            echo "HA_DISCOVERY=True"
+        elif bashio::services.available "mqtt"; then
+            bashio::log.info "Using Home Assistant's internal MQTT broker"
             echo ""
             echo "[MQTT_INSIGHTS]"
             echo "BROKER=$(bashio::services 'mqtt' 'host')"

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -20,6 +20,9 @@ configuration:
   custom_config:
     name: Custom Config
     description: "Optional. Name of a custom config.ini file to use instead of the UI configuration. The file must be placed in the app's configuration directory."
+  mqtt_uri:
+    name: Custom MQTT URI
+    description: "Optional. MQTT broker URI for MQTT Insights, e.g. mqtt://user:pass@broker.example.com:1883 (or mqtts:// for TLS). When set, this overrides Home Assistant's internal MQTT broker. Leave empty to use the Mosquitto add-on automatically."
   min_efficient_power:
     name: Min Efficient Power
     description: "Minimum watts each active battery should handle. At low demand, excess batteries are idled so the remaining ones stay above this threshold and operate more efficiently. Set to 0 to disable (default). Example: 2 batteries, 200 W demand, threshold 150 — one battery gets 200 W, the other idles. Only applies to CT002/CT003 device types."

--- a/src/astrameter/config/config_loader.py
+++ b/src/astrameter/config/config_loader.py
@@ -106,6 +106,13 @@ def parse_mqtt_uri(uri: str) -> MqttUriParts:
     if not host:
         raise ValueError(f"MQTT URI is missing a host: {uri!r}")
 
+    if parsed.path not in ("", "/"):
+        raise ValueError(f"MQTT URI must not contain a path: {uri!r}")
+    if parsed.params or parsed.query or parsed.fragment:
+        raise ValueError(
+            f"MQTT URI must not contain params, query, or fragment: {uri!r}"
+        )
+
     tls = scheme == "mqtts"
     port = parsed.port if parsed.port is not None else (8883 if tls else 1883)
     username = unquote(parsed.username) if parsed.username is not None else None

--- a/src/astrameter/config/config_loader.py
+++ b/src/astrameter/config/config_loader.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import configparser
+from dataclasses import dataclass
 from ipaddress import IPv4Address, IPv4Network
 from typing import TYPE_CHECKING
+from urllib.parse import unquote, urlparse
 
 if TYPE_CHECKING:
     from astrameter.mqtt_insights import MqttInsightsConfig
@@ -68,6 +70,54 @@ class ClientFilter:
             logger.error(f"Error: {e}")
             return False
         return False
+
+
+@dataclass
+class MqttUriParts:
+    """Parsed connection details from an MQTT URI."""
+
+    host: str
+    port: int
+    username: str | None
+    password: str | None
+    tls: bool
+
+
+def parse_mqtt_uri(uri: str) -> MqttUriParts:
+    """Parse an ``mqtt://`` / ``mqtts://`` URI into its connection parts.
+
+    Accepts URIs of the form ``mqtt[s]://[user[:pass]@]host[:port]``. Username
+    and password may be percent-encoded. Raises ``ValueError`` if the URI is
+    not a valid MQTT URI.
+    """
+
+    raw = (uri or "").strip()
+    if not raw:
+        raise ValueError("MQTT URI is empty")
+
+    parsed = urlparse(raw)
+    scheme = parsed.scheme.lower()
+    if scheme not in ("mqtt", "mqtts"):
+        raise ValueError(
+            f"Unsupported MQTT URI scheme '{parsed.scheme}'; expected 'mqtt' or 'mqtts'"
+        )
+
+    host = parsed.hostname
+    if not host:
+        raise ValueError(f"MQTT URI is missing a host: {uri!r}")
+
+    tls = scheme == "mqtts"
+    port = parsed.port if parsed.port is not None else (8883 if tls else 1883)
+    username = unquote(parsed.username) if parsed.username is not None else None
+    password = unquote(parsed.password) if parsed.password is not None else None
+
+    return MqttUriParts(
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        tls=tls,
+    )
 
 
 def parse_float_list(value: str, key_name: str, section: str) -> list[float]:
@@ -258,13 +308,29 @@ def create_mqtt_powermeter(
     else:
         json_path = config.get(section, "JSON_PATH", fallback=None)
 
+    uri = config.get(section, "URI", fallback="").strip()
+    if uri:
+        parts = parse_mqtt_uri(uri)
+        broker = parts.host
+        port = parts.port
+        username = parts.username
+        password = parts.password
+        tls = parts.tls
+    else:
+        broker = config.get(section, "BROKER", fallback="")
+        port = config.getint(section, "PORT", fallback=1883)
+        username = config.get(section, "USERNAME", fallback=None)
+        password = config.get(section, "PASSWORD", fallback=None)
+        tls = config.getboolean(section, "TLS", fallback=False)
+
     return MqttPowermeter(
-        config.get(section, "BROKER", fallback=""),
-        config.getint(section, "PORT", fallback=1883),
+        broker,
+        port,
         topic,
         json_path,
-        config.get(section, "USERNAME", fallback=None),
-        config.get(section, "PASSWORD", fallback=None),
+        username,
+        password,
+        tls=tls,
     )
 
 
@@ -468,12 +534,26 @@ def read_mqtt_insights_config(
             raw_port = config.get(section, "PORT", fallback="")
             raw_tls = config.get(section, "TLS", fallback="")
             raw_ha_discovery = config.get(section, "HA_DISCOVERY", fallback="")
+            uri = config.get(section, "URI", fallback="").strip()
+            if uri:
+                parts = parse_mqtt_uri(uri)
+                broker_value = parts.host
+                port_value = parts.port
+                username_value: str | None = parts.username
+                password_value: str | None = parts.password
+                tls_value = parts.tls
+            else:
+                broker_value = config.get(section, "BROKER", fallback="") or "localhost"
+                port_value = int(raw_port) if raw_port else 1883
+                username_value = config.get(section, "USERNAME", fallback=None) or None
+                password_value = config.get(section, "PASSWORD", fallback=None) or None
+                tls_value = config.getboolean(section, "TLS") if raw_tls else False
             return MqttInsightsConfig(
-                broker=config.get(section, "BROKER", fallback="") or "localhost",
-                port=int(raw_port) if raw_port else 1883,
-                username=config.get(section, "USERNAME", fallback=None) or None,
-                password=config.get(section, "PASSWORD", fallback=None) or None,
-                tls=config.getboolean(section, "TLS") if raw_tls else False,
+                broker=broker_value,
+                port=port_value,
+                username=username_value,
+                password=password_value,
+                tls=tls_value,
                 base_topic=config.get(section, "BASE_TOPIC", fallback="")
                 or "astrameter",
                 ha_discovery=config.getboolean(section, "HA_DISCOVERY")

--- a/src/astrameter/config/config_loader_test.py
+++ b/src/astrameter/config/config_loader_test.py
@@ -25,7 +25,9 @@ from astrameter.config.config_loader import (
     create_tq_em_powermeter,
     create_vzlogger_powermeter,
     parse_float_list,
+    parse_mqtt_uri,
     read_all_powermeter_configs,
+    read_mqtt_insights_config,
 )
 from astrameter.powermeter import TransformedPowermeter
 
@@ -288,6 +290,105 @@ def test_create_mqtt_powermeter_with_json_paths():
     assert pm._subscriptions[0] == ("home/power", "$.l1.power")
     assert pm._subscriptions[1] == ("home/power", "$.l2.power")
     assert pm._subscriptions[2] == ("home/power", "$.l3.power")
+
+
+def test_parse_mqtt_uri_full():
+    parts = parse_mqtt_uri("mqtt://alice:s%40cret@broker.example.com:1884")
+    assert parts.host == "broker.example.com"
+    assert parts.port == 1884
+    assert parts.username == "alice"
+    assert parts.password == "s@cret"
+    assert parts.tls is False
+
+
+def test_parse_mqtt_uri_mqtts_default_port():
+    parts = parse_mqtt_uri("mqtts://broker.example.com")
+    assert parts.host == "broker.example.com"
+    assert parts.port == 8883
+    assert parts.username is None
+    assert parts.password is None
+    assert parts.tls is True
+
+
+def test_parse_mqtt_uri_mqtt_default_port():
+    parts = parse_mqtt_uri("mqtt://broker.example.com")
+    assert parts.port == 1883
+    assert parts.tls is False
+
+
+def test_parse_mqtt_uri_invalid_scheme():
+    with pytest.raises(ValueError):
+        parse_mqtt_uri("http://broker.example.com")
+
+
+def test_parse_mqtt_uri_missing_host():
+    with pytest.raises(ValueError):
+        parse_mqtt_uri("mqtt://")
+
+
+def test_parse_mqtt_uri_empty():
+    with pytest.raises(ValueError):
+        parse_mqtt_uri("")
+
+
+def test_create_mqtt_powermeter_with_uri():
+    config = configparser.ConfigParser()
+    config["MQTT"] = {
+        "URI": "mqtts://alice:secret@broker.example.com:8884",
+        "TOPIC": "home/power",
+    }
+    pm = create_mqtt_powermeter("MQTT", config)
+    assert pm.broker == "broker.example.com"
+    assert pm.port == 8884
+    assert pm.username == "alice"
+    assert pm.password == "secret"
+    assert pm.tls is True
+
+
+def test_read_mqtt_insights_config_with_uri():
+    config = configparser.ConfigParser()
+    config["MQTT_INSIGHTS"] = {
+        "URI": "mqtt://bob:pw@192.168.1.50:1885",
+    }
+    cfg = read_mqtt_insights_config(config)
+    assert cfg is not None
+    assert cfg.broker == "192.168.1.50"
+    assert cfg.port == 1885
+    assert cfg.username == "bob"
+    assert cfg.password == "pw"
+    assert cfg.tls is False
+
+
+def test_read_mqtt_insights_config_with_mqtts_uri():
+    config = configparser.ConfigParser()
+    config["MQTT_INSIGHTS"] = {
+        "URI": "mqtts://broker.example.com",
+    }
+    cfg = read_mqtt_insights_config(config)
+    assert cfg is not None
+    assert cfg.tls is True
+    assert cfg.port == 8883
+    assert cfg.username is None
+    assert cfg.password is None
+
+
+def test_read_mqtt_insights_config_without_uri():
+    """Plain BROKER/PORT/USERNAME/PASSWORD/TLS still works."""
+    config = configparser.ConfigParser()
+    config["MQTT_INSIGHTS"] = {
+        "BROKER": "10.0.0.1",
+        "PORT": "1888",
+        "USERNAME": "u",
+        "PASSWORD": "p",
+        "TLS": "true",
+    }
+    cfg = read_mqtt_insights_config(config)
+    assert cfg is not None
+    assert cfg.broker == "10.0.0.1"
+    assert cfg.port == 1888
+    assert cfg.username == "u"
+    assert cfg.password == "p"
+    assert cfg.tls is True
 
 
 def test_create_mqtt_powermeter_topics_takes_precedence_over_topic():

--- a/src/astrameter/config/config_loader_test.py
+++ b/src/astrameter/config/config_loader_test.py
@@ -331,6 +331,27 @@ def test_parse_mqtt_uri_empty():
         parse_mqtt_uri("")
 
 
+def test_parse_mqtt_uri_rejects_path():
+    with pytest.raises(ValueError, match="path"):
+        parse_mqtt_uri("mqtt://broker.example.com/some/path")
+
+
+def test_parse_mqtt_uri_allows_trailing_slash():
+    parts = parse_mqtt_uri("mqtt://broker.example.com:1883/")
+    assert parts.host == "broker.example.com"
+    assert parts.port == 1883
+
+
+def test_parse_mqtt_uri_rejects_query():
+    with pytest.raises(ValueError, match="query"):
+        parse_mqtt_uri("mqtt://broker.example.com?clientId=foo")
+
+
+def test_parse_mqtt_uri_rejects_fragment():
+    with pytest.raises(ValueError, match="fragment"):
+        parse_mqtt_uri("mqtt://broker.example.com#frag")
+
+
 def test_create_mqtt_powermeter_with_uri():
     config = configparser.ConfigParser()
     config["MQTT"] = {

--- a/src/astrameter/powermeter/mqtt.py
+++ b/src/astrameter/powermeter/mqtt.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import json
+import ssl
 
 import aiomqtt
 from jsonpath_ng import parse
@@ -30,11 +31,13 @@ class MqttPowermeter(Powermeter):
         json_path: str | list[str] | None = None,
         username: str | None = None,
         password: str | None = None,
+        tls: bool = False,
     ):
         self.broker = broker
         self.port = port
         self.username = username
         self.password = password
+        self.tls = tls
 
         # Normalize topic(s) and json_path(s) into subscription list
         topics = [topic] if isinstance(topic, str) else list(topic)
@@ -92,6 +95,7 @@ class MqttPowermeter(Powermeter):
 
     async def _run(self) -> None:
         unique_topics = list(self._topic_indices.keys())
+        tls_context = ssl.create_default_context() if self.tls else None
         while True:
             try:
                 async with aiomqtt.Client(
@@ -99,6 +103,7 @@ class MqttPowermeter(Powermeter):
                     port=self.port,
                     username=self.username,
                     password=self.password,
+                    tls_context=tls_context,
                     keepalive=60,
                 ) as client:
                     logger.info(f"Connected to MQTT broker {self.broker}:{self.port}")


### PR DESCRIPTION
## Summary
Added support for configuring MQTT brokers via a single URI parameter (e.g., `mqtt://user:pass@host:1883` or `mqtts://...`) as an alternative to specifying individual `BROKER`, `PORT`, `USERNAME`, `PASSWORD`, and `TLS` configuration options. This simplifies configuration and improves usability, especially for the Home Assistant add-on.

## Key Changes

- **New `parse_mqtt_uri()` function**: Parses MQTT URIs in the format `mqtt[s]://[user[:pass]@]host[:port]` with support for percent-encoded credentials. Validates scheme, extracts host/port/credentials, and automatically sets TLS flag and default ports (1883 for mqtt, 8883 for mqtts).

- **New `MqttUriParts` dataclass**: Represents parsed MQTT connection details (host, port, username, password, tls).

- **Updated `create_mqtt_powermeter()`**: Now checks for a `URI` config option first; if present, uses parsed URI values; otherwise falls back to individual `BROKER`/`PORT`/`USERNAME`/`PASSWORD`/`TLS` options.

- **Updated `read_mqtt_insights_config()`**: Similarly supports `URI` option with fallback to individual configuration fields.

- **TLS support in `MqttPowermeter`**: Added `tls` parameter to the constructor and SSL context creation in the `_run()` method for secure connections.

- **Home Assistant add-on enhancements**: 
  - Added `mqtt_uri` configuration option to `config.yaml`
  - Updated `run.sh` to prioritize custom `mqtt_uri` when provided, with appropriate logging
  - Added translations for the new `mqtt_uri` option

- **Documentation updates**: Updated README and example config to document the new `URI` option for both `[MQTT]` and `[MQTT_INSIGHTS]` sections with examples.

- **Comprehensive test coverage**: Added 9 new tests covering URI parsing (valid/invalid cases), default ports, TLS detection, and integration with powermeter/insights config readers.

## Implementation Details

- URI parsing uses Python's `urllib.parse` with percent-decoding for credentials
- When `URI` is specified, it takes precedence over individual broker configuration fields
- Default ports follow MQTT conventions: 1883 for unencrypted, 8883 for TLS
- Backward compatibility maintained—existing configs without `URI` continue to work unchanged

https://claude.ai/code/session_01DHFX8ucBEoysYSzAt9La66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional MQTT URI support (mqtt://, mqtts://) that overrides per-field broker/credential settings.
  * TLS-enabled MQTT connections and Home Assistant addon support for custom MQTT URI.

* **Documentation**
  * Updated docs and config examples to show URI and TLS options and precedence rules.

* **Tests**
  * Added unit and integration tests covering URI parsing, defaults, and backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->