### PR TITLE
Add several smoothing, oscillation-reduction features, and web config editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/__pycache__/*
 .venv
+test-results.xml

--- a/config.ini.example
+++ b/config.ini.example
@@ -16,6 +16,16 @@ POLL_INTERVAL = 1
 # Recommended values: 1-3 seconds for slower data sources
 # Can be overridden per powermeter section
 THROTTLE_INTERVAL = 0
+# Global EMA (exponential moving average) smoothing factor - applies to all powermeters unless overridden
+# Smooths out short-term fluctuations in power readings before sending them to the client
+# EMA formula: ema = alpha * raw_value + (1 - alpha) * previous_ema
+# alpha must be in the range (0, 1]:
+#   - Values close to 0 produce heavy smoothing (slow to react to changes)
+#   - Values close to 1 produce little smoothing (close to the raw reading)
+#   - Set to 0 to disable EMA (default)
+# Recommended values: 0.1 (heavy) to 0.5 (moderate) smoothing
+# Can be overridden per powermeter section
+EMA_ALPHA = 0
 
 #[SHELLY]
 #TYPE = 1PM #PLUS1PM #EM #3EM #3EMPRO
@@ -26,6 +36,8 @@ THROTTLE_INTERVAL = 0
 ## Per-powermeter throttling override (optional)
 ## Shelly devices are typically fast, so throttling may not be needed
 #THROTTLE_INTERVAL = 0
+## Per-powermeter EMA smoothing override (optional, range (0, 1])
+#EMA_ALPHA = 0
 
 #[TASMOTA]
 #IP = 192.168.1.101

--- a/config.ini.example
+++ b/config.ini.example
@@ -26,12 +26,42 @@ THROTTLE_INTERVAL = 0
 # Recommended values: 0.1 (heavy) to 0.5 (moderate) smoothing
 # Can be overridden per powermeter section
 EMA_ALPHA = 0
+# Global EMA sampling interval (in seconds) - decouples EMA accumulation from the B2500 poll rate
+# When set > 0, a background thread samples the underlying powermeter at this interval and updates
+# the EMA continuously, independently of how often the B2500 requests data. This lets the EMA
+# accumulate many samples between B2500 polls, making it more effective at smoothing rapid spikes.
+# When set to 0 (default), the EMA is updated on every get_powermeter_watts() call (original behaviour).
+# Example: EMA_INTERVAL = 1  (sample every 1 second regardless of B2500 poll rate)
+# Can be overridden per powermeter section
+EMA_INTERVAL = 0
 # Global power offset (in watts) - added to all power readings from all powermeters unless overridden
 # Useful to compensate for a known systematic measurement error or to factor in a constant baseline load
 # Positive values increase the reported power; negative values decrease it
 # Set to 0 to disable (default)
 # Can be overridden per powermeter section
 POWER_OFFSET = 0
+# Global slew-rate limiter (in watts per second) - limits how quickly the reported value can change
+# Even if the raw reading jumps instantly by a large amount, the value reported to the storage system
+# ramps towards the target at most this many watts per second.
+# This prevents sudden large steps from triggering an aggressive over-response that causes oscillation.
+# Set to 0 to disable (default)
+# Example: SLEW_RATE_WATTS_PER_SEC = 100  (max 100 W/s ramp rate)
+# Can be overridden per powermeter section
+SLEW_RATE_WATTS_PER_SEC = 0
+# Global dead-band filter (in watts) - suppresses reported power changes smaller than this threshold
+# A new value is only forwarded when at least one phase has moved more than this many watts from the
+# last reported value. This is the most effective way to prevent oscillation near the operating point.
+# Set to 0 to disable (default)
+# Example: DEADBAND_WATTS = 50  (ignore changes ≤ 50 W)
+# Can be overridden per powermeter section
+DEADBAND_WATTS = 0
+# Global hold timer (in seconds) - holds each reported value for a minimum duration before updating
+# Once a value is forwarded to the storage system it is held constant for this many seconds, giving
+# the system time to physically respond before receiving another update.
+# Set to 0 to disable (default)
+# Example: HOLD_TIME = 5  (hold each reported value for at least 5 seconds)
+# Can be overridden per powermeter section
+HOLD_TIME = 0
 
 #[SHELLY]
 #TYPE = 1PM #PLUS1PM #EM #3EM #3EMPRO
@@ -44,6 +74,13 @@ POWER_OFFSET = 0
 #THROTTLE_INTERVAL = 0
 ## Per-powermeter EMA smoothing override (optional, range (0, 1])
 #EMA_ALPHA = 0
+## Per-powermeter EMA sampling interval override in seconds (optional)
+#EMA_INTERVAL = 0
+#SLEW_RATE_WATTS_PER_SEC = 0
+## Per-powermeter dead-band filter override in watts (optional)
+#DEADBAND_WATTS = 0
+## Per-powermeter hold timer override in seconds (optional)
+#HOLD_TIME = 0
 ## Per-powermeter power offset override in watts (optional, can be negative)
 #POWER_OFFSET = 0
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -3,6 +3,9 @@
 DEVICE_TYPE = ct001
 # Skip initial powermeter test on startup
 SKIP_POWERMETER_TEST = False
+# Enable or disable the web-based configuration editor (served on the health-check port 52500)
+# When True, the editor is accessible at http://<host>:52500/config — set to False to disable
+WEB_CONFIG_ENABLED = False
 # Sum power values of all phases and report on phase 1 (ct001 only and default is False)
 DISABLE_SUM_PHASES = False
 # Send absolute values (necessary for storage system) (ct001 only and default is False)

--- a/config.ini.example
+++ b/config.ini.example
@@ -26,6 +26,12 @@ THROTTLE_INTERVAL = 0
 # Recommended values: 0.1 (heavy) to 0.5 (moderate) smoothing
 # Can be overridden per powermeter section
 EMA_ALPHA = 0
+# Global power offset (in watts) - added to all power readings from all powermeters unless overridden
+# Useful to compensate for a known systematic measurement error or to factor in a constant baseline load
+# Positive values increase the reported power; negative values decrease it
+# Set to 0 to disable (default)
+# Can be overridden per powermeter section
+POWER_OFFSET = 0
 
 #[SHELLY]
 #TYPE = 1PM #PLUS1PM #EM #3EM #3EMPRO
@@ -38,6 +44,8 @@ EMA_ALPHA = 0
 #THROTTLE_INTERVAL = 0
 ## Per-powermeter EMA smoothing override (optional, range (0, 1])
 #EMA_ALPHA = 0
+## Per-powermeter power offset override in watts (optional, can be negative)
+#POWER_OFFSET = 0
 
 #[TASMOTA]
 #IP = 192.168.1.101

--- a/config.ini.example
+++ b/config.ini.example
@@ -65,6 +65,51 @@ DEADBAND_WATTS = 0
 # Example: HOLD_TIME = 5  (hold each reported value for at least 5 seconds)
 # Can be overridden per powermeter section
 HOLD_TIME = 0
+# Global PID controller - applies closed-loop control to steer the grid meter reading toward zero.
+# The PID uses the raw power reading as its process variable and computes an adjustment.
+# A negative adjustment decreases the reported value (motivates the B2500 to reduce feed-in,
+# allowing imports to rise); a positive adjustment increases it (motivates B2500 to increase feed-in).
+#
+# Error formula: error = −actual_power
+# A positive grid import produces a negative error; the PID output opposes the import,
+# telling the B2500 to cover it.
+#
+# To keep a small safety buffer and avoid exporting to the grid, set a small negative
+# POWER_OFFSET (e.g. POWER_OFFSET = -20) in the filter chain before the PID.
+#
+# PID_KP: Proportional gain. 0.5 is the recommended value.
+#         Must be < 1 to avoid instability.  Set to 0 to disable PID (default).
+# PID_KI: Integral gain. Usually 0 — a non-zero Ki can cause windup during
+#         sustained imbalances or when the output is saturated.
+#         Keep at 0 unless you need to eliminate steady-state error and
+#         understand anti-windup behaviour.
+# PID_KD: Derivative gain. Anticipates changes. Usually 0 (noisy readings amplify the D-term).
+# PID_OUTPUT_MAX: Maximum absolute PID output in watts. Should match B2500 max output (e.g. 800 or 1200).
+#                 Prevents integral windup. Default 800.
+# PID_MODE: "bias" — add PID output to the raw meter reading (recommended, the B2500 still sees
+#                     realistic data with a control bias applied)
+#           "replace" — use PID output directly as the reported value (the B2500 sees only the
+#                       controller output, not the actual meter reading)
+#           Default: bias
+#
+# Stability tip: enable DEADBAND_WATTS (e.g. 20) and EMA_ALPHA (e.g. 0.3) BEFORE the PID to
+# smooth the input signal.  This is the most effective way to prevent oscillation.
+#
+# Tuning guide (Method 1 — Manual Tuning):
+#   1. Set POWER_OFFSET = -20 to hold a 20 W import safety buffer.
+#   2. Enable smoothing: EMA_ALPHA = 0.3, DEADBAND_WATTS = 20
+#   3. Start P-only: PID_KP = 0.5, PID_KI = 0, PID_KD = 0
+#   4. Observe grid meter for 10–30 min.  If oscillating, reduce Kp (e.g. 0.4).
+#      If response is too slow, try 0.6.
+#   5. Keep PID_KI = 0 unless you need to eliminate steady-state error and
+#      understand anti-windup limitations.
+#
+# Can be overridden per powermeter section
+PID_KP = 0
+PID_KI = 0
+PID_KD = 0
+PID_OUTPUT_MAX = 800
+PID_MODE = bias
 
 #[SHELLY]
 #TYPE = 1PM #PLUS1PM #EM #3EM #3EMPRO
@@ -86,6 +131,12 @@ HOLD_TIME = 0
 #HOLD_TIME = 0
 ## Per-powermeter power offset override in watts (optional, can be negative)
 #POWER_OFFSET = 0
+## Per-powermeter PID controller overrides (optional)
+#PID_KP = 0
+#PID_KI = 0
+#PID_KD = 0
+#PID_OUTPUT_MAX = 800
+#PID_MODE = bias
 
 #[TASMOTA]
 #IP = 192.168.1.101

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -66,6 +66,7 @@ def read_all_powermeter_configs(
         "GENERAL", "THROTTLE_INTERVAL", fallback=0.0
     )
     global_ema_alpha = config.getfloat("GENERAL", "EMA_ALPHA", fallback=0.0)
+    global_ema_interval = config.getfloat("GENERAL", "EMA_INTERVAL", fallback=0.0)
     global_power_offset = config.getfloat("GENERAL", "POWER_OFFSET", fallback=0.0)
 
     for section in config.sections():
@@ -99,11 +100,25 @@ def read_all_powermeter_configs(
                     if config.has_option(section, "EMA_ALPHA")
                     else "global"
                 )
-                print(
-                    f"Applying {ema_source} EMA smoothing (alpha={section_ema_alpha}) to {section}"
+                section_ema_interval = config.getfloat(
+                    section, "EMA_INTERVAL", fallback=global_ema_interval
                 )
+                if section_ema_interval > 0:
+                    ema_interval_source = (
+                        "section-specific"
+                        if config.has_option(section, "EMA_INTERVAL")
+                        else "global"
+                    )
+                    print(
+                        f"Applying {ema_source} EMA smoothing (alpha={section_ema_alpha}, "
+                        f"{ema_interval_source} interval={section_ema_interval}s) to {section}"
+                    )
+                else:
+                    print(
+                        f"Applying {ema_source} EMA smoothing (alpha={section_ema_alpha}) to {section}"
+                    )
                 powermeter = ExponentialMovingAveragePowermeter(
-                    powermeter, alpha=section_ema_alpha
+                    powermeter, alpha=section_ema_alpha, ema_interval=section_ema_interval
                 )
 
             section_power_offset = config.getfloat(

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -151,11 +151,11 @@ def read_all_powermeter_configs(
             section_ema_alpha = safe_getfloat(
                 config, section, "EMA_ALPHA", fallback=global_ema_alpha
             )
+            if section_ema_alpha < 0 or section_ema_alpha > 1.0:
+                raise ValueError(
+                    f"EMA_ALPHA in [{section}] must be 0 (disabled) or in the range (0, 1], got {section_ema_alpha}"
+                )
             if section_ema_alpha > 0:
-                if section_ema_alpha > 1.0:
-                    raise ValueError(
-                        f"EMA_ALPHA in [{section}] must be in the range (0, 1], got {section_ema_alpha}"
-                    )
                 ema_source = (
                     "section-specific"
                     if config.has_option(section, "EMA_ALPHA")

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -26,6 +26,9 @@ from powermeter import (
     ThrottledPowermeter,
     ExponentialMovingAveragePowermeter,
     OffsetPowermeter,
+    SlewRatePowermeter,
+    DeadBandPowermeter,
+    HoldTimerPowermeter,
 )
 
 SHELLY_SECTION = "SHELLY"
@@ -67,6 +70,11 @@ def read_all_powermeter_configs(
     )
     global_ema_alpha = config.getfloat("GENERAL", "EMA_ALPHA", fallback=0.0)
     global_ema_interval = config.getfloat("GENERAL", "EMA_INTERVAL", fallback=0.0)
+    global_slew_rate = config.getfloat(
+        "GENERAL", "SLEW_RATE_WATTS_PER_SEC", fallback=0.0
+    )
+    global_deadband_watts = config.getfloat("GENERAL", "DEADBAND_WATTS", fallback=0.0)
+    global_hold_time = config.getfloat("GENERAL", "HOLD_TIME", fallback=0.0)
     global_power_offset = config.getfloat("GENERAL", "POWER_OFFSET", fallback=0.0)
 
     for section in config.sections():
@@ -120,6 +128,48 @@ def read_all_powermeter_configs(
                 powermeter = ExponentialMovingAveragePowermeter(
                     powermeter, alpha=section_ema_alpha, ema_interval=section_ema_interval
                 )
+
+            section_slew_rate = config.getfloat(
+                section, "SLEW_RATE_WATTS_PER_SEC", fallback=global_slew_rate
+            )
+            if section_slew_rate > 0:
+                slew_source = (
+                    "section-specific"
+                    if config.has_option(section, "SLEW_RATE_WATTS_PER_SEC")
+                    else "global"
+                )
+                print(
+                    f"Applying {slew_source} slew-rate limit ({section_slew_rate} W/s) to {section}"
+                )
+                powermeter = SlewRatePowermeter(powermeter, section_slew_rate)
+
+            section_deadband_watts = config.getfloat(
+                section, "DEADBAND_WATTS", fallback=global_deadband_watts
+            )
+            if section_deadband_watts > 0:
+                deadband_source = (
+                    "section-specific"
+                    if config.has_option(section, "DEADBAND_WATTS")
+                    else "global"
+                )
+                print(
+                    f"Applying {deadband_source} dead-band filter ({section_deadband_watts} W) to {section}"
+                )
+                powermeter = DeadBandPowermeter(powermeter, section_deadband_watts)
+
+            section_hold_time = config.getfloat(
+                section, "HOLD_TIME", fallback=global_hold_time
+            )
+            if section_hold_time > 0:
+                hold_source = (
+                    "section-specific"
+                    if config.has_option(section, "HOLD_TIME")
+                    else "global"
+                )
+                print(
+                    f"Applying {hold_source} hold timer ({section_hold_time}s) to {section}"
+                )
+                powermeter = HoldTimerPowermeter(powermeter, section_hold_time)
 
             section_power_offset = config.getfloat(
                 section, "POWER_OFFSET", fallback=global_power_offset

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -25,6 +25,7 @@ from powermeter import (
     TQEnergyManager,
     ThrottledPowermeter,
     ExponentialMovingAveragePowermeter,
+    OffsetPowermeter,
 )
 
 SHELLY_SECTION = "SHELLY"
@@ -65,6 +66,7 @@ def read_all_powermeter_configs(
         "GENERAL", "THROTTLE_INTERVAL", fallback=0.0
     )
     global_ema_alpha = config.getfloat("GENERAL", "EMA_ALPHA", fallback=0.0)
+    global_power_offset = config.getfloat("GENERAL", "POWER_OFFSET", fallback=0.0)
 
     for section in config.sections():
         powermeter = create_powermeter(section, config)
@@ -103,6 +105,20 @@ def read_all_powermeter_configs(
                 powermeter = ExponentialMovingAveragePowermeter(
                     powermeter, alpha=section_ema_alpha
                 )
+
+            section_power_offset = config.getfloat(
+                section, "POWER_OFFSET", fallback=global_power_offset
+            )
+            if section_power_offset != 0.0:
+                offset_source = (
+                    "section-specific"
+                    if config.has_option(section, "POWER_OFFSET")
+                    else "global"
+                )
+                print(
+                    f"Applying {offset_source} power offset ({section_power_offset}W) to {section}"
+                )
+                powermeter = OffsetPowermeter(powermeter, offset=section_power_offset)
 
             client_filter = create_client_filter(section, config)
             powermeters.append((powermeter, client_filter))

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -3,6 +3,42 @@ from ipaddress import IPv4Network, IPv4Address
 from typing import List, Union, Tuple
 from config.logger import logger
 
+
+def safe_getboolean(config: configparser.ConfigParser, section: str, option: str, fallback: bool) -> bool:
+    """Like config.getboolean but logs a warning and uses fallback on invalid values."""
+    try:
+        return config.getboolean(section, option, fallback=fallback)
+    except ValueError:
+        raw = config.get(section, option, fallback=str(fallback))
+        logger.warning(
+            f"Invalid boolean value '{raw}' for [{section}] {option}; using fallback '{fallback}'"
+        )
+        return fallback
+
+
+def safe_getint(config: configparser.ConfigParser, section: str, option: str, fallback: int) -> int:
+    """Like config.getint but logs a warning and uses fallback on invalid values."""
+    try:
+        return config.getint(section, option, fallback=fallback)
+    except ValueError:
+        raw = config.get(section, option, fallback=str(fallback))
+        logger.warning(
+            f"Invalid integer value '{raw}' for [{section}] {option}; using fallback '{fallback}'"
+        )
+        return fallback
+
+
+def safe_getfloat(config: configparser.ConfigParser, section: str, option: str, fallback: float) -> float:
+    """Like config.getfloat but logs a warning and uses fallback on invalid values."""
+    try:
+        return config.getfloat(section, option, fallback=fallback)
+    except ValueError:
+        raw = config.get(section, option, fallback=str(fallback))
+        logger.warning(
+            f"Invalid float value '{raw}' for [{section}] {option}; using fallback '{fallback}'"
+        )
+        return fallback
+
 from powermeter import (
     Powermeter,
     Tasmota,
@@ -65,23 +101,23 @@ def read_all_powermeter_configs(
     config: configparser.ConfigParser,
 ) -> List[Tuple[Powermeter, ClientFilter]]:
     powermeters = []
-    global_throttle_interval = config.getfloat(
-        "GENERAL", "THROTTLE_INTERVAL", fallback=0.0
+    global_throttle_interval = safe_getfloat(
+        config, "GENERAL", "THROTTLE_INTERVAL", fallback=0.0
     )
-    global_ema_alpha = config.getfloat("GENERAL", "EMA_ALPHA", fallback=0.0)
-    global_ema_interval = config.getfloat("GENERAL", "EMA_INTERVAL", fallback=0.0)
-    global_slew_rate = config.getfloat(
-        "GENERAL", "SLEW_RATE_WATTS_PER_SEC", fallback=0.0
+    global_ema_alpha = safe_getfloat(config, "GENERAL", "EMA_ALPHA", fallback=0.0)
+    global_ema_interval = safe_getfloat(config, "GENERAL", "EMA_INTERVAL", fallback=0.0)
+    global_slew_rate = safe_getfloat(
+        config, "GENERAL", "SLEW_RATE_WATTS_PER_SEC", fallback=0.0
     )
-    global_deadband_watts = config.getfloat("GENERAL", "DEADBAND_WATTS", fallback=0.0)
-    global_hold_time = config.getfloat("GENERAL", "HOLD_TIME", fallback=0.0)
-    global_power_offset = config.getfloat("GENERAL", "POWER_OFFSET", fallback=0.0)
+    global_deadband_watts = safe_getfloat(config, "GENERAL", "DEADBAND_WATTS", fallback=0.0)
+    global_hold_time = safe_getfloat(config, "GENERAL", "HOLD_TIME", fallback=0.0)
+    global_power_offset = safe_getfloat(config, "GENERAL", "POWER_OFFSET", fallback=0.0)
 
     for section in config.sections():
         powermeter = create_powermeter(section, config)
         if powermeter is not None:
-            section_throttle_interval = config.getfloat(
-                section, "THROTTLE_INTERVAL", fallback=global_throttle_interval
+            section_throttle_interval = safe_getfloat(
+                config, section, "THROTTLE_INTERVAL", fallback=global_throttle_interval
             )
 
             if section_throttle_interval > 0:
@@ -95,8 +131,8 @@ def read_all_powermeter_configs(
                 )
                 powermeter = ThrottledPowermeter(powermeter, section_throttle_interval)
 
-            section_ema_alpha = config.getfloat(
-                section, "EMA_ALPHA", fallback=global_ema_alpha
+            section_ema_alpha = safe_getfloat(
+                config, section, "EMA_ALPHA", fallback=global_ema_alpha
             )
             if section_ema_alpha > 0:
                 if section_ema_alpha > 1.0:
@@ -108,8 +144,8 @@ def read_all_powermeter_configs(
                     if config.has_option(section, "EMA_ALPHA")
                     else "global"
                 )
-                section_ema_interval = config.getfloat(
-                    section, "EMA_INTERVAL", fallback=global_ema_interval
+                section_ema_interval = safe_getfloat(
+                    config, section, "EMA_INTERVAL", fallback=global_ema_interval
                 )
                 if section_ema_interval > 0:
                     ema_interval_source = (
@@ -129,8 +165,8 @@ def read_all_powermeter_configs(
                     powermeter, alpha=section_ema_alpha, ema_interval=section_ema_interval
                 )
 
-            section_slew_rate = config.getfloat(
-                section, "SLEW_RATE_WATTS_PER_SEC", fallback=global_slew_rate
+            section_slew_rate = safe_getfloat(
+                config, section, "SLEW_RATE_WATTS_PER_SEC", fallback=global_slew_rate
             )
             if section_slew_rate > 0:
                 slew_source = (
@@ -143,8 +179,8 @@ def read_all_powermeter_configs(
                 )
                 powermeter = SlewRatePowermeter(powermeter, section_slew_rate)
 
-            section_deadband_watts = config.getfloat(
-                section, "DEADBAND_WATTS", fallback=global_deadband_watts
+            section_deadband_watts = safe_getfloat(
+                config, section, "DEADBAND_WATTS", fallback=global_deadband_watts
             )
             if section_deadband_watts > 0:
                 deadband_source = (
@@ -157,8 +193,8 @@ def read_all_powermeter_configs(
                 )
                 powermeter = DeadBandPowermeter(powermeter, section_deadband_watts)
 
-            section_hold_time = config.getfloat(
-                section, "HOLD_TIME", fallback=global_hold_time
+            section_hold_time = safe_getfloat(
+                config, section, "HOLD_TIME", fallback=global_hold_time
             )
             if section_hold_time > 0:
                 hold_source = (
@@ -171,8 +207,8 @@ def read_all_powermeter_configs(
                 )
                 powermeter = HoldTimerPowermeter(powermeter, section_hold_time)
 
-            section_power_offset = config.getfloat(
-                section, "POWER_OFFSET", fallback=global_power_offset
+            section_power_offset = safe_getfloat(
+                config, section, "POWER_OFFSET", fallback=global_power_offset
             )
             if section_power_offset != 0.0:
                 offset_source = (
@@ -271,7 +307,7 @@ def create_mqtt_powermeter(
 ) -> Powermeter:
     return MqttPowermeter(
         config.get(section, "BROKER", fallback=""),
-        config.getint(section, "PORT", fallback=1883),
+        safe_getint(config, section, "PORT", fallback=1883),
         config.get(section, "TOPIC", fallback=""),
         config.get(section, "JSON_PATH", fallback=None),
         config.get(section, "USERNAME", fallback=None),
@@ -314,10 +350,10 @@ def create_modbus_powermeter(
 ) -> Powermeter:
     return ModbusPowermeter(
         config.get(section, "HOST", fallback=""),
-        config.getint(section, "PORT", fallback=502),
-        config.getint(section, "UNIT_ID", fallback=1),
-        config.getint(section, "ADDRESS", fallback=0),
-        config.getint(section, "COUNT", fallback=1),
+        safe_getint(config, section, "PORT", fallback=502),
+        safe_getint(config, section, "UNIT_ID", fallback=1),
+        safe_getint(config, section, "ADDRESS", fallback=0),
+        safe_getint(config, section, "COUNT", fallback=1),
         config.get(section, "DATA_TYPE", fallback="UINT16"),
         config.get(section, "BYTE_ORDER", fallback="BIG"),
         config.get(section, "WORD_ORDER", fallback="BIG"),
@@ -370,10 +406,10 @@ def create_homeassistant_powermeter(
     return HomeAssistant(
         config.get(section, "IP", fallback=""),
         config.get(section, "PORT", fallback=""),
-        config.getboolean(section, "HTTPS", fallback=False),
+        safe_getboolean(config, section, "HTTPS", fallback=False),
         config.get(section, "ACCESSTOKEN", fallback=""),
         current_power_entity,
-        config.getboolean(section, "POWER_CALCULATE", fallback=False),
+        safe_getboolean(config, section, "POWER_CALCULATE", fallback=False),
         power_input_alias,
         power_output_alias,
         config.get(section, "API_PATH_PREFIX", fallback=None),
@@ -387,7 +423,7 @@ def create_iobroker_powermeter(
         config.get(section, "IP", fallback=""),
         config.get(section, "PORT", fallback=""),
         config.get(section, "CURRENT_POWER_ALIAS", fallback=""),
-        config.getboolean(section, "POWER_CALCULATE", fallback=False),
+        safe_getboolean(config, section, "POWER_CALCULATE", fallback=False),
         config.get(section, "POWER_INPUT_ALIAS", fallback=""),
         config.get(section, "POWER_OUTPUT_ALIAS", fallback=""),
     )
@@ -399,7 +435,7 @@ def create_emlog_powermeter(
     return Emlog(
         config.get(section, "IP", fallback=""),
         config.get(section, "METER_INDEX", fallback=""),
-        config.getboolean(section, "JSON_POWER_CALCULATE", fallback=False),
+        safe_getboolean(config, section, "JSON_POWER_CALCULATE", fallback=False),
     )
 
 
@@ -425,7 +461,7 @@ def create_tasmota_powermeter(
         config.get(section, "JSON_POWER_MQTT_LABEL", fallback=""),
         config.get(section, "JSON_POWER_INPUT_MQTT_LABEL", fallback=""),
         config.get(section, "JSON_POWER_OUTPUT_MQTT_LABEL", fallback=""),
-        config.getboolean(section, "JSON_POWER_CALCULATE", fallback=False),
+        safe_getboolean(config, section, "JSON_POWER_CALCULATE", fallback=False),
     )
 
 
@@ -435,5 +471,5 @@ def create_tq_em_powermeter(
     return TQEnergyManager(
         config.get(section, "IP", fallback=""),
         config.get(section, "PASSWORD", fallback=""),
-        timeout=config.getfloat(section, "TIMEOUT", fallback=5.0),
+        timeout=safe_getfloat(config, section, "TIMEOUT", fallback=5.0),
     )

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -24,6 +24,7 @@ from powermeter import (
     JsonHttpPowermeter,
     TQEnergyManager,
     ThrottledPowermeter,
+    ExponentialMovingAveragePowermeter,
 )
 
 SHELLY_SECTION = "SHELLY"
@@ -63,6 +64,7 @@ def read_all_powermeter_configs(
     global_throttle_interval = config.getfloat(
         "GENERAL", "THROTTLE_INTERVAL", fallback=0.0
     )
+    global_ema_alpha = config.getfloat("GENERAL", "EMA_ALPHA", fallback=0.0)
 
     for section in config.sections():
         powermeter = create_powermeter(section, config)
@@ -81,6 +83,26 @@ def read_all_powermeter_configs(
                     f"Applying {throttle_source} throttling ({section_throttle_interval}s) to {section}"
                 )
                 powermeter = ThrottledPowermeter(powermeter, section_throttle_interval)
+
+            section_ema_alpha = config.getfloat(
+                section, "EMA_ALPHA", fallback=global_ema_alpha
+            )
+            if section_ema_alpha > 0:
+                if section_ema_alpha > 1.0:
+                    raise ValueError(
+                        f"EMA_ALPHA in [{section}] must be in the range (0, 1], got {section_ema_alpha}"
+                    )
+                ema_source = (
+                    "section-specific"
+                    if config.has_option(section, "EMA_ALPHA")
+                    else "global"
+                )
+                print(
+                    f"Applying {ema_source} EMA smoothing (alpha={section_ema_alpha}) to {section}"
+                )
+                powermeter = ExponentialMovingAveragePowermeter(
+                    powermeter, alpha=section_ema_alpha
+                )
 
             client_filter = create_client_filter(section, config)
             powermeters.append((powermeter, client_filter))

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -4,7 +4,9 @@ from typing import List, Union, Tuple
 from config.logger import logger
 
 
-def safe_getboolean(config: configparser.ConfigParser, section: str, option: str, fallback: bool) -> bool:
+def safe_getboolean(
+    config: configparser.ConfigParser, section: str, option: str, fallback: bool
+) -> bool:
     """Like config.getboolean but logs a warning and uses fallback on invalid values."""
     try:
         return config.getboolean(section, option, fallback=fallback)
@@ -16,7 +18,9 @@ def safe_getboolean(config: configparser.ConfigParser, section: str, option: str
         return fallback
 
 
-def safe_getint(config: configparser.ConfigParser, section: str, option: str, fallback: int) -> int:
+def safe_getint(
+    config: configparser.ConfigParser, section: str, option: str, fallback: int
+) -> int:
     """Like config.getint but logs a warning and uses fallback on invalid values."""
     try:
         return config.getint(section, option, fallback=fallback)
@@ -28,7 +32,9 @@ def safe_getint(config: configparser.ConfigParser, section: str, option: str, fa
         return fallback
 
 
-def safe_getfloat(config: configparser.ConfigParser, section: str, option: str, fallback: float) -> float:
+def safe_getfloat(
+    config: configparser.ConfigParser, section: str, option: str, fallback: float
+) -> float:
     """Like config.getfloat but logs a warning and uses fallback on invalid values."""
     try:
         return config.getfloat(section, option, fallback=fallback)
@@ -38,6 +44,7 @@ def safe_getfloat(config: configparser.ConfigParser, section: str, option: str, 
             f"Invalid float value '{raw}' for [{section}] {option}; using fallback '{fallback}'"
         )
         return fallback
+
 
 from powermeter import (
     Powermeter,
@@ -65,6 +72,7 @@ from powermeter import (
     SlewRatePowermeter,
     DeadBandPowermeter,
     HoldTimerPowermeter,
+    PidPowermeter,
 )
 
 SHELLY_SECTION = "SHELLY"
@@ -109,9 +117,18 @@ def read_all_powermeter_configs(
     global_slew_rate = safe_getfloat(
         config, "GENERAL", "SLEW_RATE_WATTS_PER_SEC", fallback=0.0
     )
-    global_deadband_watts = safe_getfloat(config, "GENERAL", "DEADBAND_WATTS", fallback=0.0)
+    global_deadband_watts = safe_getfloat(
+        config, "GENERAL", "DEADBAND_WATTS", fallback=0.0
+    )
     global_hold_time = safe_getfloat(config, "GENERAL", "HOLD_TIME", fallback=0.0)
     global_power_offset = safe_getfloat(config, "GENERAL", "POWER_OFFSET", fallback=0.0)
+    global_pid_kp = safe_getfloat(config, "GENERAL", "PID_KP", fallback=0.0)
+    global_pid_ki = safe_getfloat(config, "GENERAL", "PID_KI", fallback=0.0)
+    global_pid_kd = safe_getfloat(config, "GENERAL", "PID_KD", fallback=0.0)
+    global_pid_output_max = safe_getfloat(
+        config, "GENERAL", "PID_OUTPUT_MAX", fallback=800.0
+    )
+    global_pid_mode = config.get("GENERAL", "PID_MODE", fallback="bias").strip().lower()
 
     for section in config.sections():
         powermeter = create_powermeter(section, config)
@@ -162,7 +179,9 @@ def read_all_powermeter_configs(
                         f"Applying {ema_source} EMA smoothing (alpha={section_ema_alpha}) to {section}"
                     )
                 powermeter = ExponentialMovingAveragePowermeter(
-                    powermeter, alpha=section_ema_alpha, ema_interval=section_ema_interval
+                    powermeter,
+                    alpha=section_ema_alpha,
+                    ema_interval=section_ema_interval,
                 )
 
             section_slew_rate = safe_getfloat(
@@ -220,6 +239,45 @@ def read_all_powermeter_configs(
                     f"Applying {offset_source} power offset ({section_power_offset}W) to {section}"
                 )
                 powermeter = OffsetPowermeter(powermeter, offset=section_power_offset)
+
+            section_pid_kp = safe_getfloat(
+                config, section, "PID_KP", fallback=global_pid_kp
+            )
+            if section_pid_kp > 0:
+                pid_source = (
+                    "section-specific"
+                    if config.has_option(section, "PID_KP")
+                    else "global"
+                )
+                section_pid_ki = safe_getfloat(
+                    config, section, "PID_KI", fallback=global_pid_ki
+                )
+                section_pid_kd = safe_getfloat(
+                    config, section, "PID_KD", fallback=global_pid_kd
+                )
+                section_pid_output_max = safe_getfloat(
+                    config, section, "PID_OUTPUT_MAX", fallback=global_pid_output_max
+                )
+                section_pid_mode = (
+                    config.get(section, "PID_MODE", fallback=global_pid_mode)
+                    .strip()
+                    .lower()
+                )
+                print(
+                    f"Applying {pid_source} PID controller "
+                    f"(Kp={section_pid_kp}, Ki={section_pid_ki}, "
+                    f"Kd={section_pid_kd}, "
+                    f"max={section_pid_output_max}W, mode={section_pid_mode}) "
+                    f"to {section}"
+                )
+                powermeter = PidPowermeter(
+                    powermeter,
+                    kp=section_pid_kp,
+                    ki=section_pid_ki,
+                    kd=section_pid_kd,
+                    output_max=section_pid_output_max,
+                    mode=section_pid_mode,
+                )
 
             client_filter = create_client_filter(section, config)
             powermeters.append((powermeter, client_filter))

--- a/config/config_loader_test.py
+++ b/config/config_loader_test.py
@@ -20,6 +20,9 @@ from config.config_loader import (
     create_mqtt_powermeter,
     create_json_http_powermeter,
     create_tq_em_powermeter,
+    safe_getboolean,
+    safe_getint,
+    safe_getfloat,
 )
 import unittest
 from unittest.mock import patch, Mock
@@ -299,6 +302,76 @@ def test_read_all_powermeter_configs():
         # Some powermeters might fail due to connection issues, but the function should run
         assert isinstance(powermeters, list)
 
+    except Exception as e:
+        if "Connection" not in str(e) and "timed out" not in str(e):
+            raise
+
+
+def test_safe_getboolean_valid():
+    """safe_getboolean returns the correct value for valid boolean strings."""
+    config = configparser.ConfigParser()
+    config["S"] = {"FLAG": "true"}
+    assert safe_getboolean(config, "S", "FLAG", fallback=False) is True
+
+
+def test_safe_getboolean_typo_uses_fallback():
+    """safe_getboolean returns the fallback and does not raise on a typo value."""
+    config = configparser.ConfigParser()
+    config["S"] = {"FLAG": "Flase"}
+    result = safe_getboolean(config, "S", "FLAG", fallback=False)
+    assert result is False
+
+
+def test_safe_getboolean_missing_uses_fallback():
+    """safe_getboolean returns the fallback when the key is absent."""
+    config = configparser.ConfigParser()
+    config["S"] = {}
+    assert safe_getboolean(config, "S", "MISSING", fallback=True) is True
+
+
+def test_safe_getint_valid():
+    """safe_getint returns the correct integer for a valid value."""
+    config = configparser.ConfigParser()
+    config["S"] = {"PORT": "8080"}
+    assert safe_getint(config, "S", "PORT", fallback=80) == 8080
+
+
+def test_safe_getint_typo_uses_fallback():
+    """safe_getint returns the fallback and does not raise on a typo value."""
+    config = configparser.ConfigParser()
+    config["S"] = {"PORT": "80xx"}
+    result = safe_getint(config, "S", "PORT", fallback=1883)
+    assert result == 1883
+
+
+def test_safe_getfloat_valid():
+    """safe_getfloat returns the correct float for a valid value."""
+    config = configparser.ConfigParser()
+    config["S"] = {"INTERVAL": "1.5"}
+    assert safe_getfloat(config, "S", "INTERVAL", fallback=0.0) == 1.5
+
+
+def test_safe_getfloat_typo_uses_fallback():
+    """safe_getfloat returns the fallback and does not raise on a typo value."""
+    config = configparser.ConfigParser()
+    config["S"] = {"INTERVAL": "1.5s"}
+    result = safe_getfloat(config, "S", "INTERVAL", fallback=0.0)
+    assert result == 0.0
+
+
+def test_read_all_powermeter_configs_typo_in_general():
+    """read_all_powermeter_configs does not raise when GENERAL section has typo'd numeric values."""
+    config = configparser.ConfigParser()
+    config["GENERAL"] = {
+        "THROTTLE_INTERVAL": "bad_value",
+        "EMA_ALPHA": "not_a_float",
+        "DEADBAND_WATTS": "50abc",
+    }
+    config["TASMOTA_1"] = {"IP": "127.0.0.1"}
+    # Should not raise even with invalid values in GENERAL
+    try:
+        powermeters = read_all_powermeter_configs(config)
+        assert isinstance(powermeters, list)
     except Exception as e:
         if "Connection" not in str(e) and "timed out" not in str(e):
             raise

--- a/health_service.py
+++ b/health_service.py
@@ -3,99 +3,223 @@ Health Check Service for B2500 Meter
 
 Provides HTTP health check endpoints for monitoring service health.
 Compatible with both Home Assistant addon watchdog and Docker health checks.
+
+Also serves a web-based configuration editor at /config.
 """
 
+import json
+import os
 import threading
 import time
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from config.logger import logger
+from web_config import (
+    CONFIG_EDITOR_HTML,
+    config_to_json,
+    write_config_from_dict,
+)
 
 
 class HealthCheckHandler(BaseHTTPRequestHandler):
-    """HTTP handler for health check endpoints."""
-    
+    """HTTP handler for health check endpoints and the config editor."""
+
+    # Set by HealthCheckService before the server starts
+    config_path = None
+    enable_web_config = False
+
     def do_GET(self):
-        """Handle GET requests to health check endpoints."""
-        # Normalize path to handle trailing slashes
-        normalized_path = self.path.rstrip('/')
-        if normalized_path in ['/health', '/api']:
-            logger.debug(f"Health check request received from {self.client_address[0]}:{self.client_address[1]}")
+        """Handle GET requests."""
+        normalized_path = self.path.split("?")[0].rstrip("/")
+
+        if normalized_path in ("/health", "/api"):
+            logger.debug(
+                f"Health check request received from "
+                f"{self.client_address[0]}:{self.client_address[1]}"
+            )
             self.send_response(200)
-            self.send_header('Content-type', 'application/json')
-            self.send_header('Cache-Control', 'no-cache')
+            self.send_header("Content-type", "application/json")
+            self.send_header("Cache-Control", "no-cache")
             self.end_headers()
-            response = b'{"status": "healthy", "service": "b2500-meter"}'
-            self.wfile.write(response)
+            self.wfile.write(b'{"status": "healthy", "service": "b2500-meter"}')
+
+        elif normalized_path == "":
+            # Redirect root to /config when enabled, otherwise to /health
+            target = "/config" if self.enable_web_config else "/health"
+            self.send_response(302)
+            self.send_header("Location", target)
+            self.end_headers()
+
+        elif normalized_path == "/config":
+            if not self.enable_web_config:
+                self._json_response(404, {"error": "Not Found"})
+                return
+            self.send_response(200)
+            self.send_header("Content-type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(CONFIG_EDITOR_HTML.encode("utf-8"))
+
+        elif normalized_path == "/api/config":
+            if not self.enable_web_config:
+                self._json_response(404, {"error": "Not Found"})
+                return
+            if self.config_path is None:
+                self._json_response(
+                    500, {"error": "Config path not set"}
+                )
+                return
+            try:
+                payload = config_to_json(self.config_path)
+                self.send_response(200)
+                self.send_header("Content-type", "application/json")
+                self.send_header("Cache-Control", "no-cache")
+                self.end_headers()
+                self.wfile.write(payload.encode("utf-8"))
+            except Exception as e:
+                logger.error(f"Error reading config: {e}")
+                self._json_response(500, {"error": str(e)})
+
         else:
-            logger.debug(f"Invalid request {self.path} from {self.client_address[0]}:{self.client_address[1]}")
-            self.send_response(404)
-            self.send_header('Content-type', 'application/json')
-            self.end_headers()
-            response = b'{"error": "Not Found"}'
-            self.wfile.write(response)
-    
+            logger.debug(
+                f"Invalid request {self.path} from "
+                f"{self.client_address[0]}:{self.client_address[1]}"
+            )
+            self._json_response(404, {"error": "Not Found"})
+
+    def do_POST(self):
+        """Handle POST requests."""
+        normalized_path = self.path.split("?")[0].rstrip("/")
+
+        if normalized_path == "/api/config":
+            if not self.enable_web_config:
+                self._json_response(404, {"error": "Not Found"})
+                return
+            if self.config_path is None:
+                self._json_response(500, {"error": "Config path not set"})
+                return
+            try:
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length)
+                data = json.loads(body.decode("utf-8"))
+                sections = data.get("sections", {})
+                order = data.get("order", list(sections.keys()))
+                write_config_from_dict(self.config_path, sections, order)
+                logger.info("Configuration updated via web UI")
+                self._json_response(200, {"success": True})
+            except Exception as e:
+                logger.error(f"Error saving config: {e}")
+                self._json_response(500, {"error": str(e)})
+
+        elif normalized_path == "/api/restart":
+            if not self.enable_web_config:
+                self._json_response(404, {"error": "Not Found"})
+                return
+            self._json_response(200, {"success": True, "message": "Service is restarting..."})
+            logger.info("Restart requested via web UI")
+            # Use os._exit() rather than SIGTERM so the process terminates
+            # unconditionally even when the main thread is blocked in native I/O.
+            # Docker (restart: unless-stopped) will restart the container with
+            # the updated config.ini loaded from scratch.
+            _RESTART_DELAY_SECONDS = 0.5
+            threading.Timer(_RESTART_DELAY_SECONDS, lambda: os._exit(0)).start()
+
+        else:
+            self._json_response(404, {"error": "Not Found"})
+
     def do_HEAD(self):
         """Handle HEAD requests (some health checkers use HEAD)."""
-        # Normalize path to handle trailing slashes
-        normalized_path = self.path.rstrip('/')
-        if normalized_path in ['/health', '/api']:
+        normalized_path = self.path.split("?")[0].rstrip("/")
+        if normalized_path in ("/health", "/api"):
             self.send_response(200)
-            self.send_header('Content-type', 'application/json')
-            self.send_header('Cache-Control', 'no-cache')
+            self.send_header("Content-type", "application/json")
+            self.send_header("Cache-Control", "no-cache")
             self.end_headers()
         else:
             self.send_response(404)
             self.end_headers()
-    
+
+    def _json_response(self, status: int, payload: dict):
+        """Send a JSON response with the given HTTP status code."""
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-type", "application/json")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def handle(self):
+        """Handle a request, suppressing broken-pipe errors from clients that disconnect early."""
+        try:
+            super().handle()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
     def log_message(self, format, *args):
         """Suppress default HTTP server logging to avoid spam."""
         pass
 
 
 class HealthCheckService:
-    """Health check service manager."""
-    
-    def __init__(self, port=52500, bind_address='0.0.0.0'):
+    """Health check and configuration-editor service manager."""
+
+    def __init__(self, port=52500, bind_address="0.0.0.0", config_path=None, enable_web_config=False):
         self.port = port
         self.bind_address = bind_address
+        self.config_path = config_path
+        self.enable_web_config = enable_web_config
         self.server = None
         self.server_thread = None
         self._running = False
-    
+
     def start(self):
-        """Start the health check HTTP server."""
+        """Start the HTTP server (health check + config editor)."""
         if self._running:
             logger.warning("Health check service is already running")
             return False
-        
+
         try:
+            # Inject config_path and enable_web_config into the handler class before binding.
+            HealthCheckHandler.config_path = self.config_path
+            HealthCheckHandler.enable_web_config = self.enable_web_config
+
             self.server = HTTPServer((self.bind_address, self.port), HealthCheckHandler)
             self.server_thread = threading.Thread(
-                target=self._run_server, 
+                target=self._run_server,
                 name="HealthCheckService",
-                daemon=True
+                daemon=True,
             )
             self.server_thread.start()
-            
+
             # Give the server a moment to start and verify it's working
             time.sleep(0.5)
             if not self.server_thread.is_alive():
                 logger.error("Health check service thread failed to start")
                 return False
-                
+
             self._running = True
-            logger.info(f"Health check service started on {self.bind_address}:{self.port}")
-            
+            logger.info(
+                f"Health check service started on {self.bind_address}:{self.port}"
+            )
+            if self.enable_web_config and self.config_path:
+                logger.info(
+                    f"Config editor enabled — accessible at "
+                    f"http://{self.bind_address}:{self.port}/config"
+                )
+            else:
+                logger.info(
+                    "Config editor disabled (WEB_CONFIG_ENABLED = False)"
+                )
+
             # Test the endpoint to ensure it's working
             if self.test_endpoint():
                 logger.debug("Health check endpoint test passed")
             else:
                 logger.warning("Health check endpoint test failed, but service is running")
-                
+
             return True
         except OSError as e:
             if e.errno == 98:  # Address already in use
-                logger.error(f"Port {self.port} is already in use. Health check service not started.")
+                logger.error(
+                    f"Port {self.port} is already in use. Health check service not started."
+                )
             else:
                 logger.error(f"Failed to bind to {self.bind_address}:{self.port}: {e}")
             return False
@@ -151,24 +275,29 @@ class HealthCheckService:
 _health_service = None
 
 
-def start_health_service(port=52500, bind_address='0.0.0.0'):
+def start_health_service(port=52500, bind_address="0.0.0.0", config_path=None, enable_web_config=False):
     """
     Start the global health check service.
-    
+
     Args:
         port (int): Port to bind to (default: 52500)
-        bind_address (str): Address to bind to (default: 'localhost')
-    
+        bind_address (str): Address to bind to (default: '0.0.0.0')
+        config_path (str | None): Path to config.ini for the web editor
+        enable_web_config (bool): Whether to enable the web config editor (default: False)
+
     Returns:
         bool: True if started successfully, False otherwise
     """
     global _health_service
-    
+
     if _health_service and _health_service.is_running():
         logger.debug("Health service already running")
         return True
-    
-    _health_service = HealthCheckService(port=port, bind_address=bind_address)
+
+    _health_service = HealthCheckService(
+        port=port, bind_address=bind_address, config_path=config_path,
+        enable_web_config=enable_web_config,
+    )
     return _health_service.start()
 
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, List, Tuple
-from config.config_loader import read_all_powermeter_configs, ClientFilter
+from config.config_loader import read_all_powermeter_configs, ClientFilter, safe_getboolean, safe_getint
 from ct001 import CT001
 from powermeter import Powermeter
 from shelly import Shelly
@@ -62,17 +62,17 @@ def run_device(
         disable_sum = (
             args.disable_sum
             if args.disable_sum is not None
-            else cfg.getboolean("GENERAL", "DISABLE_SUM_PHASES", fallback=False)
+            else safe_getboolean(cfg, "GENERAL", "DISABLE_SUM_PHASES", fallback=False)
         )
         disable_absolute = (
             args.disable_absolute
             if args.disable_absolute is not None
-            else cfg.getboolean("GENERAL", "DISABLE_ABSOLUTE_VALUES", fallback=False)
+            else safe_getboolean(cfg, "GENERAL", "DISABLE_ABSOLUTE_VALUES", fallback=False)
         )
         poll_interval = (
             args.poll_interval
             if args.poll_interval is not None
-            else cfg.getint("GENERAL", "POLL_INTERVAL", fallback=1)
+            else safe_getint(cfg, "GENERAL", "POLL_INTERVAL", fallback=1)
         )
         logger.debug(f"CT001 Settings for {device_id}:")
         logger.debug(f"Disable Sum Phases: {disable_sum}")
@@ -195,7 +195,7 @@ def main():
     skip_test = (
         args.skip_powermeter_test
         if args.skip_powermeter_test is not None
-        else cfg.getboolean("GENERAL", "SKIP_POWERMETER_TEST", fallback=False)
+        else safe_getboolean(cfg, "GENERAL", "SKIP_POWERMETER_TEST", fallback=False)
     )
 
     device_ids = args.device_ids if args.device_ids is not None else []
@@ -225,8 +225,8 @@ def main():
         cfg.set("GENERAL", "THROTTLE_INTERVAL", str(args.throttle_interval))
 
     # Start health check server for watchdog monitoring
-    if cfg.getboolean("GENERAL", "ENABLE_HEALTH_CHECK", fallback=True):
-        web_config_enabled = cfg.getboolean("GENERAL", "WEB_CONFIG_ENABLED", fallback=False)
+    if safe_getboolean(cfg, "GENERAL", "ENABLE_HEALTH_CHECK", fallback=True):
+        web_config_enabled = safe_getboolean(cfg, "GENERAL", "WEB_CONFIG_ENABLED", fallback=False)
         logger.info("Starting health check service...")
         if start_health_service(config_path=args.config, enable_web_config=web_config_enabled):
             logger.info("Health check service started successfully")

--- a/main.py
+++ b/main.py
@@ -226,8 +226,9 @@ def main():
 
     # Start health check server for watchdog monitoring
     if cfg.getboolean("GENERAL", "ENABLE_HEALTH_CHECK", fallback=True):
+        web_config_enabled = cfg.getboolean("GENERAL", "WEB_CONFIG_ENABLED", fallback=False)
         logger.info("Starting health check service...")
-        if start_health_service():
+        if start_health_service(config_path=args.config, enable_web_config=web_config_enabled):
             logger.info("Health check service started successfully")
         else:
             logger.error("Failed to start health check service")

--- a/main.py
+++ b/main.py
@@ -74,7 +74,6 @@ def run_device(
             if args.poll_interval is not None
             else cfg.getint("GENERAL", "POLL_INTERVAL", fallback=1)
         )
-
         logger.debug(f"CT001 Settings for {device_id}:")
         logger.debug(f"Disable Sum Phases: {disable_sum}")
         logger.debug(f"Disable Absolute Values: {disable_absolute}")

--- a/powermeter/__init__.py
+++ b/powermeter/__init__.py
@@ -14,4 +14,5 @@ from .json_http import JsonHttpPowermeter
 from .script import Script
 from .throttling import ThrottledPowermeter
 from .ema import ExponentialMovingAveragePowermeter
+from .offset import OffsetPowermeter
 from .tq_em import TQEnergyManager

--- a/powermeter/__init__.py
+++ b/powermeter/__init__.py
@@ -13,4 +13,5 @@ from .mqtt import MqttPowermeter
 from .json_http import JsonHttpPowermeter
 from .script import Script
 from .throttling import ThrottledPowermeter
+from .ema import ExponentialMovingAveragePowermeter
 from .tq_em import TQEnergyManager

--- a/powermeter/__init__.py
+++ b/powermeter/__init__.py
@@ -18,4 +18,5 @@ from .offset import OffsetPowermeter
 from .slewrate import SlewRatePowermeter
 from .deadband import DeadBandPowermeter
 from .holdtimer import HoldTimerPowermeter
+from .pid import PidPowermeter
 from .tq_em import TQEnergyManager

--- a/powermeter/__init__.py
+++ b/powermeter/__init__.py
@@ -15,4 +15,7 @@ from .script import Script
 from .throttling import ThrottledPowermeter
 from .ema import ExponentialMovingAveragePowermeter
 from .offset import OffsetPowermeter
+from .slewrate import SlewRatePowermeter
+from .deadband import DeadBandPowermeter
+from .holdtimer import HoldTimerPowermeter
 from .tq_em import TQEnergyManager

--- a/powermeter/deadband.py
+++ b/powermeter/deadband.py
@@ -1,0 +1,67 @@
+from typing import List, Optional
+from .base import Powermeter
+
+
+class DeadBandPowermeter(Powermeter):
+    """
+    A wrapper around a powermeter that suppresses small power changes.
+
+    A new set of values is forwarded to the caller only when at least one
+    phase has moved outside a symmetric dead-band (± ``deadband_watts``)
+    around the last reported value.  While all phases remain inside the
+    dead-band the previously reported values are returned unchanged.
+
+    This prevents the storage system from reacting to noise or minor load
+    fluctuations near the current operating point and is the most direct
+    way to reduce hunting oscillation in Auto / Self-Adaptation mode.
+
+    The dead-band is evaluated independently per phase; a change on any
+    single phase is enough to trigger an update for all phases.
+
+    The very first reading is always forwarded (no previous reference
+    exists).
+    """
+
+    def __init__(self, wrapped_powermeter: Powermeter, deadband_watts: float):
+        """
+        Initialise the dead-band powermeter wrapper.
+
+        Args:
+            wrapped_powermeter: The actual powermeter instance to wrap.
+            deadband_watts: Half-width of the dead-band in watts (must be > 0).
+                            A change smaller than or equal to this threshold is
+                            suppressed; a change larger than this threshold
+                            triggers an update.
+        """
+        if deadband_watts <= 0:
+            raise ValueError(
+                f"deadband_watts must be positive, got {deadband_watts}"
+            )
+        self.wrapped_powermeter = wrapped_powermeter
+        self.deadband_watts = deadband_watts
+        self.last_reported: Optional[List[float]] = None
+
+    def wait_for_message(self, timeout=5):
+        """Pass through to wrapped powermeter."""
+        return self.wrapped_powermeter.wait_for_message(timeout)
+
+    def get_powermeter_watts(self) -> List[float]:
+        values = self.wrapped_powermeter.get_powermeter_watts()
+
+        if self.last_reported is None:
+            # First reading – always forward and initialise the reference
+            self.last_reported = list(values)
+            return list(values)
+
+        # Update if any phase exceeds the dead-band threshold
+        outside = any(
+            abs(new - last) > self.deadband_watts
+            for new, last in zip(values, self.last_reported)
+        )
+
+        if outside:
+            self.last_reported = list(values)
+            return list(values)
+
+        # All phases within dead-band – return last reported value
+        return list(self.last_reported)

--- a/powermeter/deadband_test.py
+++ b/powermeter/deadband_test.py
@@ -1,0 +1,138 @@
+import unittest
+from unittest.mock import Mock
+from .deadband import DeadBandPowermeter
+
+
+class TestDeadBandPowermeter(unittest.TestCase):
+    def setUp(self):
+        self.mock_powermeter = Mock()
+
+    def test_first_reading_always_forwarded(self):
+        """First call should return the raw value regardless of dead-band."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm = DeadBandPowermeter(self.mock_powermeter, deadband_watts=50.0)
+
+        result = pm.get_powermeter_watts()
+        self.assertEqual(result, [100.0])
+
+    def test_change_within_deadband_suppressed(self):
+        """A change smaller than the dead-band should return the previous value."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm = DeadBandPowermeter(self.mock_powermeter, deadband_watts=50.0)
+
+        pm.get_powermeter_watts()  # initialise at 100 W
+
+        # Change of 30 W is within the 50 W dead-band
+        self.mock_powermeter.get_powermeter_watts.return_value = [130.0]
+        result = pm.get_powermeter_watts()
+        self.assertEqual(result, [100.0])
+
+    def test_change_at_deadband_boundary_suppressed(self):
+        """An exact dead-band-sized change should be suppressed (not strictly greater)."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm = DeadBandPowermeter(self.mock_powermeter, deadband_watts=50.0)
+
+        pm.get_powermeter_watts()  # initialise at 100 W
+
+        # Change of exactly 50 W equals the dead-band – should still be suppressed
+        self.mock_powermeter.get_powermeter_watts.return_value = [150.0]
+        result = pm.get_powermeter_watts()
+        self.assertEqual(result, [100.0])
+
+    def test_change_outside_deadband_forwarded(self):
+        """A change larger than the dead-band should return the new value."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm = DeadBandPowermeter(self.mock_powermeter, deadband_watts=50.0)
+
+        pm.get_powermeter_watts()  # initialise at 100 W
+
+        # Change of 51 W exceeds the 50 W dead-band
+        self.mock_powermeter.get_powermeter_watts.return_value = [151.0]
+        result = pm.get_powermeter_watts()
+        self.assertEqual(result, [151.0])
+
+    def test_negative_change_outside_deadband_forwarded(self):
+        """A negative change larger than the dead-band should be forwarded."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [200.0]
+        pm = DeadBandPowermeter(self.mock_powermeter, deadband_watts=50.0)
+
+        pm.get_powermeter_watts()  # initialise at 200 W
+
+        # Drop of 60 W exceeds the 50 W dead-band
+        self.mock_powermeter.get_powermeter_watts.return_value = [140.0]
+        result = pm.get_powermeter_watts()
+        self.assertEqual(result, [140.0])
+
+    def test_reference_updates_after_forward(self):
+        """After forwarding a new value the reference updates to that value."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm = DeadBandPowermeter(self.mock_powermeter, deadband_watts=50.0)
+
+        pm.get_powermeter_watts()  # initialise at 100 W
+
+        # Jump outside dead-band → reference moves to 200 W
+        self.mock_powermeter.get_powermeter_watts.return_value = [200.0]
+        pm.get_powermeter_watts()
+
+        # Now a change of 30 W from the NEW reference (200 W) should be suppressed
+        self.mock_powermeter.get_powermeter_watts.return_value = [230.0]
+        result = pm.get_powermeter_watts()
+        self.assertEqual(result, [200.0])
+
+    def test_three_phase_any_phase_triggers_update(self):
+        """If any single phase exceeds the dead-band, all phases are updated."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 100.0, 100.0]
+        pm = DeadBandPowermeter(self.mock_powermeter, deadband_watts=50.0)
+
+        pm.get_powermeter_watts()  # initialise
+
+        # Only phase 2 exceeds the dead-band
+        self.mock_powermeter.get_powermeter_watts.return_value = [110.0, 200.0, 105.0]
+        result = pm.get_powermeter_watts()
+        self.assertEqual(result, [110.0, 200.0, 105.0])
+
+    def test_three_phase_all_within_deadband_suppressed(self):
+        """All phases within dead-band → return previous values for all phases."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 100.0, 100.0]
+        pm = DeadBandPowermeter(self.mock_powermeter, deadband_watts=50.0)
+
+        pm.get_powermeter_watts()  # initialise
+
+        self.mock_powermeter.get_powermeter_watts.return_value = [110.0, 120.0, 130.0]
+        result = pm.get_powermeter_watts()
+        self.assertEqual(result, [100.0, 100.0, 100.0])
+
+    def test_invalid_deadband_raises_error(self):
+        """Non-positive deadband_watts should raise ValueError."""
+        with self.assertRaises(ValueError):
+            DeadBandPowermeter(self.mock_powermeter, deadband_watts=0.0)
+        with self.assertRaises(ValueError):
+            DeadBandPowermeter(self.mock_powermeter, deadband_watts=-10.0)
+
+    def test_wait_for_message_passthrough(self):
+        """wait_for_message should be delegated to the wrapped powermeter."""
+        pm = DeadBandPowermeter(self.mock_powermeter, deadband_watts=50.0)
+        pm.wait_for_message(timeout=5)
+        self.mock_powermeter.wait_for_message.assert_called_once()
+        call_args = self.mock_powermeter.wait_for_message.call_args
+        if call_args[1]:
+            self.assertEqual(call_args[1]["timeout"], 5)
+        else:
+            self.assertEqual(call_args[0][0], 5)
+
+    def test_return_value_does_not_mutate_internal_state(self):
+        """Mutating the returned list must not corrupt the internal reference."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm = DeadBandPowermeter(self.mock_powermeter, deadband_watts=50.0)
+
+        result = pm.get_powermeter_watts()
+        result[0] = 9999.0  # mutate the returned list
+
+        # Suppress a within-deadband change – should still get original reference
+        self.mock_powermeter.get_powermeter_watts.return_value = [110.0]
+        result2 = pm.get_powermeter_watts()
+        self.assertEqual(result2, [100.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/powermeter/ema.py
+++ b/powermeter/ema.py
@@ -1,4 +1,7 @@
-from typing import List, Optional
+import threading
+import time
+from typing import List
+from config.logger import logger
 from .base import Powermeter
 
 
@@ -19,9 +22,20 @@ class ExponentialMovingAveragePowermeter(Powermeter):
         EMA_t = alpha * raw_t + (1 - alpha) * EMA_{t-1}
 
     The first reading initialises the EMA (no averaging on the very first call).
+
+    When ``ema_interval`` is set to a positive value, a background thread
+    samples the underlying powermeter every ``ema_interval`` seconds to update
+    the EMA state.  Calls to ``get_powermeter_watts()`` then return the cached
+    EMA value without hitting the underlying source, so the EMA accumulation
+    rate is decoupled from how often the B2500 device requests data.
     """
 
-    def __init__(self, wrapped_powermeter: Powermeter, alpha: float = 0.1):
+    def __init__(
+        self,
+        wrapped_powermeter: Powermeter,
+        alpha: float = 0.1,
+        ema_interval: float = 0.0,
+    ):
         """
         Initialise the EMA powermeter wrapper.
 
@@ -29,22 +43,32 @@ class ExponentialMovingAveragePowermeter(Powermeter):
             wrapped_powermeter: The actual powermeter instance to wrap.
             alpha: Smoothing factor in the range (0, 1].
                    Lower values mean more smoothing; 1.0 disables smoothing.
+            ema_interval: If > 0, a background thread samples the underlying
+                          powermeter at this interval (in seconds) to update
+                          the EMA, independent of how often
+                          ``get_powermeter_watts()`` is called.
+                          If 0 (default), the EMA is updated on every call to
+                          ``get_powermeter_watts()``, preserving the original
+                          behaviour.
         """
         if not (0 < alpha <= 1.0):
             raise ValueError(f"EMA alpha must be in the range (0, 1], got {alpha}")
         self.wrapped_powermeter = wrapped_powermeter
         self.alpha = alpha
-        self.ema_values: Optional[List[float]] = None
+        self.ema_values: List[float] = []
+        self._lock = threading.Lock()
+        self._ema_interval = ema_interval
 
-    def wait_for_message(self, timeout=5):
-        """Pass through to wrapped powermeter."""
-        return self.wrapped_powermeter.wait_for_message(timeout)
+        if ema_interval > 0:
+            self._first_reading_event = threading.Event()
+            self._thread = threading.Thread(
+                target=self._update_loop, daemon=True, name="ema-sampler"
+            )
+            self._thread.start()
 
-    def get_powermeter_watts(self) -> List[float]:
-        raw_values = self.wrapped_powermeter.get_powermeter_watts()
-
-        if self.ema_values is None:
-            # Initialise EMA with the first reading
+    def _apply_ema(self, raw_values: List[float]) -> None:
+        """Update ``self.ema_values`` in-place with one EMA step (caller holds lock)."""
+        if not self.ema_values:
             self.ema_values = list(raw_values)
         else:
             self.ema_values = [
@@ -52,4 +76,44 @@ class ExponentialMovingAveragePowermeter(Powermeter):
                 for raw, ema in zip(raw_values, self.ema_values)
             ]
 
+    def _update_loop(self) -> None:
+        """Background thread: sample the underlying powermeter every ema_interval seconds."""
+        while True:
+            start = time.monotonic()
+            try:
+                raw_values = self.wrapped_powermeter.get_powermeter_watts()
+                with self._lock:
+                    self._apply_ema(raw_values)
+                self._first_reading_event.set()
+            except Exception as e:
+                logger.warning(f"EMA background thread failed to read powermeter: {e}")
+            elapsed = time.monotonic() - start
+            sleep_time = max(0.0, self._ema_interval - elapsed)
+            time.sleep(sleep_time)
+
+    def wait_for_message(self, timeout=5):
+        """Pass through to wrapped powermeter."""
+        return self.wrapped_powermeter.wait_for_message(timeout)
+
+    def get_powermeter_watts(self) -> List[float]:
+        if self._ema_interval > 0:
+            # Background-thread mode: wait for the first reading if needed,
+            # then return the cached EMA without touching the underlying source.
+            # Use a finite timeout per iteration so we can log a warning if
+            # the first reading is taking unexpectedly long (e.g. network error).
+            waited = 0.0
+            while not self._first_reading_event.wait(timeout=1.0):
+                waited += 1.0
+                if waited % 30.0 == 0:
+                    logger.warning(
+                        f"EMA background thread has not produced a reading after "
+                        f"{waited:.0f}s; still waiting..."
+                    )
+            with self._lock:
+                return list(self.ema_values)
+
+        # Original synchronous mode: fetch and update EMA on every call.
+        raw_values = self.wrapped_powermeter.get_powermeter_watts()
+        with self._lock:
+            self._apply_ema(raw_values)
         return list(self.ema_values)

--- a/powermeter/ema.py
+++ b/powermeter/ema.py
@@ -1,0 +1,55 @@
+from typing import List, Optional
+from .base import Powermeter
+
+
+class ExponentialMovingAveragePowermeter(Powermeter):
+    """
+    A wrapper around a powermeter that applies an exponential moving average
+    (EMA) to the raw values before returning them to the client.
+
+    The EMA smooths out short-term fluctuations in power readings, which can
+    be useful for noisy data sources or to reduce oscillation in the storage
+    system's charge/discharge decisions.
+
+    The smoothing factor ``alpha`` controls the degree of smoothing:
+      - Values close to 0 produce heavy smoothing (slow to react to changes).
+      - Values close to 1 produce little smoothing (close to the raw reading).
+
+    Formula:
+        EMA_t = alpha * raw_t + (1 - alpha) * EMA_{t-1}
+
+    The first reading initialises the EMA (no averaging on the very first call).
+    """
+
+    def __init__(self, wrapped_powermeter: Powermeter, alpha: float = 0.1):
+        """
+        Initialise the EMA powermeter wrapper.
+
+        Args:
+            wrapped_powermeter: The actual powermeter instance to wrap.
+            alpha: Smoothing factor in the range (0, 1].
+                   Lower values mean more smoothing; 1.0 disables smoothing.
+        """
+        if not (0 < alpha <= 1.0):
+            raise ValueError(f"EMA alpha must be in the range (0, 1], got {alpha}")
+        self.wrapped_powermeter = wrapped_powermeter
+        self.alpha = alpha
+        self.ema_values: Optional[List[float]] = None
+
+    def wait_for_message(self, timeout=5):
+        """Pass through to wrapped powermeter."""
+        return self.wrapped_powermeter.wait_for_message(timeout)
+
+    def get_powermeter_watts(self) -> List[float]:
+        raw_values = self.wrapped_powermeter.get_powermeter_watts()
+
+        if self.ema_values is None:
+            # Initialise EMA with the first reading
+            self.ema_values = list(raw_values)
+        else:
+            self.ema_values = [
+                self.alpha * raw + (1.0 - self.alpha) * ema
+                for raw, ema in zip(raw_values, self.ema_values)
+            ]
+
+        return list(self.ema_values)

--- a/powermeter/ema_test.py
+++ b/powermeter/ema_test.py
@@ -1,3 +1,5 @@
+import threading
+import time
 import unittest
 from unittest.mock import Mock
 from .ema import ExponentialMovingAveragePowermeter
@@ -93,6 +95,84 @@ class TestExponentialMovingAveragePowermeter(unittest.TestCase):
 
         # After 100 iterations with alpha=0.1, EMA should be very close to 1000
         self.assertAlmostEqual(result[0], 1000.0, delta=1.0)
+
+    # --- Background-thread (ema_interval) mode tests ---
+
+    def test_ema_interval_returns_value_from_background_thread(self):
+        """With ema_interval set, get_powermeter_watts returns the cached EMA value."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [42.0]
+        ema = ExponentialMovingAveragePowermeter(
+            self.mock_powermeter, alpha=1.0, ema_interval=0.05
+        )
+
+        # Wait for background thread to produce at least one reading
+        result = ema.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 42.0)
+
+    def test_ema_interval_does_not_call_underlying_on_get(self):
+        """With ema_interval set, get_powermeter_watts must not call the underlying source."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [10.0]
+        ema = ExponentialMovingAveragePowermeter(
+            self.mock_powermeter, alpha=1.0, ema_interval=0.05
+        )
+
+        # Wait for first background reading
+        ema._first_reading_event.wait(timeout=2)
+
+        call_count_before = self.mock_powermeter.get_powermeter_watts.call_count
+        # Multiple get calls must not increase the underlying call count
+        ema.get_powermeter_watts()
+        ema.get_powermeter_watts()
+        ema.get_powermeter_watts()
+        call_count_after = self.mock_powermeter.get_powermeter_watts.call_count
+        self.assertEqual(call_count_before, call_count_after)
+
+    def test_ema_interval_background_thread_updates_ema(self):
+        """Background thread should keep updating the EMA over time."""
+        # Start with 0, then switch to 100 after first reading
+        call_count = [0]
+
+        def side_effect():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [0.0]
+            return [100.0]
+
+        self.mock_powermeter.get_powermeter_watts.side_effect = side_effect
+        ema = ExponentialMovingAveragePowermeter(
+            self.mock_powermeter, alpha=0.5, ema_interval=0.05
+        )
+
+        # Wait long enough for several background updates
+        time.sleep(0.4)
+
+        result = ema.get_powermeter_watts()
+        # After several iterations converging from 0 to 100, value should be high
+        self.assertGreater(result[0], 80.0)
+
+    def test_ema_interval_zero_uses_synchronous_mode(self):
+        """ema_interval=0 (default) must use the original synchronous behaviour."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [0.0]
+        ema = ExponentialMovingAveragePowermeter(
+            self.mock_powermeter, alpha=0.5, ema_interval=0.0
+        )
+
+        ema.get_powermeter_watts()  # initialise at 0
+
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        result = ema.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 50.0)
+
+        result = ema.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 75.0)
+
+    def test_ema_interval_background_thread_is_daemon(self):
+        """Background thread must be a daemon so it does not prevent process exit."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [1.0]
+        ema = ExponentialMovingAveragePowermeter(
+            self.mock_powermeter, alpha=0.5, ema_interval=1.0
+        )
+        self.assertTrue(ema._thread.daemon)
 
 
 if __name__ == "__main__":

--- a/powermeter/ema_test.py
+++ b/powermeter/ema_test.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest.mock import Mock
+from .ema import ExponentialMovingAveragePowermeter
+
+
+class TestExponentialMovingAveragePowermeter(unittest.TestCase):
+    def setUp(self):
+        self.mock_powermeter = Mock()
+
+    def test_first_reading_initialises_ema(self):
+        """First call should return the raw value (EMA is initialised to it)."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        ema = ExponentialMovingAveragePowermeter(self.mock_powermeter, alpha=0.5)
+
+        result = ema.get_powermeter_watts()
+        self.assertEqual(result, [100.0])
+
+    def test_ema_smoothing_single_phase(self):
+        """EMA should smooth values across consecutive readings (single phase)."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [0.0]
+        ema = ExponentialMovingAveragePowermeter(self.mock_powermeter, alpha=0.5)
+
+        # Initialise: EMA = 0
+        ema.get_powermeter_watts()
+
+        # Feed a spike of 100 W
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        result = ema.get_powermeter_watts()
+        # EMA = 0.5 * 100 + 0.5 * 0 = 50
+        self.assertAlmostEqual(result[0], 50.0)
+
+        # Another reading at 100 W
+        result = ema.get_powermeter_watts()
+        # EMA = 0.5 * 100 + 0.5 * 50 = 75
+        self.assertAlmostEqual(result[0], 75.0)
+
+    def test_ema_smoothing_three_phase(self):
+        """EMA should smooth all phases independently."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [0.0, 0.0, 0.0]
+        ema = ExponentialMovingAveragePowermeter(self.mock_powermeter, alpha=0.5)
+
+        ema.get_powermeter_watts()  # initialise
+
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+        result = ema.get_powermeter_watts()
+
+        self.assertAlmostEqual(result[0], 50.0)
+        self.assertAlmostEqual(result[1], 100.0)
+        self.assertAlmostEqual(result[2], 150.0)
+
+    def test_alpha_one_returns_raw_value(self):
+        """alpha=1 means no smoothing – each reading is the raw value."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [50.0]
+        ema = ExponentialMovingAveragePowermeter(self.mock_powermeter, alpha=1.0)
+
+        ema.get_powermeter_watts()  # initialise
+
+        self.mock_powermeter.get_powermeter_watts.return_value = [200.0]
+        result = ema.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 200.0)
+
+    def test_invalid_alpha_raises_error(self):
+        """alpha outside (0, 1] should raise ValueError."""
+        with self.assertRaises(ValueError):
+            ExponentialMovingAveragePowermeter(self.mock_powermeter, alpha=0.0)
+        with self.assertRaises(ValueError):
+            ExponentialMovingAveragePowermeter(self.mock_powermeter, alpha=1.5)
+        with self.assertRaises(ValueError):
+            ExponentialMovingAveragePowermeter(self.mock_powermeter, alpha=-0.1)
+
+    def test_wait_for_message_passthrough(self):
+        """wait_for_message should be delegated to the wrapped powermeter."""
+        ema = ExponentialMovingAveragePowermeter(self.mock_powermeter, alpha=0.3)
+        ema.wait_for_message(timeout=10)
+        self.mock_powermeter.wait_for_message.assert_called_once()
+        call_args = self.mock_powermeter.wait_for_message.call_args
+        if call_args[1]:
+            self.assertEqual(call_args[1]["timeout"], 10)
+        else:
+            self.assertEqual(call_args[0][0], 10)
+
+    def test_ema_converges_towards_stable_value(self):
+        """EMA should converge to a stable input after enough readings."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [0.0]
+        ema = ExponentialMovingAveragePowermeter(self.mock_powermeter, alpha=0.1)
+
+        ema.get_powermeter_watts()  # initialise at 0
+
+        self.mock_powermeter.get_powermeter_watts.return_value = [1000.0]
+        result = None
+        for _ in range(100):
+            result = ema.get_powermeter_watts()
+
+        # After 100 iterations with alpha=0.1, EMA should be very close to 1000
+        self.assertAlmostEqual(result[0], 1000.0, delta=1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/powermeter/holdtimer.py
+++ b/powermeter/holdtimer.py
@@ -1,0 +1,54 @@
+import time
+from typing import List, Optional
+from .base import Powermeter
+
+
+class HoldTimerPowermeter(Powermeter):
+    """
+    A wrapper around a powermeter that holds each reported value for a
+    minimum duration before allowing an update.
+
+    Once a value is forwarded to the caller a hold window of ``hold_time``
+    seconds starts.  Any poll that arrives during this window receives the
+    held value unchanged, preventing the storage system from acting on
+    rapid successive changes before it has had a chance to respond
+    physically.  After the window expires the next underlying value is
+    forwarded and a new hold window begins.
+
+    This complements throttling (which rate-limits *fetching* from the
+    source) by rate-limiting *reporting* to the storage system regardless
+    of how frequently it polls.
+    """
+
+    def __init__(self, wrapped_powermeter: Powermeter, hold_time: float):
+        """
+        Initialise the hold-timer powermeter wrapper.
+
+        Args:
+            wrapped_powermeter: The actual powermeter instance to wrap.
+            hold_time: Minimum seconds to hold a reported value before
+                       forwarding the next update (must be > 0).
+        """
+        if hold_time <= 0:
+            raise ValueError(f"hold_time must be positive, got {hold_time}")
+        self.wrapped_powermeter = wrapped_powermeter
+        self.hold_time = hold_time
+        self.held_values: Optional[List[float]] = None
+        self.hold_until: float = 0.0
+
+    def wait_for_message(self, timeout=5):
+        """Pass through to wrapped powermeter."""
+        return self.wrapped_powermeter.wait_for_message(timeout)
+
+    def get_powermeter_watts(self) -> List[float]:
+        current_time = time.time()
+
+        if self.held_values is not None and current_time < self.hold_until:
+            # Still within the hold window – return the held value
+            return list(self.held_values)
+
+        # Hold window has expired (or first call) – fetch and hold new value
+        values = self.wrapped_powermeter.get_powermeter_watts()
+        self.held_values = list(values)
+        self.hold_until = current_time + self.hold_time
+        return list(values)

--- a/powermeter/holdtimer_test.py
+++ b/powermeter/holdtimer_test.py
@@ -1,0 +1,132 @@
+import time
+import unittest
+from unittest.mock import Mock
+from .holdtimer import HoldTimerPowermeter
+
+
+class TestHoldTimerPowermeter(unittest.TestCase):
+    def setUp(self):
+        self.mock_powermeter = Mock()
+
+    def test_first_reading_forwarded_immediately(self):
+        """First call should fetch and return the underlying value."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm = HoldTimerPowermeter(self.mock_powermeter, hold_time=5.0)
+
+        result = pm.get_powermeter_watts()
+        self.assertEqual(result, [100.0])
+        self.mock_powermeter.get_powermeter_watts.assert_called_once()
+
+    def test_value_held_during_hold_window(self):
+        """Polls within the hold window should return the held value."""
+        pm = HoldTimerPowermeter(self.mock_powermeter, hold_time=5.0)
+
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm.get_powermeter_watts()  # fetch and start hold window
+
+        # Change underlying value; poll while hold window is still active
+        self.mock_powermeter.get_powermeter_watts.return_value = [999.0]
+        # hold_until is in the future, so we are inside the window
+        result = pm.get_powermeter_watts()
+
+        # Should still return the held value, not the new underlying value
+        self.assertEqual(result, [100.0])
+        # Underlying powermeter should only have been called once
+        self.mock_powermeter.get_powermeter_watts.assert_called_once()
+
+    def test_new_value_forwarded_after_hold_expires(self):
+        """After the hold window expires a new value should be fetched."""
+        pm = HoldTimerPowermeter(self.mock_powermeter, hold_time=5.0)
+
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm.get_powermeter_watts()  # fetch and start hold window
+
+        # Expire the hold window by setting hold_until to the past
+        pm.hold_until = 0.0
+
+        self.mock_powermeter.get_powermeter_watts.return_value = [200.0]
+        result = pm.get_powermeter_watts()
+
+        self.assertEqual(result, [200.0])
+
+    def test_hold_window_resets_after_update(self):
+        """Each new fetch should start a fresh hold window."""
+        pm = HoldTimerPowermeter(self.mock_powermeter, hold_time=5.0)
+
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm.get_powermeter_watts()  # first fetch
+
+        # Expire first hold window
+        pm.hold_until = 0.0
+        self.mock_powermeter.get_powermeter_watts.return_value = [200.0]
+        pm.get_powermeter_watts()  # second fetch, starts new hold window
+
+        # Poll again while new hold window is still active
+        self.mock_powermeter.get_powermeter_watts.return_value = [999.0]
+        result = pm.get_powermeter_watts()
+
+        self.assertEqual(result, [200.0])
+
+    def test_three_phase_values_held(self):
+        """Hold timer should hold all phases simultaneously."""
+        pm = HoldTimerPowermeter(self.mock_powermeter, hold_time=5.0)
+
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+        pm.get_powermeter_watts()
+
+        self.mock_powermeter.get_powermeter_watts.return_value = [1.0, 2.0, 3.0]
+        result = pm.get_powermeter_watts()
+
+        self.assertEqual(result, [100.0, 200.0, 300.0])
+
+    def test_real_time_hold(self):
+        """Integration test using real time: value should be held for ~0.1 s."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm = HoldTimerPowermeter(self.mock_powermeter, hold_time=0.1)
+
+        pm.get_powermeter_watts()  # fetch and start hold window
+
+        # Immediately poll again – should get held value
+        self.mock_powermeter.get_powermeter_watts.return_value = [999.0]
+        result_held = pm.get_powermeter_watts()
+        self.assertEqual(result_held, [100.0])
+
+        # Wait for hold to expire, then poll again
+        time.sleep(0.15)
+        result_new = pm.get_powermeter_watts()
+        self.assertEqual(result_new, [999.0])
+
+    def test_invalid_hold_time_raises_error(self):
+        """Non-positive hold_time should raise ValueError."""
+        with self.assertRaises(ValueError):
+            HoldTimerPowermeter(self.mock_powermeter, hold_time=0.0)
+        with self.assertRaises(ValueError):
+            HoldTimerPowermeter(self.mock_powermeter, hold_time=-1.0)
+
+    def test_wait_for_message_passthrough(self):
+        """wait_for_message should be delegated to the wrapped powermeter."""
+        pm = HoldTimerPowermeter(self.mock_powermeter, hold_time=2.0)
+        pm.wait_for_message(timeout=4)
+        self.mock_powermeter.wait_for_message.assert_called_once()
+        call_args = self.mock_powermeter.wait_for_message.call_args
+        if call_args[1]:
+            self.assertEqual(call_args[1]["timeout"], 4)
+        else:
+            self.assertEqual(call_args[0][0], 4)
+
+    def test_return_value_does_not_mutate_internal_state(self):
+        """Mutating the returned list must not corrupt the held value."""
+        pm = HoldTimerPowermeter(self.mock_powermeter, hold_time=5.0)
+
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        result = pm.get_powermeter_watts()
+        result[0] = 9999.0  # mutate returned list
+
+        # Poll within hold window – held value should still be the original
+        result2 = pm.get_powermeter_watts()
+
+        self.assertEqual(result2, [100.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/powermeter/offset.py
+++ b/powermeter/offset.py
@@ -1,0 +1,36 @@
+from typing import List
+from .base import Powermeter
+
+
+class OffsetPowermeter(Powermeter):
+    """
+    A wrapper around a powermeter that adds a constant offset (in watts) to
+    every phase value returned by the underlying powermeter.
+
+    A positive offset increases the reported power; a negative offset decreases
+    it.  The offset is applied to each phase independently.
+
+    This is useful when the physical meter has a known, systematic measurement
+    error that should be compensated in software, or when a constant baseline
+    load should be factored into the readings.
+    """
+
+    def __init__(self, wrapped_powermeter: Powermeter, offset: float):
+        """
+        Initialise the offset powermeter wrapper.
+
+        Args:
+            wrapped_powermeter: The actual powermeter instance to wrap.
+            offset: Constant value in watts to add to every phase reading.
+                    May be negative.
+        """
+        self.wrapped_powermeter = wrapped_powermeter
+        self.offset = offset
+
+    def wait_for_message(self, timeout=5):
+        """Pass through to wrapped powermeter."""
+        return self.wrapped_powermeter.wait_for_message(timeout)
+
+    def get_powermeter_watts(self) -> List[float]:
+        raw_values = self.wrapped_powermeter.get_powermeter_watts()
+        return [value + self.offset for value in raw_values]

--- a/powermeter/offset_test.py
+++ b/powermeter/offset_test.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import Mock
+from .offset import OffsetPowermeter
+
+
+class TestOffsetPowermeter(unittest.TestCase):
+    def setUp(self):
+        self.mock_powermeter = Mock()
+
+    def test_positive_offset_single_phase(self):
+        """A positive offset should be added to the raw reading."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm = OffsetPowermeter(self.mock_powermeter, offset=50.0)
+
+        result = pm.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 150.0)
+
+    def test_negative_offset_single_phase(self):
+        """A negative offset should be subtracted from the raw reading."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [200.0]
+        pm = OffsetPowermeter(self.mock_powermeter, offset=-30.0)
+
+        result = pm.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 170.0)
+
+    def test_zero_offset_returns_raw_value(self):
+        """An offset of zero should return the raw value unchanged."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [123.4]
+        pm = OffsetPowermeter(self.mock_powermeter, offset=0.0)
+
+        result = pm.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 123.4)
+
+    def test_offset_applied_to_all_phases(self):
+        """The offset should be applied independently to every phase."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [
+            100.0,
+            200.0,
+            300.0,
+        ]
+        pm = OffsetPowermeter(self.mock_powermeter, offset=25.0)
+
+        result = pm.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 125.0)
+        self.assertAlmostEqual(result[1], 225.0)
+        self.assertAlmostEqual(result[2], 325.0)
+
+    def test_wait_for_message_passthrough(self):
+        """wait_for_message should be delegated to the wrapped powermeter."""
+        pm = OffsetPowermeter(self.mock_powermeter, offset=10.0)
+        pm.wait_for_message(timeout=7)
+        self.mock_powermeter.wait_for_message.assert_called_once()
+        call_args = self.mock_powermeter.wait_for_message.call_args
+        if call_args[1]:
+            self.assertEqual(call_args[1]["timeout"], 7)
+        else:
+            self.assertEqual(call_args[0][0], 7)
+
+    def test_offset_does_not_mutate_original_list(self):
+        """The wrapper must not mutate the list returned by the inner powermeter."""
+        raw = [100.0, 200.0]
+        self.mock_powermeter.get_powermeter_watts.return_value = raw
+        pm = OffsetPowermeter(self.mock_powermeter, offset=10.0)
+
+        pm.get_powermeter_watts()
+        self.assertEqual(raw, [100.0, 200.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/powermeter/pid.py
+++ b/powermeter/pid.py
@@ -125,7 +125,7 @@ class PidPowermeter(Powermeter):
                 # Only accept the new integral if output is not saturated,
                 # or if the integral is moving toward zero (unwinding).
                 if abs(tentative_output) <= self.output_max or (
-                    tentative_integral * error < 0
+                    self._integral != 0 and self._integral * error < 0
                 ):
                     self._integral = tentative_integral
             i_term = self.ki * self._integral

--- a/powermeter/pid.py
+++ b/powermeter/pid.py
@@ -1,0 +1,154 @@
+import time
+import threading
+from typing import List, Optional
+from .base import Powermeter
+
+
+class PidPowermeter(Powermeter):
+    """
+    A wrapper around a powermeter that applies a PID (Proportional-Integral-
+    Derivative) controller to steer the reported power toward zero (grid balance).
+
+    The PID controller uses the raw power-meter reading as its *process
+    variable* and computes an adjustment that is either **added** to the raw
+    reading (``mode="bias"``) or **used in place of** the raw reading
+    (``mode="replace"``).
+
+    Positive PID output motivates the B2500 to increase feed-in power;
+    negative output motivates it to decrease feed-in power.
+
+    **Gain sensitivity:** in ``mode="bias"`` the PID and the B2500's own
+    closed-loop controller act *together*.  The effective closed-loop gain
+    is ``(1 − Kp) × Kb``, where ``Kb`` is the B2500's internal gain.
+    The system is stable for ``0 < Kp < 1``.  Use ``Kp = 0.5`` as the
+    recommended starting value.
+
+    **Anti-windup** is built in: the integral term is clamped so that the
+    total PID output never exceeds ``[−output_max, +output_max]``, and
+    integration is paused while the output is saturated.
+
+    Error convention:
+        error = −measurement
+    A positive grid import produces a negative error, causing the PID to
+    reduce the reported value and motivate the B2500 to cover the import.
+
+    To maintain a small import safety buffer (prevent export), set a small
+    negative ``POWER_OFFSET`` (e.g. ``POWER_OFFSET = -20``) in the filter
+    chain *before* the PID.
+
+    The controller runs on the **sum** of all phases (total grid power)
+    and distributes its output equally across phases.
+
+    Config parameters:
+        PID_KP          Proportional gain (default 0 → PID disabled)
+        PID_KI          Integral gain (default 0)
+        PID_KD          Derivative gain (default 0)
+        PID_OUTPUT_MAX  Output clamp magnitude in watts (default 800)
+        PID_MODE        "bias" or "replace" (default "bias")
+    """
+
+    VALID_MODES = ("bias", "replace")
+
+    def __init__(
+        self,
+        wrapped_powermeter: Powermeter,
+        kp: float = 0.0,
+        ki: float = 0.0,
+        kd: float = 0.0,
+        output_max: float = 800.0,
+        mode: str = "bias",
+    ):
+        """
+        Initialise the PID powermeter wrapper.
+
+        Args:
+            wrapped_powermeter: The actual powermeter instance to wrap.
+            kp:  Proportional gain.
+            ki:  Integral gain.
+            kd:  Derivative gain.
+            output_max:  Maximum absolute PID output in watts.  Must be > 0.
+            mode:  ``"bias"``  — add PID output to raw reading, or
+                   ``"replace"`` — use PID output as the reported value.
+        """
+        if output_max <= 0:
+            raise ValueError(f"PID output_max must be positive, got {output_max}")
+        mode = mode.lower()
+        if mode not in self.VALID_MODES:
+            raise ValueError(
+                f"PID mode must be one of {self.VALID_MODES}, got '{mode}'"
+            )
+
+        self.wrapped_powermeter = wrapped_powermeter
+        self.kp = kp
+        self.ki = ki
+        self.kd = kd
+        self.output_max = output_max
+        self.mode = mode
+
+        # PID state
+        self._integral: float = 0.0
+        self._prev_error: Optional[float] = None
+        self._prev_time: Optional[float] = None
+        self._lock = threading.Lock()
+
+    def wait_for_message(self, timeout=5):
+        """Pass through to wrapped powermeter."""
+        return self.wrapped_powermeter.wait_for_message(timeout)
+
+    def get_powermeter_watts(self) -> List[float]:
+        raw_values = self.wrapped_powermeter.get_powermeter_watts()
+        current_time = time.monotonic()
+
+        # Compute error on the total power across all phases
+        total_power = sum(raw_values)
+        error = -total_power
+
+        with self._lock:
+            if self._prev_time is None:
+                # First call — initialise state, no derivative yet
+                self._prev_error = error
+                self._prev_time = current_time
+                dt = 0.0
+            else:
+                dt = current_time - self._prev_time
+                if dt <= 0:
+                    dt = 0.0
+
+            # --- Proportional ---
+            p_term = self.kp * error
+
+            # --- Integral with anti-windup ---
+            if dt > 0:
+                # Tentatively accumulate
+                tentative_integral = self._integral + error * dt
+                tentative_output = p_term + self.ki * tentative_integral
+                # Only accept the new integral if output is not saturated,
+                # or if the integral is moving toward zero (unwinding).
+                if abs(tentative_output) <= self.output_max or (
+                    tentative_integral * error < 0
+                ):
+                    self._integral = tentative_integral
+            i_term = self.ki * self._integral
+
+            # --- Derivative ---
+            if dt > 0 and self._prev_error is not None:
+                d_term = self.kd * (error - self._prev_error) / dt
+            else:
+                d_term = 0.0
+
+            self._prev_error = error
+            self._prev_time = current_time
+
+        # --- Total output with clamping ---
+        pid_output = p_term + i_term + d_term
+        pid_output = max(-self.output_max, min(self.output_max, pid_output))
+
+        # --- Apply to readings ---
+        num_phases = len(raw_values)
+        per_phase = pid_output / num_phases if num_phases > 0 else 0.0
+
+        if self.mode == "bias":
+            return [value + per_phase for value in raw_values]
+        else:
+            # replace mode: distribute PID output equally across phases
+            return [per_phase] * num_phases

--- a/powermeter/pid.py
+++ b/powermeter/pid.py
@@ -96,14 +96,13 @@ class PidPowermeter(Powermeter):
         return self.wrapped_powermeter.wait_for_message(timeout)
 
     def get_powermeter_watts(self) -> List[float]:
-        raw_values = self.wrapped_powermeter.get_powermeter_watts()
-        current_time = time.monotonic()
-
-        # Compute error on the total power across all phases
-        total_power = sum(raw_values)
-        error = -total_power
-
         with self._lock:
+            raw_values = self.wrapped_powermeter.get_powermeter_watts()
+            current_time = time.monotonic()
+    
+            # Compute error on the total power across all phases
+            total_power = sum(raw_values)
+            error = -total_power
             if self._prev_time is None:
                 # First call — initialise state, no derivative yet
                 self._prev_error = error

--- a/powermeter/pid_test.py
+++ b/powermeter/pid_test.py
@@ -1,0 +1,257 @@
+import unittest
+import time
+from unittest.mock import Mock, patch
+from .pid import PidPowermeter
+
+
+class TestPidPowermeter(unittest.TestCase):
+    def setUp(self):
+        self.mock_powermeter = Mock()
+
+    # ------------------------------------------------------------------
+    # Construction / validation
+    # ------------------------------------------------------------------
+
+    def test_invalid_output_max_raises(self):
+        """output_max must be positive."""
+        with self.assertRaises(ValueError):
+            PidPowermeter(self.mock_powermeter, output_max=0.0)
+        with self.assertRaises(ValueError):
+            PidPowermeter(self.mock_powermeter, output_max=-100.0)
+
+    def test_invalid_mode_raises(self):
+        """Only 'bias' and 'replace' are accepted."""
+        with self.assertRaises(ValueError):
+            PidPowermeter(self.mock_powermeter, mode="invalid")
+
+    def test_mode_case_insensitive(self):
+        """Mode string should be case-insensitive."""
+        pm = PidPowermeter(self.mock_powermeter, mode="BIAS")
+        self.assertEqual(pm.mode, "bias")
+        pm2 = PidPowermeter(self.mock_powermeter, mode="Replace")
+        self.assertEqual(pm2.mode, "replace")
+
+    # ------------------------------------------------------------------
+    # Proportional-only behaviour
+    # ------------------------------------------------------------------
+
+    def test_p_only_positive_error(self):
+        """With P-only control, a large import (actual=200W) produces
+        a negative adjustment to tell the B2500 to cover that import."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [200.0]
+        pm = PidPowermeter(self.mock_powermeter, kp=1.0, output_max=800.0)
+        # error = -200  →  P output = -200
+        result = pm.get_powermeter_watts()
+        # bias mode: 200 + (-200) = 0  (reported as balanced, B2500 stops)
+        self.assertAlmostEqual(result[0], 0.0)
+
+    def test_p_only_negative_error(self):
+        """Export reading (actual=-100W) produces a positive adjustment,
+        telling the B2500 to reduce feed-in and let imports rise."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [-100.0]
+        pm = PidPowermeter(self.mock_powermeter, kp=1.0, output_max=800.0)
+        # error = -(-100) = 100  →  P output = 100
+        result = pm.get_powermeter_watts()
+        # bias: -100 + 100 = 0
+        self.assertAlmostEqual(result[0], 0.0)
+
+    # ------------------------------------------------------------------
+    # Output clamping
+    # ------------------------------------------------------------------
+
+    def test_output_clamped_positive(self):
+        """PID output should not exceed +output_max."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [-1000.0]
+        pm = PidPowermeter(self.mock_powermeter, kp=1.0, output_max=500.0)
+        # error = -(-1000) = 1000  →  clamped to 500
+        result = pm.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], -500.0)  # -1000 + 500
+
+    def test_output_clamped_negative(self):
+        """PID output should not go below -output_max."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [2000.0]
+        pm = PidPowermeter(self.mock_powermeter, kp=1.0, output_max=500.0)
+        # error = -2000  →  clamped to -500
+        result = pm.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 1500.0)  # 2000 + (-500)
+
+    # ------------------------------------------------------------------
+    # Integral behaviour
+    # ------------------------------------------------------------------
+
+    def test_integral_accumulates_over_time(self):
+        """The integral term should grow over successive calls."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        pm = PidPowermeter(
+            self.mock_powermeter, kp=0.0, ki=1.0, output_max=800.0
+        )
+
+        # First call initialises state (dt = 0, no integral contribution)
+        t0 = 1000.0
+        with patch("powermeter.pid.time") as mock_time:
+            mock_time.monotonic.return_value = t0
+            r1 = pm.get_powermeter_watts()
+
+        # Second call after 1 second
+        with patch("powermeter.pid.time") as mock_time:
+            mock_time.monotonic.return_value = t0 + 1.0
+            r2 = pm.get_powermeter_watts()
+
+        # error = -100, integral = -100 * 1s = -100
+        # I output = 1.0 * -100 = -100
+        self.assertAlmostEqual(r2[0], 0.0)  # 100 + (-100) in bias mode
+
+    def test_anti_windup_stops_integration(self):
+        """The integral should not grow beyond what output_max allows."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [500.0]
+        pm = PidPowermeter(
+            self.mock_powermeter, kp=0.0, ki=1.0, output_max=200.0
+        )
+
+        t0 = 1000.0
+        with patch("powermeter.pid.time") as mock_time:
+            mock_time.monotonic.return_value = t0
+            pm.get_powermeter_watts()  # init
+
+        # Accumulate a large integral over 10 seconds
+        with patch("powermeter.pid.time") as mock_time:
+            mock_time.monotonic.return_value = t0 + 10.0
+            result = pm.get_powermeter_watts()
+
+        # Without anti-windup the integral would be -500*10 = -5000
+        # But output is clamped to -200, so bias result >= 500 - 200 = 300
+        self.assertGreaterEqual(result[0], 300.0)
+
+    # ------------------------------------------------------------------
+    # Derivative behaviour
+    # ------------------------------------------------------------------
+
+    def test_derivative_reacts_to_change(self):
+        """The D term should respond to changes in error."""
+        pm = PidPowermeter(
+            self.mock_powermeter, kp=0.0, kd=1.0, output_max=800.0
+        )
+
+        t0 = 1000.0
+        # First reading: 100 W
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        with patch("powermeter.pid.time") as mock_time:
+            mock_time.monotonic.return_value = t0
+            pm.get_powermeter_watts()
+
+        # Second reading: 200 W (1 second later)
+        self.mock_powermeter.get_powermeter_watts.return_value = [200.0]
+        with patch("powermeter.pid.time") as mock_time:
+            mock_time.monotonic.return_value = t0 + 1.0
+            result = pm.get_powermeter_watts()
+
+        # error1 = -100, error2 = -200
+        # d_term = 1.0 * (-200 - (-100)) / 1.0 = -100
+        # bias: 200 + (-100) = 100
+        self.assertAlmostEqual(result[0], 100.0)
+
+    # ------------------------------------------------------------------
+    # Multi-phase
+    # ------------------------------------------------------------------
+
+    def test_multiphase_bias(self):
+        """PID output should be distributed equally across phases in bias mode."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+        pm = PidPowermeter(self.mock_powermeter, kp=1.0, output_max=800.0)
+        # total = 600, error = -600, P = -600
+        # per_phase = -600 / 3 = -200
+        result = pm.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], -100.0)  # 100 + (-200)
+        self.assertAlmostEqual(result[1], 0.0)   # 200 + (-200)
+        self.assertAlmostEqual(result[2], 100.0)  # 300 + (-200)
+
+    def test_multiphase_replace(self):
+        """In replace mode, all phases should get equal share of PID output."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+        pm = PidPowermeter(
+            self.mock_powermeter,
+            kp=1.0,
+            output_max=800.0,
+            mode="replace",
+        )
+        # total = 600, error = -600, P = -600
+        # per_phase = -600 / 3 = -200
+        result = pm.get_powermeter_watts()
+        self.assertEqual(len(result), 3)
+        self.assertAlmostEqual(result[0], -200.0)
+        self.assertAlmostEqual(result[1], -200.0)
+        self.assertAlmostEqual(result[2], -200.0)
+
+    # ------------------------------------------------------------------
+    # Replace mode basics
+    # ------------------------------------------------------------------
+
+    def test_replace_mode(self):
+        """In replace mode the raw value should be discarded."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [500.0]
+        pm = PidPowermeter(
+            self.mock_powermeter,
+            kp=1.0,
+            output_max=800.0,
+            mode="replace",
+        )
+        # error = -500, P = -500
+        result = pm.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], -500.0)
+
+    # ------------------------------------------------------------------
+    # Zero gains (disabled)
+    # ------------------------------------------------------------------
+
+    def test_all_gains_zero_passthrough(self):
+        """With all gains at zero, the PID should have no effect."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [123.4]
+        pm = PidPowermeter(self.mock_powermeter, kp=0.0, ki=0.0, kd=0.0)
+        result = pm.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 123.4)
+
+    # ------------------------------------------------------------------
+    # wait_for_message pass-through
+    # ------------------------------------------------------------------
+
+    def test_wait_for_message_passthrough(self):
+        """wait_for_message should be delegated to the wrapped powermeter."""
+        pm = PidPowermeter(self.mock_powermeter, kp=1.0)
+        pm.wait_for_message(timeout=7)
+        self.mock_powermeter.wait_for_message.assert_called_once()
+        call_args = self.mock_powermeter.wait_for_message.call_args
+        if call_args[1]:
+            self.assertEqual(call_args[1]["timeout"], 7)
+        else:
+            self.assertEqual(call_args[0][0], 7)
+
+    # ------------------------------------------------------------------
+    # Immutability
+    # ------------------------------------------------------------------
+
+    def test_does_not_mutate_wrapped_list(self):
+        """The wrapper must not mutate the list from the inner powermeter."""
+        raw = [100.0, 200.0]
+        self.mock_powermeter.get_powermeter_watts.return_value = raw
+        pm = PidPowermeter(self.mock_powermeter, kp=0.5)
+
+        pm.get_powermeter_watts()
+        self.assertEqual(raw, [100.0, 200.0])
+
+    # ------------------------------------------------------------------
+    # First call — no derivative spike
+    # ------------------------------------------------------------------
+
+    def test_first_call_no_derivative_spike(self):
+        """The first call should not produce a derivative spike."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [500.0]
+        pm = PidPowermeter(
+            self.mock_powermeter, kp=0.0, kd=100.0, output_max=800.0
+        )
+        # First call: dt=0, so D term should be 0
+        result = pm.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 500.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/powermeter/slewrate.py
+++ b/powermeter/slewrate.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from typing import List, Optional
 from .base import Powermeter
@@ -44,26 +45,27 @@ class SlewRatePowermeter(Powermeter):
         return self.wrapped_powermeter.wait_for_message(timeout)
 
     def get_powermeter_watts(self) -> List[float]:
-        raw_values = self.wrapped_powermeter.get_powermeter_watts()
-        current_time = time.time()
-
-        if self.last_values is None or self.last_time is None:
-            # First reading – initialise without slewing
-            self.last_values = list(raw_values)
+        with self._lock:
+            raw_values = self.wrapped_powermeter.get_powermeter_watts()
+            current_time = time.time()
+    
+            if self.last_values is None or self.last_time is None:
+                # First reading – initialise without slewing
+                self.last_values = list(raw_values)
+                self.last_time = current_time
+                return list(raw_values)
+    
+            elapsed = current_time - self.last_time
+            max_change = self.slew_rate_watts_per_sec * elapsed
+    
+            slewed = []
+            for raw, last in zip(raw_values, self.last_values):
+                delta = raw - last
+                if abs(delta) <= max_change:
+                    slewed.append(raw)
+                else:
+                    slewed.append(last + max_change * (1.0 if delta > 0 else -1.0))
+    
+            self.last_values = slewed
             self.last_time = current_time
-            return list(raw_values)
-
-        elapsed = current_time - self.last_time
-        max_change = self.slew_rate_watts_per_sec * elapsed
-
-        slewed = []
-        for raw, last in zip(raw_values, self.last_values):
-            delta = raw - last
-            if abs(delta) <= max_change:
-                slewed.append(raw)
-            else:
-                slewed.append(last + max_change * (1.0 if delta > 0 else -1.0))
-
-        self.last_values = slewed
-        self.last_time = current_time
-        return list(slewed)
+            return list(slewed)

--- a/powermeter/slewrate.py
+++ b/powermeter/slewrate.py
@@ -1,0 +1,69 @@
+import time
+from typing import List, Optional
+from .base import Powermeter
+
+
+class SlewRatePowermeter(Powermeter):
+    """
+    A wrapper around a powermeter that limits the rate of change of power values.
+
+    Even when the underlying reading jumps by a large amount in a single
+    poll cycle, the reported value advances towards the target at most
+    ``slew_rate_watts_per_sec`` watts per second.  This prevents sudden
+    large steps from triggering an aggressive over-response in the storage
+    system that would then reverse direction and cause oscillation.
+
+    The slew limit is applied independently to each phase.
+
+    The very first reading is always forwarded as-is (no previous reference
+    exists, so there is nothing to slew from).
+    """
+
+    def __init__(
+        self, wrapped_powermeter: Powermeter, slew_rate_watts_per_sec: float
+    ):
+        """
+        Initialise the slew-rate powermeter wrapper.
+
+        Args:
+            wrapped_powermeter: The actual powermeter instance to wrap.
+            slew_rate_watts_per_sec: Maximum allowed change in watts per second
+                                     (must be > 0).
+        """
+        if slew_rate_watts_per_sec <= 0:
+            raise ValueError(
+                f"slew_rate_watts_per_sec must be positive, got {slew_rate_watts_per_sec}"
+            )
+        self.wrapped_powermeter = wrapped_powermeter
+        self.slew_rate_watts_per_sec = slew_rate_watts_per_sec
+        self.last_values: Optional[List[float]] = None
+        self.last_time: Optional[float] = None
+
+    def wait_for_message(self, timeout=5):
+        """Pass through to wrapped powermeter."""
+        return self.wrapped_powermeter.wait_for_message(timeout)
+
+    def get_powermeter_watts(self) -> List[float]:
+        raw_values = self.wrapped_powermeter.get_powermeter_watts()
+        current_time = time.time()
+
+        if self.last_values is None or self.last_time is None:
+            # First reading – initialise without slewing
+            self.last_values = list(raw_values)
+            self.last_time = current_time
+            return list(raw_values)
+
+        elapsed = current_time - self.last_time
+        max_change = self.slew_rate_watts_per_sec * elapsed
+
+        slewed = []
+        for raw, last in zip(raw_values, self.last_values):
+            delta = raw - last
+            if abs(delta) <= max_change:
+                slewed.append(raw)
+            else:
+                slewed.append(last + max_change * (1.0 if delta > 0 else -1.0))
+
+        self.last_values = slewed
+        self.last_time = current_time
+        return list(slewed)

--- a/powermeter/slewrate_test.py
+++ b/powermeter/slewrate_test.py
@@ -1,0 +1,111 @@
+import time
+import unittest
+from unittest.mock import Mock
+from .slewrate import SlewRatePowermeter
+
+
+class TestSlewRatePowermeter(unittest.TestCase):
+    def setUp(self):
+        self.mock_powermeter = Mock()
+
+    def test_first_reading_returned_unchanged(self):
+        """First call should return the raw value with no slewing applied."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [500.0]
+        pm = SlewRatePowermeter(self.mock_powermeter, slew_rate_watts_per_sec=100.0)
+
+        result = pm.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 500.0)
+
+    def test_small_change_passes_through_immediately(self):
+        """A change smaller than max_change for the elapsed time passes through."""
+        pm = SlewRatePowermeter(self.mock_powermeter, slew_rate_watts_per_sec=100.0)
+        self.mock_powermeter.get_powermeter_watts.return_value = [0.0]
+        pm.get_powermeter_watts()  # initialise at 0 W
+
+        # Simulate 1 second elapsed; max_change = 100 W; a 50 W jump should pass through
+        pm.last_time -= 1.0
+        self.mock_powermeter.get_powermeter_watts.return_value = [50.0]
+        result = pm.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 50.0)
+
+    def test_large_jump_is_slew_limited(self):
+        """A jump much larger than max_change should be clamped to max_change."""
+        pm = SlewRatePowermeter(self.mock_powermeter, slew_rate_watts_per_sec=100.0)
+        self.mock_powermeter.get_powermeter_watts.return_value = [0.0]
+        pm.get_powermeter_watts()  # initialise at 0 W
+
+        # Simulate 1 second elapsed; max_change = 100 W; raw jumps to 500 W
+        pm.last_time -= 1.0
+        self.mock_powermeter.get_powermeter_watts.return_value = [500.0]
+        result = pm.get_powermeter_watts()
+
+        # Reported value should advance by at most 100 W (with small real-time tolerance)
+        self.assertAlmostEqual(result[0], 100.0, delta=1.0)
+
+    def test_negative_jump_is_slew_limited(self):
+        """A negative jump larger than max_change is also clamped."""
+        pm = SlewRatePowermeter(self.mock_powermeter, slew_rate_watts_per_sec=100.0)
+        self.mock_powermeter.get_powermeter_watts.return_value = [500.0]
+        pm.get_powermeter_watts()  # initialise at 500 W
+
+        # Simulate 1 second elapsed; raw drops to 0 W
+        pm.last_time -= 1.0
+        self.mock_powermeter.get_powermeter_watts.return_value = [0.0]
+        result = pm.get_powermeter_watts()
+
+        self.assertAlmostEqual(result[0], 400.0, delta=1.0)
+
+    def test_slew_converges_to_target_over_time(self):
+        """Given enough time the slewed value should reach the target."""
+        pm = SlewRatePowermeter(self.mock_powermeter, slew_rate_watts_per_sec=100.0)
+        self.mock_powermeter.get_powermeter_watts.return_value = [0.0]
+        pm.get_powermeter_watts()  # initialise at 0 W
+
+        # Simulate 10 polling cycles each 1 second apart
+        target = 500.0
+        self.mock_powermeter.get_powermeter_watts.return_value = [target]
+        result = None
+        for _ in range(10):
+            pm.last_time -= 1.0
+            result = pm.get_powermeter_watts()
+
+        self.assertAlmostEqual(result[0], target, delta=1.0)
+
+    def test_three_phase_each_phase_slewed_independently(self):
+        """Each phase should be slewed independently."""
+        pm = SlewRatePowermeter(self.mock_powermeter, slew_rate_watts_per_sec=100.0)
+        self.mock_powermeter.get_powermeter_watts.return_value = [0.0, 0.0, 0.0]
+        pm.get_powermeter_watts()  # initialise
+
+        pm.last_time -= 1.0  # simulate 1 second elapsed
+        self.mock_powermeter.get_powermeter_watts.return_value = [50.0, 500.0, -500.0]
+        result = pm.get_powermeter_watts()
+
+        # Phase 1: 50 W jump < 100 W/s × 1 s → passes through
+        self.assertAlmostEqual(result[0], 50.0, delta=1.0)
+        # Phase 2: 500 W jump > 100 W/s → clamped to ~+100 W
+        self.assertAlmostEqual(result[1], 100.0, delta=1.0)
+        # Phase 3: -500 W jump > 100 W/s → clamped to ~-100 W
+        self.assertAlmostEqual(result[2], -100.0, delta=1.0)
+
+    def test_invalid_slew_rate_raises_error(self):
+        """Non-positive slew_rate_watts_per_sec should raise ValueError."""
+        with self.assertRaises(ValueError):
+            SlewRatePowermeter(self.mock_powermeter, slew_rate_watts_per_sec=0.0)
+        with self.assertRaises(ValueError):
+            SlewRatePowermeter(self.mock_powermeter, slew_rate_watts_per_sec=-50.0)
+
+    def test_wait_for_message_passthrough(self):
+        """wait_for_message should be delegated to the wrapped powermeter."""
+        pm = SlewRatePowermeter(self.mock_powermeter, slew_rate_watts_per_sec=100.0)
+        pm.wait_for_message(timeout=8)
+        self.mock_powermeter.wait_for_message.assert_called_once()
+        call_args = self.mock_powermeter.wait_for_message.call_args
+        if call_args[1]:
+            self.assertEqual(call_args[1]["timeout"], 8)
+        else:
+            self.assertEqual(call_args[0][0], 8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web_config.py
+++ b/web_config.py
@@ -370,6 +370,12 @@ const KEY_TYPES = {
   DEADBAND_WATTS:          { type: 'float' },
   HOLD_TIME:               { type: 'float' },
   TIMEOUT:                 { type: 'float' },
+  // PID controller
+  PID_KP:                  { type: 'float', min: 0 },
+  PID_KI:                  { type: 'float', min: 0 },
+  PID_KD:                  { type: 'float', min: 0 },
+  PID_OUTPUT_MAX:          { type: 'float', min: 0 },
+  PID_MODE:                { type: 'select', options: ['bias', 'replace'] },
   // Passwords
   PASS:                    { type: 'password' },
   PASSWORD:                { type: 'password' },
@@ -764,7 +770,7 @@ def write_config_from_dict(config_path: str, sections: Dict, order: list) -> Non
     for line in original_lines:
         stripped = line.strip()
         if stripped.startswith("[") and "]" in stripped:
-            name = stripped[1:stripped.index("]")]
+            name = stripped[1 : stripped.index("]")]
             if cur_name is not None:
                 parsed_sections.append([cur_name, cur_lines])
             else:
@@ -820,7 +826,9 @@ def write_config_from_dict(config_path: str, sections: Dict, order: list) -> Non
         if section not in sections:
             continue
         if section in orig_section_lines:
-            output_lines.extend(_update_section(orig_section_lines[section], sections[section]))
+            output_lines.extend(
+                _update_section(orig_section_lines[section], sections[section])
+            )
         else:
             # Entirely new section
             if output_lines and output_lines[-1].strip():

--- a/web_config.py
+++ b/web_config.py
@@ -4,6 +4,8 @@ Web-based configuration editor for B2500 Meter.
 Provides helpers and an HTML page for reading and editing config.ini via a browser.
 """
 
+import tempfile
+import threading
 import configparser
 import json
 import os
@@ -733,6 +735,16 @@ def read_config_as_dict(config_path: str) -> Tuple[Dict, list]:
         order.append(section)
     return sections, order
 
+_CONFIG_WRITE_LOCK = threading.Lock()
+
+def _atomic_write_lines(config_path: str, lines: list) -> None:
+    dir_name = os.path.dirname(config_path) or "."
+    with tempfile.NamedTemporaryFile("w", dir=dir_name, delete=False) as tmp:
+        tmp.writelines(lines)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp_path = tmp.name
+    os.replace(tmp_path, config_path)
 
 def write_config_from_dict(config_path: str, sections: Dict, order: list) -> None:
     """
@@ -758,8 +770,8 @@ def write_config_from_dict(config_path: str, sections: Dict, order: list) -> Non
             for key, value in sections[section].items():
                 lines.append(f"{key} = {value}\n")
             lines.append("\n")
-        with open(config_path, "w") as f:
-            f.writelines(lines)
+          with _CONFIG_WRITE_LOCK:
+            _atomic_write_lines(config_path, lines)
         return
 
     with open(config_path, "r") as f:
@@ -845,7 +857,8 @@ def write_config_from_dict(config_path: str, sections: Dict, order: list) -> Non
 
     with open(config_path, "w") as f:
         f.writelines(output_lines)
-
+    with _CONFIG_WRITE_LOCK:
+        _atomic_write_lines(config_path, output_lines)
 
 def config_to_json(config_path: str) -> str:
     """Return the config as a JSON string suitable for the web UI."""

--- a/web_config.py
+++ b/web_config.py
@@ -117,7 +117,7 @@ th {
 tr:not(:last-child) td { border-bottom: 1px solid #f8f8f8; }
 tr:hover td { background: #fafbff; }
 td.key-cell { width: 35%; }
-td.key-cell input, td.val-cell input {
+td.key-cell input, td.val-cell input, td.val-cell select {
   width: 100%;
   border: 1px solid transparent;
   border-radius: 5px;
@@ -127,13 +127,14 @@ td.key-cell input, td.val-cell input {
   color: #1a1a2e;
   transition: border-color .15s, background .15s;
 }
-td.key-cell input:hover, td.val-cell input:hover { border-color: #ddd; background: #f9f9f9; }
-td.key-cell input:focus, td.val-cell input:focus {
+td.key-cell input:hover, td.val-cell input:hover, td.val-cell select:hover { border-color: #ddd; background: #f9f9f9; }
+td.key-cell input:focus, td.val-cell input:focus, td.val-cell select:focus {
   border-color: #4ecca3;
   background: #fff;
   outline: none;
   box-shadow: 0 0 0 3px rgba(78,204,163,.15);
 }
+td.val-cell select { cursor: pointer; appearance: auto; }
 td.action-cell { width: 36px; text-align: center; }
 .btn-icon {
   background: none;
@@ -343,12 +344,180 @@ function renderSection(sectionName, pairs) {
   return card;
 }
 
+/* ===== Key-type metadata ===== */
+const KEY_TYPES = {
+  // Booleans
+  SKIP_POWERMETER_TEST:    { type: 'boolean' },
+  WEB_CONFIG_ENABLED:      { type: 'boolean' },
+  ENABLE_HEALTH_CHECK:     { type: 'boolean' },
+  DISABLE_SUM_PHASES:      { type: 'boolean' },
+  DISABLE_ABSOLUTE_VALUES: { type: 'boolean' },
+  HTTPS:                   { type: 'boolean' },
+  POWER_CALCULATE:         { type: 'boolean' },
+  JSON_POWER_CALCULATE:    { type: 'boolean' },
+  // Integers
+  POLL_INTERVAL:           { type: 'integer' },
+  PORT:                    { type: 'integer' },
+  UNIT_ID:                 { type: 'integer' },
+  ADDRESS:                 { type: 'integer' },
+  COUNT:                   { type: 'integer' },
+  // Floats
+  THROTTLE_INTERVAL:       { type: 'float' },
+  EMA_ALPHA:               { type: 'float', min: 0, max: 1 },
+  EMA_INTERVAL:            { type: 'float' },
+  POWER_OFFSET:            { type: 'float' },
+  SLEW_RATE_WATTS_PER_SEC: { type: 'float' },
+  DEADBAND_WATTS:          { type: 'float' },
+  HOLD_TIME:               { type: 'float' },
+  TIMEOUT:                 { type: 'float' },
+  // Passwords
+  PASS:                    { type: 'password' },
+  PASSWORD:                { type: 'password' },
+  ACCESSTOKEN:             { type: 'password' },
+  // Enums
+  TYPE:                    { type: 'select', options: ['1PM', 'PLUS1PM', 'EM', '3EM', '3EMPro'] },
+  DEVICE_TYPE:             { type: 'select', options: ['ct001', 'shellypro3em', 'shellyemg3', 'shellyproem50'] },
+  DATA_TYPE:               { type: 'select', options: ['UINT16', 'INT16', 'UINT32', 'INT32', 'FLOAT32', 'FLOAT64'] },
+  BYTE_ORDER:              { type: 'select', options: ['BIG', 'LITTLE'] },
+  WORD_ORDER:              { type: 'select', options: ['BIG', 'LITTLE'] },
+  REGISTER_TYPE:           { type: 'select', options: ['HOLDING', 'INPUT'] },
+};
+
+function makeValueInput(key, value) {
+  const info = KEY_TYPES[(key || '').toUpperCase()] || {};
+  switch (info.type) {
+
+    case 'boolean': {
+      const sel = document.createElement('select');
+      sel.className = 'val-input';
+      const lower = String(value).toLowerCase();
+      const boolOptions = ['True', 'False'];
+      const normalised = ['true', 'yes', 'on', '1'].includes(lower) ? boolOptions[0] : boolOptions[1];
+      boolOptions.forEach(opt => {
+        const o = document.createElement('option');
+        o.value = opt;
+        o.textContent = opt;
+        if (opt === normalised) o.selected = true;
+        sel.appendChild(o);
+      });
+      return sel;
+    }
+
+    case 'integer': {
+      const inp = document.createElement('input');
+      inp.type = 'number';
+      inp.step = '1';
+      inp.className = 'val-input';
+      inp.value = value;
+      inp.placeholder = '0';
+      return inp;
+    }
+
+    case 'float': {
+      const inp = document.createElement('input');
+      inp.type = 'number';
+      inp.step = 'any';
+      inp.className = 'val-input';
+      inp.value = value;
+      inp.placeholder = '0';
+      if (info.min !== undefined) inp.min = info.min;
+      if (info.max !== undefined) inp.max = info.max;
+      return inp;
+    }
+
+    case 'password': {
+      const wrapper = document.createElement('span');
+      wrapper.style.cssText = 'display:flex;align-items:center;gap:4px;width:100%';
+      const inp = document.createElement('input');
+      inp.type = 'password';
+      inp.className = 'val-input';
+      inp.value = value;
+      inp.autocomplete = 'off';
+      inp.style.flex = '1';
+      const toggle = document.createElement('button');
+      toggle.type = 'button';
+      toggle.className = 'btn-icon';
+      toggle.title = 'Show / hide';
+      toggle.style.cssText = 'flex-shrink:0;font-size:.85rem;color:#aaa';
+      toggle.textContent = '\uD83D\uDC41';
+      toggle.addEventListener('click', () => {
+        inp.type = inp.type === 'password' ? 'text' : 'password';
+      });
+      wrapper.appendChild(inp);
+      wrapper.appendChild(toggle);
+      return wrapper;
+    }
+
+    case 'select': {
+      const sel = document.createElement('select');
+      sel.className = 'val-input';
+      const lower = String(value).toLowerCase();
+      const hasMatch = info.options.some(o => o.toLowerCase() === lower);
+      if (value !== '' && !hasMatch) {
+        // Preserve an unknown current value as a custom option
+        const o = document.createElement('option');
+        o.value = value;
+        o.textContent = value;
+        o.selected = true;
+        sel.appendChild(o);
+      }
+      info.options.forEach(opt => {
+        const o = document.createElement('option');
+        o.value = opt;
+        o.textContent = opt;
+        if (opt.toLowerCase() === lower) o.selected = true;
+        sel.appendChild(o);
+      });
+      return sel;
+    }
+
+    default: {
+      const inp = document.createElement('input');
+      inp.type = 'text';
+      inp.className = 'val-input';
+      inp.value = value;
+      inp.placeholder = 'value';
+      return inp;
+    }
+  }
+}
+
 function renderRow(key, value) {
   const tr = document.createElement('tr');
-  tr.innerHTML = `
-    <td class="key-cell"><input type="text" class="key-input" value="${esc(key)}" placeholder="KEY"></td>
-    <td class="val-cell"><input type="text" class="val-input" value="${esc(value)}" placeholder="value"></td>
-    <td class="action-cell"><button class="btn-icon" title="Remove key" onclick="removeRow(this)">&#215;</button></td>`;
+
+  const keyTd = document.createElement('td');
+  keyTd.className = 'key-cell';
+  const keyInp = document.createElement('input');
+  keyInp.type = 'text';
+  keyInp.className = 'key-input';
+  keyInp.value = key;
+  keyInp.placeholder = 'KEY';
+  keyTd.appendChild(keyInp);
+
+  const valTd = document.createElement('td');
+  valTd.className = 'val-cell';
+  valTd.appendChild(makeValueInput(key, value));
+
+  const actTd = document.createElement('td');
+  actTd.className = 'action-cell';
+  const delBtn = document.createElement('button');
+  delBtn.className = 'btn-icon';
+  delBtn.title = 'Remove key';
+  delBtn.innerHTML = '&#215;';
+  delBtn.addEventListener('click', function () { removeRow(this); });
+  actTd.appendChild(delBtn);
+
+  tr.appendChild(keyTd);
+  tr.appendChild(valTd);
+  tr.appendChild(actTd);
+
+  // When the key name is changed, swap the value element to the right type.
+  keyInp.addEventListener('change', () => {
+    const elem = valTd.querySelector('.val-input');
+    const currentVal = elem ? elem.value : '';
+    valTd.replaceChildren(makeValueInput(keyInp.value, currentVal));
+  });
+
   return tr;
 }
 

--- a/web_config.py
+++ b/web_config.py
@@ -1,0 +1,671 @@
+"""
+Web-based configuration editor for B2500 Meter.
+
+Provides helpers and an HTML page for reading and editing config.ini via a browser.
+"""
+
+import configparser
+import json
+import os
+from collections import OrderedDict
+from typing import Dict, Tuple
+
+CONFIG_EDITOR_HTML = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>B2500 Meter &ndash; Configuration Editor</title>
+<style>
+*, *::before, *::after { box-sizing: border-box; }
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #f0f2f5;
+  color: #1a1a2e;
+  margin: 0;
+  min-height: 100vh;
+}
+header {
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  color: #fff;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,.3);
+}
+header h1 { font-size: 1.25rem; font-weight: 600; margin: 0; }
+header .subtitle { font-size: 0.8rem; opacity: .7; margin: 0; }
+main {
+  max-width: 900px;
+  margin: 1.5rem auto;
+  padding: 0 1rem 4rem;
+}
+.banner {
+  display: none;
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 8px;
+  padding: .75rem 1rem;
+  margin-bottom: 1rem;
+  font-size: .875rem;
+  color: #856404;
+}
+.banner.visible { display: flex; align-items: center; gap: .5rem; }
+.section-card {
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 1px 4px rgba(0,0,0,.1);
+  margin-bottom: 1rem;
+  overflow: hidden;
+}
+.section-header {
+  display: flex;
+  align-items: center;
+  padding: .6rem 1rem;
+  background: #16213e;
+  color: #fff;
+  cursor: pointer;
+  user-select: none;
+  gap: .5rem;
+}
+.section-header h2 {
+  font-size: .95rem;
+  font-weight: 600;
+  margin: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+}
+.section-header h2 input {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid rgba(255,255,255,.4);
+  color: #fff;
+  font-size: .95rem;
+  font-weight: 600;
+  width: auto;
+  min-width: 120px;
+  padding: 0 2px;
+  outline: none;
+}
+.section-header h2 input:focus { border-bottom-color: #4ecca3; }
+.section-header .chevron {
+  transition: transform .2s;
+  font-size: .75rem;
+}
+.section-header.collapsed .chevron { transform: rotate(-90deg); }
+.section-body {
+  padding: .5rem 0;
+}
+.section-body.hidden { display: none; }
+table { width: 100%; border-collapse: collapse; }
+th, td {
+  padding: .45rem .9rem;
+  text-align: left;
+  font-size: .875rem;
+}
+th {
+  color: #888;
+  font-weight: 500;
+  font-size: .75rem;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  border-bottom: 1px solid #f0f0f0;
+}
+tr:not(:last-child) td { border-bottom: 1px solid #f8f8f8; }
+tr:hover td { background: #fafbff; }
+td.key-cell { width: 35%; }
+td.key-cell input, td.val-cell input {
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  padding: .35rem .5rem;
+  font-size: .875rem;
+  background: transparent;
+  color: #1a1a2e;
+  transition: border-color .15s, background .15s;
+}
+td.key-cell input:hover, td.val-cell input:hover { border-color: #ddd; background: #f9f9f9; }
+td.key-cell input:focus, td.val-cell input:focus {
+  border-color: #4ecca3;
+  background: #fff;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(78,204,163,.15);
+}
+td.action-cell { width: 36px; text-align: center; }
+.btn-icon {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: .25rem;
+  border-radius: 4px;
+  color: #aaa;
+  font-size: 1rem;
+  line-height: 1;
+  transition: color .15s, background .15s;
+}
+.btn-icon:hover { color: #e74c3c; background: #fdf0f0; }
+.section-footer {
+  padding: .4rem .9rem;
+  border-top: 1px solid #f4f4f4;
+  display: flex;
+  gap: .5rem;
+}
+.btn {
+  border: none;
+  cursor: pointer;
+  border-radius: 6px;
+  font-size: .8rem;
+  font-weight: 500;
+  padding: .35rem .75rem;
+  transition: opacity .15s, transform .1s;
+}
+.btn:hover { opacity: .88; }
+.btn:active { transform: scale(.97); }
+.btn-add-key { background: #eaf6f0; color: #27ae60; }
+.btn-remove-section { background: #fdecea; color: #c0392b; margin-left: auto; }
+.toolbar {
+  display: flex;
+  gap: .75rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.btn-add-section { background: #e8f4fd; color: #2980b9; }
+.btn-save {
+  background: #4ecca3;
+  color: #1a1a2e;
+  font-weight: 700;
+  font-size: .95rem;
+  padding: .5rem 1.5rem;
+  border-radius: 8px;
+  margin-left: auto;
+}
+.btn-save:disabled { opacity: .5; cursor: not-allowed; }
+.status-bar {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #222;
+  color: #fff;
+  border-radius: 8px;
+  padding: .6rem 1.2rem;
+  font-size: .875rem;
+  box-shadow: 0 4px 16px rgba(0,0,0,.25);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .3s;
+  white-space: nowrap;
+}
+.status-bar.success { background: #27ae60; }
+.status-bar.error { background: #c0392b; }
+.status-bar.visible { opacity: 1; pointer-events: auto; }
+.btn-save-restart {
+  background: #e67e22;
+  color: #fff;
+  font-weight: 700;
+  font-size: .95rem;
+  padding: .5rem 1.5rem;
+  border-radius: 8px;
+}
+.btn-save-restart:disabled { opacity: .5; cursor: not-allowed; }
+.overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(22, 33, 62, 0.92);
+  z-index: 999;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  gap: 1rem;
+}
+.overlay.visible { display: flex; }
+.overlay h2 { font-size: 1.5rem; margin: 0; }
+.overlay p { font-size: 1rem; opacity: .75; margin: 0; }
+.spinner {
+  width: 48px; height: 48px;
+  border: 4px solid rgba(255,255,255,.2);
+  border-top-color: #4ecca3;
+  border-radius: 50%;
+  animation: spin .9s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+</style>
+</head>
+<body>
+<header>
+  <div>
+    <h1>&#9889; B2500 Meter &ndash; Configuration Editor</h1>
+    <p class="subtitle">Edit and save your config.ini settings</p>
+  </div>
+</header>
+<main>
+  <div id="restart-banner" class="banner">
+    <span>&#9888;&#65039;</span>
+    <span>Configuration saved. <strong>Restart the service</strong> to apply the changes.</span>
+  </div>
+
+  <div class="toolbar">
+    <button class="btn btn-add-section" onclick="addSection()">&#43; Add Section</button>
+    <button id="save-btn" class="btn btn-save" onclick="saveConfig()">&#128190; Save Configuration</button>
+    <button id="save-restart-btn" class="btn btn-save-restart" onclick="saveAndRestart()">&#9654; Save &amp; Restart</button>
+  </div>
+
+  <div id="config-container">
+    <p class="loading">Loading configuration&hellip;</p>
+  </div>
+</main>
+<div id="status-bar" class="status-bar"></div>
+<div id="restart-overlay" class="overlay">
+  <div class="spinner"></div>
+  <h2>Restarting service&hellip;</h2>
+  <p id="reconnect-msg">Reconnecting in <span id="reconnect-countdown">20</span>s</p>
+</div>
+
+<script>
+/* ===== State ===== */
+let currentConfig = {};   // { sectionName: { key: value, ... }, ... }
+let sectionOrder = [];    // preserve section order
+
+/* ===== Boot ===== */
+async function loadConfig() {
+  try {
+    const resp = await fetch('/api/config');
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    const data = await resp.json();
+    currentConfig = data.sections || {};
+    sectionOrder = data.order || Object.keys(currentConfig);
+    renderAll();
+  } catch (e) {
+    document.getElementById('config-container').innerHTML =
+      '<p class="loading" style="color:#c0392b">&#10060; Failed to load configuration: ' + e.message + '</p>';
+  }
+}
+
+/* ===== Rendering ===== */
+function renderAll() {
+  const container = document.getElementById('config-container');
+  container.innerHTML = '';
+  sectionOrder.forEach(sec => {
+    container.appendChild(renderSection(sec, currentConfig[sec] || {}));
+  });
+}
+
+function renderSection(sectionName, pairs) {
+  const card = document.createElement('div');
+  card.className = 'section-card';
+  card.dataset.section = sectionName;
+
+  // Header
+  const header = document.createElement('div');
+  header.className = 'section-header';
+  header.innerHTML = `
+    <h2>
+      <span style="opacity:.6;font-size:.8rem">[</span>
+      <input type="text" class="section-name-input" value="${esc(sectionName)}" title="Section name">
+      <span style="opacity:.6;font-size:.8rem">]</span>
+    </h2>
+    <span class="chevron">&#9660;</span>`;
+  header.addEventListener('click', (e) => {
+    if (e.target.tagName === 'INPUT') return;
+    header.classList.toggle('collapsed');
+    card.querySelector('.section-body').classList.toggle('hidden');
+  });
+
+  // Body
+  const body = document.createElement('div');
+  body.className = 'section-body';
+  const table = document.createElement('table');
+  table.innerHTML = '<thead><tr><th>Key</th><th>Value</th><th></th></tr></thead>';
+  const tbody = document.createElement('tbody');
+  tbody.className = 'key-value-body';
+  Object.entries(pairs).forEach(([k, v]) => {
+    tbody.appendChild(renderRow(k, v));
+  });
+  table.appendChild(tbody);
+  body.appendChild(table);
+
+  // Footer
+  const footer = document.createElement('div');
+  footer.className = 'section-footer';
+  footer.innerHTML = `
+    <button class="btn btn-add-key" onclick="addKey(this)">&#43; Add Key</button>
+    <button class="btn btn-remove-section" onclick="removeSection(this)">&#128465; Remove Section</button>`;
+
+  card.appendChild(header);
+  card.appendChild(body);
+  card.appendChild(footer);
+  return card;
+}
+
+function renderRow(key, value) {
+  const tr = document.createElement('tr');
+  tr.innerHTML = `
+    <td class="key-cell"><input type="text" class="key-input" value="${esc(key)}" placeholder="KEY"></td>
+    <td class="val-cell"><input type="text" class="val-input" value="${esc(value)}" placeholder="value"></td>
+    <td class="action-cell"><button class="btn-icon" title="Remove key" onclick="removeRow(this)">&#215;</button></td>`;
+  return tr;
+}
+
+/* ===== Actions ===== */
+function addSection() {
+  const sectionName = 'NEW_SECTION';
+  let name = sectionName;
+  let i = 1;
+  while (sectionOrder.includes(name)) { name = sectionName + '_' + (i++); }
+  sectionOrder.push(name);
+  currentConfig[name] = {};
+  const container = document.getElementById('config-container');
+  container.appendChild(renderSection(name, {}));
+  // Focus the section name input
+  const lastCard = container.lastElementChild;
+  const input = lastCard.querySelector('.section-name-input');
+  input.select();
+  input.focus();
+}
+
+function addKey(btn) {
+  const card = btn.closest('.section-card');
+  const tbody = card.querySelector('.key-value-body');
+  tbody.appendChild(renderRow('', ''));
+  tbody.lastElementChild.querySelector('.key-input').focus();
+}
+
+function removeRow(btn) {
+  btn.closest('tr').remove();
+}
+
+function removeSection(btn) {
+  const card = btn.closest('.section-card');
+  const name = card.dataset.section;
+  if (!confirm('Remove section [' + name + '] and all its keys?')) return;
+  card.remove();
+  sectionOrder = sectionOrder.filter(s => s !== name);
+  delete currentConfig[name];
+}
+
+/* ===== Collect data from DOM ===== */
+function collectConfig() {
+  const result = {};
+  const order = [];
+  document.querySelectorAll('.section-card').forEach(card => {
+    const nameInput = card.querySelector('.section-name-input');
+    const sectionName = nameInput.value.trim();
+    if (!sectionName) return;
+    const pairs = {};
+    card.querySelectorAll('.key-value-body tr').forEach(tr => {
+      const key = tr.querySelector('.key-input').value.trim();
+      const val = tr.querySelector('.val-input').value.trim();
+      if (key) pairs[key] = val;
+    });
+    result[sectionName] = pairs;
+    order.push(sectionName);
+  });
+  return { sections: result, order };
+}
+
+/* ===== Save ===== */
+async function saveConfig() {
+  const saveBtn = document.getElementById('save-btn');
+  saveBtn.disabled = true;
+  saveBtn.textContent = 'Saving\u2026';
+  try {
+    const payload = collectConfig();
+    const resp = await fetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const data = await resp.json();
+    if (resp.ok && data.success) {
+      showStatus('Configuration saved successfully!', 'success');
+      document.getElementById('restart-banner').classList.add('visible');
+    } else {
+      showStatus('Error: ' + (data.error || 'Unknown error'), 'error');
+    }
+  } catch (e) {
+    showStatus('Failed to save: ' + e.message, 'error');
+  } finally {
+    saveBtn.disabled = false;
+    saveBtn.textContent = '\uD83D\uDCBE Save Configuration';
+  }
+}
+
+/* ===== Save & Restart ===== */
+async function saveAndRestart() {
+  const saveRestartBtn = document.getElementById('save-restart-btn');
+  const saveBtn = document.getElementById('save-btn');
+  saveRestartBtn.disabled = true;
+  saveBtn.disabled = true;
+  saveRestartBtn.textContent = 'Saving\u2026';
+  try {
+    // Step 1: save config
+    const payload = collectConfig();
+    const saveResp = await fetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const saveData = await saveResp.json();
+    if (!saveResp.ok || !saveData.success) {
+      showStatus('Error saving: ' + (saveData.error || 'Unknown error'), 'error');
+      saveRestartBtn.disabled = false;
+      saveBtn.disabled = false;
+      saveRestartBtn.textContent = '\u25B6 Save & Restart';
+      return;
+    }
+
+    // Step 2: trigger restart
+    saveRestartBtn.textContent = 'Restarting\u2026';
+    try {
+      await fetch('/api/restart', { method: 'POST' });
+    } catch (_) {
+      // Connection drop is expected as the service restarts
+    }
+
+    // Step 3: show overlay and poll until the service is back
+    showRestartOverlay();
+  } catch (e) {
+    showStatus('Failed: ' + e.message, 'error');
+    saveRestartBtn.disabled = false;
+    saveBtn.disabled = false;
+    saveRestartBtn.textContent = '\u25B6 Save & Restart';
+  }
+}
+
+function showRestartOverlay() {
+  const overlay = document.getElementById('restart-overlay');
+  overlay.classList.add('visible');
+  let remaining = 20;
+  document.getElementById('reconnect-countdown').textContent = remaining;
+
+  const ticker = setInterval(() => {
+    remaining -= 1;
+    document.getElementById('reconnect-countdown').textContent = remaining;
+  }, 1000);
+
+  // Poll /health until it responds, then reload
+  const poll = setInterval(async () => {
+    try {
+      const r = await fetch('/health', { cache: 'no-store' });
+      if (r.ok) {
+        clearInterval(poll);
+        clearInterval(ticker);
+        window.location.reload();
+      }
+    } catch (_) { /* still restarting */ }
+  }, 1500);
+
+  // Safety: reload after 30 s even if polling hasn't confirmed yet
+  setTimeout(() => {
+    clearInterval(poll);
+    clearInterval(ticker);
+    window.location.reload();
+  }, 30000);
+}
+
+/* ===== Utilities ===== */
+function esc(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+let statusTimer = null;
+function showStatus(msg, type) {
+  const bar = document.getElementById('status-bar');
+  bar.textContent = msg;
+  bar.className = 'status-bar visible ' + (type || '');
+  clearTimeout(statusTimer);
+  statusTimer = setTimeout(() => { bar.className = 'status-bar'; }, 4000);
+}
+
+/* ===== Init ===== */
+loadConfig();
+</script>
+</body>
+</html>
+"""
+
+
+def read_config_as_dict(config_path: str) -> Tuple[Dict, list]:
+    """
+    Read config.ini and return (sections_dict, ordered_section_list).
+
+    The sections_dict maps section names to dicts of key->value.
+    Case of keys is preserved.
+    """
+    cfg = configparser.RawConfigParser(dict_type=OrderedDict)
+    cfg.optionxform = str  # preserve key case
+    if os.path.exists(config_path):
+        cfg.read(config_path)
+    sections: Dict[str, Dict[str, str]] = {}
+    order = []
+    for section in cfg.sections():
+        sections[section] = dict(cfg.items(section))
+        order.append(section)
+    return sections, order
+
+
+def write_config_from_dict(config_path: str, sections: Dict, order: list) -> None:
+    """
+    Write config.ini from the provided sections dict, preserving existing comments.
+
+    If *config_path* already exists, comment lines (``#`` / ``;``) and blank
+    lines are kept in their original positions while key values are updated
+    in-place.  Keys absent from *sections* are removed; keys that are new are
+    appended at the end of their section.  Sections absent from *sections* are
+    dropped.  If the file does not yet exist it is written from scratch.
+
+    ``sections`` maps section names to dicts of key->value.
+    ``order`` controls the section order; sections not listed are appended last.
+    """
+    write_order = list(order) + [s for s in sections if s not in order]
+
+    if not os.path.exists(config_path):
+        lines: list = []
+        for section in write_order:
+            if section not in sections:
+                continue
+            lines.append(f"[{section}]\n")
+            for key, value in sections[section].items():
+                lines.append(f"{key} = {value}\n")
+            lines.append("\n")
+        with open(config_path, "w") as f:
+            f.writelines(lines)
+        return
+
+    with open(config_path, "r") as f:
+        original_lines = f.readlines()
+
+    # Split the original file into a preamble (lines before the first section
+    # header) and a list of [section_name, raw_lines] pairs.
+    pre_lines: list = []
+    parsed_sections: list = []  # list of [name, [raw lines including header]]
+    cur_name = None
+    cur_lines: list = []
+
+    for line in original_lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and "]" in stripped:
+            name = stripped[1:stripped.index("]")]
+            if cur_name is not None:
+                parsed_sections.append([cur_name, cur_lines])
+            else:
+                pre_lines = cur_lines
+            cur_name = name
+            cur_lines = [line]
+        else:
+            cur_lines.append(line)
+    if cur_name is not None:
+        parsed_sections.append([cur_name, cur_lines])
+    elif cur_lines:
+        pre_lines = cur_lines
+
+    orig_section_lines = {name: sec_lines for name, sec_lines in parsed_sections}
+
+    def _update_section(orig_sec_lines: list, new_pairs: Dict) -> list:
+        """Return updated raw lines for one section, preserving comments."""
+        result = [orig_sec_lines[0]]  # section header line
+        written: set = set()
+        pending: list = []  # buffered comment/blank lines preceding a key
+
+        for line in orig_sec_lines[1:]:
+            stripped = line.strip()
+            if stripped == "" or stripped.startswith("#") or stripped.startswith(";"):
+                pending.append(line)
+            elif "=" in stripped:
+                key = stripped.split("=", 1)[0].strip()
+                if key in new_pairs:
+                    result.extend(pending)
+                    pending = []
+                    result.append(f"{key} = {new_pairs[key]}\n")
+                    written.add(key)
+                else:
+                    # Key was deleted – discard its associated comments too
+                    pending = []
+            else:
+                result.extend(pending)
+                pending = []
+                result.append(line)
+
+        result.extend(pending)  # trailing blank/comment lines at section end
+
+        # Append brand-new keys not present in the original section
+        for key, value in new_pairs.items():
+            if key not in written:
+                result.append(f"{key} = {value}\n")
+
+        return result
+
+    output_lines = list(pre_lines)
+
+    for section in write_order:
+        if section not in sections:
+            continue
+        if section in orig_section_lines:
+            output_lines.extend(_update_section(orig_section_lines[section], sections[section]))
+        else:
+            # Entirely new section
+            if output_lines and output_lines[-1].strip():
+                output_lines.append("\n")
+            output_lines.append(f"[{section}]\n")
+            for key, value in sections[section].items():
+                output_lines.append(f"{key} = {value}\n")
+            output_lines.append("\n")
+
+    with open(config_path, "w") as f:
+        f.writelines(output_lines)
+
+
+def config_to_json(config_path: str) -> str:
+    """Return the config as a JSON string suitable for the web UI."""
+    sections, order = read_config_as_dict(config_path)
+    return json.dumps({"sections": sections, "order": order})

--- a/web_config.py
+++ b/web_config.py
@@ -568,10 +568,15 @@ function removeSection(btn) {
 function collectConfig() {
   const result = {};
   const order = [];
+  const seenSections = new Set();
   document.querySelectorAll('.section-card').forEach(card => {
     const nameInput = card.querySelector('.section-name-input');
     const sectionName = nameInput.value.trim();
     if (!sectionName) return;
+    if (seenSections.has(sectionName)) {
+      throw new Error('Duplicate section name: [' + sectionName + ']');
+    }
+    seenSections.add(sectionName);
     const pairs = {};
     card.querySelectorAll('.key-value-body tr').forEach(tr => {
       const key = tr.querySelector('.key-input').value.trim();


### PR DESCRIPTION
First of all many thanks to @tomquist and all other contributors for this great tool!

During my experiments to get a zero feed-in system using a Marstek B2500-D I was not able to eliminate oszilations as much as I would like to, so I started playing around a bit with control theory together with GthubCopilot/Cloud Sonnet 4.6.
So some new signal filtering and control features have been added to the code, also a little web page was added to change the config.ini content easily and restart the docker container. 
At the end I achieved pretty good results using THROTTLE_INTERVAL = 4 together with PID_KP = 0.5 and PID_MODE=bias.
To prevent feed-in I also use POWER_OFFSET = -20, which reduces the power drawn from grid the B2500-D sees by 20, so that the zero feed in effectively gives a 20 watt import from the grid as the control target.

The other signal filtering and control features (EMA, SLEW_RATE, DEADBAND, HOLD_TIME) may help others with other type of storage.
See config.ini.example for more details.

Here is the copilot created summary:
This pull request adds a comprehensive set of new signal filtering and control features to the powermeter configuration system, allowing for advanced smoothing, correction, and closed-loop control of power readings. It introduces new global and per-device configuration options (such as EMA (**e**xponential **m**oving **a**verage) smoothing, slew-rate limiting, dead-band filtering, hold timers, power offsets, and PID controllers) and updates the configuration loader to apply these filters in a flexible, layered manner. Additionally, it improves robustness by introducing safe configuration value parsing with logging for invalid entries.

**Major new features and improvements:**

**Signal filtering and control enhancements:**
* Added support for global and per-powermeter configuration of advanced signal processing filters, including exponential moving average (EMA) smoothing, slew-rate limiting, dead-band filtering, hold timers, power offsets, and PID controllers. These can be tuned via new options in `config.ini.example` and are applied in a configurable filter chain for each powermeter. [[1]](diffhunk://#diff-03c62cb3e26f06d4d8277f11504a5121def68db562388cd769c2c6aaa234a811R22-R112) [[2]](diffhunk://#diff-03c62cb3e26f06d4d8277f11504a5121def68db562388cd769c2c6aaa234a811R123-R139) [[3]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeR70-R75) [[4]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeL63-R137) [[5]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeR151-R281)

**Configuration system robustness:**
* Introduced `safe_getboolean`, `safe_getint`, and `safe_getfloat` helper functions in `config/config_loader.py` to safely parse configuration values and log warnings on invalid entries, preventing crashes due to misconfiguration. These are now used throughout the powermeter and client filter creation logic. [[1]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeR6-R48) [[2]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeL171-R368) [[3]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeL214-R414) [[4]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeL270-R470) [[5]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeL287-R484) [[6]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeL299-R496) [[7]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeL325-R522) [[8]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeL335-R532) [[9]](diffhunk://#diff-456ce74eaa9ecc51ec316b7a99d07ce03eae2a0ef29f1e71660c68781a4ab5f1R23-R25)

**Configuration options and documentation:**
* Expanded `config.ini.example` with detailed documentation and default values for all new signal filtering and control options, including usage guidance and tuning tips for the PID controller. Also added options for enabling/disabling a web-based configuration editor. [[1]](diffhunk://#diff-03c62cb3e26f06d4d8277f11504a5121def68db562388cd769c2c6aaa234a811R6-R8) [[2]](diffhunk://#diff-03c62cb3e26f06d4d8277f11504a5121def68db562388cd769c2c6aaa234a811R22-R112) [[3]](diffhunk://#diff-03c62cb3e26f06d4d8277f11504a5121def68db562388cd769c2c6aaa234a811R123-R139)

**Internal codebase updates:**
* Updated the powermeter creation pipeline in `config/config_loader.py` to layer the new filters and controllers in the correct order, supporting both global defaults and per-device overrides. [[1]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeL63-R137) [[2]](diffhunk://#diff-2de66d19b08eb5721fc5f83faccb38ff9ea5b617b8a61c7647a0389fb366bcfeR151-R281)

**Test support:**
* Exported the new safe config parsing helpers from `config_loader.py` for use in tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Web-based configuration editor with API endpoints, save & restart flow, and persistent load/save
  * New power-processing options: EMA smoothing, slew-rate limiting, deadband filtering, hold-time control, per-device offsets, and PID-based power adjustment
  * Per-device override settings and safer config parsing with validation and sensible fallbacks

* **Tests**
  * Comprehensive unit tests covering the new filters, PID logic, and config helpers

* **Chores**
  * .gitignore updated to ignore test-results.xml
<!-- end of auto-generated comment: release notes by coderabbit.ai -->