### PR TITLE
Add wait_for_next_message so CT002 serves fresh powermeter data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Fixed MQTT powermeter `wait_for_next_message` returning too early in multi-topic mode, which could leave some phase values unset and cause `get_powermeter_watts()` to fail
 - Added opt-in web-based configuration editor (`WEB_CONFIG_ENABLED = True` in `[GENERAL]`) accessible at `http://<host>:52500/config`; supports editing all config sections and keys with type-appropriate inputs, comment preservation, and a Save & Restart button
 - **Breaking:** Rebrand project from "B2500 Meter" to "AstraMeter" (formerly b2500-meter). Package renamed to `astrameter`, CLI commands are now `astrameter` and `astra-sim`. Docker image moved from `ghcr.io/tomquist/b2500-meter` to `ghcr.io/tomquist/astrameter` (the legacy `ghcr.io/tomquist/b2500-meter` image is still published in parallel for backward compatibility). Home Assistant users must update their app repository URL to `https://github.com/tomquist/astrameter#main`.
 - Added CT002/CT003 emulation for steering multiple Marstek storage devices over the Marstek CT UDP protocol, with opt-in efficiency optimization that concentrates power on fewer batteries at low demand and rotates fairly over time (`MIN_EFFICIENT_POWER`, `EFFICIENCY_ROTATION_INTERVAL`, and related tuning options)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## Next
-- Fixed MQTT powermeter `wait_for_next_message` returning too early in multi-topic mode, which could leave some phase values unset and cause `get_powermeter_watts()` to fail
 - Added opt-in web-based configuration editor (`WEB_CONFIG_ENABLED = True` in `[GENERAL]`) accessible at `http://<host>:52500/config`; supports editing all config sections and keys with type-appropriate inputs, comment preservation, and a Save & Restart button
 - **Breaking:** Rebrand project from "B2500 Meter" to "AstraMeter" (formerly b2500-meter). Package renamed to `astrameter`, CLI commands are now `astrameter` and `astra-sim`. Docker image moved from `ghcr.io/tomquist/b2500-meter` to `ghcr.io/tomquist/astrameter` (the legacy `ghcr.io/tomquist/b2500-meter` image is still published in parallel for backward compatibility). Home Assistant users must update their app repository URL to `https://github.com/tomquist/astrameter#main`.
 - Added CT002/CT003 emulation for steering multiple Marstek storage devices over the Marstek CT UDP protocol, with opt-in efficiency optimization that concentrates power on fewer batteries at low demand and rotates fairly over time (`MIN_EFFICIENT_POWER`, `EFFICIENCY_ROTATION_INTERVAL`, and related tuning options)

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -457,8 +457,9 @@ class CT002:
         ]
 
         phase_values = self._collect_reports_by_phase()
+        phase_power = [phase_a, phase_b, phase_c]
         for phase, idx in (("A", 0), ("B", 1), ("C", 2)):
-            if phase_values[phase]["active"]:
+            if phase_values[phase]["active"] or phase_power[idx] != 0:
                 response_fields[8 + idx] = "1"
             response_fields[15 + idx] = str(phase_values[phase]["chrg_power"])
             response_fields[20 + idx] = str(phase_values[phase]["dchrg_power"])
@@ -579,14 +580,13 @@ class CT002:
             return
         self._last_response_time[addr] = current_time
 
-        if not in_inspection_mode:
-            meter_dev_type = fields[0] if len(fields) > 0 else ""
-            self._update_consumer_report(
-                consumer_id,
-                phase=reported_phase,
-                power=reported_power,
-                device_type=meter_dev_type,
-            )
+        meter_dev_type = fields[0] if len(fields) > 0 else ""
+        self._update_consumer_report(
+            consumer_id,
+            phase=reported_phase if not in_inspection_mode else "A",
+            power=reported_power,
+            device_type=meter_dev_type,
+        )
 
         updated = await self._call_before_send(addr, fields, consumer_id)
         if updated is not None:

--- a/src/astrameter/main.py
+++ b/src/astrameter/main.py
@@ -211,6 +211,7 @@ async def run_device(
             if powermeter is None:
                 logger.debug(f"No powermeter found for client {addr[0]}")
                 return None
+            await powermeter.wait_for_next_message()
             values = await powermeter.get_powermeter_watts()
             value1 = values[0] if len(values) > 0 else 0
             value2 = values[1] if len(values) > 1 else 0

--- a/src/astrameter/powermeter/base.py
+++ b/src/astrameter/powermeter/base.py
@@ -6,6 +6,15 @@ class Powermeter:
     async def wait_for_message(self, timeout=5):
         pass
 
+    async def wait_for_next_message(self, timeout=5):
+        """Block until a *new* measurement arrives (push-based powermeters).
+
+        Unlike ``wait_for_message`` (which returns immediately once data has
+        been received *at least once*), this method waits for the *next*
+        update, ensuring callers always get fresh data.  Polling-based
+        powermeters leave the default no-op.
+        """
+
     # --- Lifecycle (no-op by default, override for push-based powermeters) ---
 
     async def start(self):

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -77,6 +77,7 @@ class HomeAssistant(Powermeter):
         self._session: aiohttp.ClientSession | None = None
         self._ws_task: asyncio.Task[None] | None = None
         self._entities_ready = asyncio.Event()
+        self._message_event = asyncio.Event()
 
     def _collect_entities(self) -> set[str]:
         if self.power_calculate:
@@ -233,6 +234,7 @@ class HomeAssistant(Powermeter):
             self._entity_values[entity_id] = None
             self._entity_update_time[entity_id] = None
         self._check_entities_ready()
+        self._message_event.set()
 
     def _check_entities_ready(self) -> None:
         ready = all(
@@ -286,5 +288,12 @@ class HomeAssistant(Powermeter):
     async def wait_for_message(self, timeout: float = 5) -> None:
         try:
             await asyncio.wait_for(self._entities_ready.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            raise TimeoutError("Timeout waiting for Home Assistant state") from None
+
+    async def wait_for_next_message(self, timeout: float = 5) -> None:
+        self._message_event.clear()
+        try:
+            await asyncio.wait_for(self._message_event.wait(), timeout=timeout)
         except asyncio.TimeoutError:
             raise TimeoutError("Timeout waiting for Home Assistant state") from None

--- a/src/astrameter/powermeter/homeassistant_test.py
+++ b/src/astrameter/powermeter/homeassistant_test.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -357,6 +358,34 @@ async def test_wait_for_message_timeout():
     pm = _create_powermeter()
     with pytest.raises(TimeoutError):
         await pm.wait_for_message(timeout=0)
+
+
+# wait_for_next_message tests
+
+
+async def test_wait_for_next_message_blocks_until_new():
+    pm = _create_powermeter()
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "100"}]
+    )
+
+    async def _push_later():
+        await asyncio.sleep(0.05)
+        pm._update_entity_value("sensor.current_power", "200")
+
+    task = asyncio.create_task(_push_later())
+    await pm.wait_for_next_message(timeout=2)
+    await task
+    assert await pm.get_powermeter_watts() == [200.0]
+
+
+async def test_wait_for_next_message_timeout():
+    pm = _create_powermeter()
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "100"}]
+    )
+    with pytest.raises(TimeoutError):
+        await pm.wait_for_next_message(timeout=0)
 
 
 # subscribe_entities entity list test

--- a/src/astrameter/powermeter/homewizard.py
+++ b/src/astrameter/powermeter/homewizard.py
@@ -238,3 +238,10 @@ class HomeWizardPowermeter(Powermeter):
             await asyncio.wait_for(self._message_event.wait(), timeout=timeout)
         except asyncio.TimeoutError:
             raise TimeoutError("Timeout waiting for HomeWizard measurement") from None
+
+    async def wait_for_next_message(self, timeout: float = 5) -> None:
+        self._message_event.clear()
+        try:
+            await asyncio.wait_for(self._message_event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            raise TimeoutError("Timeout waiting for HomeWizard measurement") from None

--- a/src/astrameter/powermeter/homewizard_test.py
+++ b/src/astrameter/powermeter/homewizard_test.py
@@ -252,6 +252,27 @@ async def test_wait_for_message_timeout():
         await pm.wait_for_message(timeout=0)
 
 
+async def test_wait_for_next_message_blocks_until_new():
+    pm = _create_powermeter()
+    pm._handle_measurement({"power_w": 100})
+
+    async def _push_later():
+        await asyncio.sleep(0.05)
+        pm._handle_measurement({"power_w": 200})
+
+    task = asyncio.create_task(_push_later())
+    await pm.wait_for_next_message(timeout=2)
+    await task
+    assert await pm.get_powermeter_watts() == [200]
+
+
+async def test_wait_for_next_message_timeout():
+    pm = _create_powermeter()
+    pm._handle_measurement({"power_w": 100})
+    with pytest.raises(TimeoutError):
+        await pm.wait_for_next_message(timeout=0)
+
+
 # --- Category F: Lifecycle ---
 
 

--- a/src/astrameter/powermeter/mqtt.py
+++ b/src/astrameter/powermeter/mqtt.py
@@ -175,7 +175,16 @@ class MqttPowermeter(Powermeter):
 
     async def wait_for_next_message(self, timeout=5):
         self._message_event.clear()
-        try:
-            await asyncio.wait_for(self._message_event.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
-            raise TimeoutError("Timeout waiting for MQTT message") from None
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise TimeoutError("Timeout waiting for MQTT message")
+            try:
+                await asyncio.wait_for(self._message_event.wait(), timeout=remaining)
+            except asyncio.TimeoutError:
+                raise TimeoutError("Timeout waiting for MQTT message") from None
+            if all(v is not None for v in self.values):
+                return
+            self._message_event.clear()

--- a/src/astrameter/powermeter/mqtt.py
+++ b/src/astrameter/powermeter/mqtt.py
@@ -172,3 +172,10 @@ class MqttPowermeter(Powermeter):
                 raise TimeoutError("Timeout waiting for MQTT message") from None
             if all(v is not None for v in self.values):
                 return
+
+    async def wait_for_next_message(self, timeout=5):
+        self._message_event.clear()
+        try:
+            await asyncio.wait_for(self._message_event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            raise TimeoutError("Timeout waiting for MQTT message") from None

--- a/src/astrameter/powermeter/mqtt_test.py
+++ b/src/astrameter/powermeter/mqtt_test.py
@@ -112,7 +112,9 @@ async def test_wait_for_next_message_blocks_until_new():
 
     task = asyncio.create_task(_set_later())
     await pm.wait_for_next_message(timeout=2)
-    assert task.done(), "wait_for_next_message returned before the setter task completed"
+    assert task.done(), (
+        "wait_for_next_message returned before the setter task completed"
+    )
     assert pm.value == 42.0
 
 

--- a/src/astrameter/powermeter/mqtt_test.py
+++ b/src/astrameter/powermeter/mqtt_test.py
@@ -100,6 +100,30 @@ async def test_wait_for_message_wakes_on_event():
     assert pm.value == 99.0
 
 
+async def test_wait_for_next_message_blocks_until_new():
+    pm = _make_pm()
+    pm.value = 1.0
+    pm._message_event.set()
+
+    async def _set_later():
+        await asyncio.sleep(0.05)
+        pm.value = 42.0
+        pm._message_event.set()
+
+    task = asyncio.create_task(_set_later())
+    await pm.wait_for_next_message(timeout=2)
+    await task
+    assert pm.value == 42.0
+
+
+async def test_wait_for_next_message_times_out():
+    pm = _make_pm()
+    pm.value = 1.0
+    pm._message_event.set()
+    with pytest.raises(TimeoutError, match="Timeout waiting"):
+        await pm.wait_for_next_message(timeout=0.1)
+
+
 # ---------------------------------------------------------------------------
 # Multi-phase constructor unit tests
 # ---------------------------------------------------------------------------

--- a/src/astrameter/powermeter/mqtt_test.py
+++ b/src/astrameter/powermeter/mqtt_test.py
@@ -124,6 +124,24 @@ async def test_wait_for_next_message_times_out():
         await pm.wait_for_next_message(timeout=0.1)
 
 
+async def test_wait_for_next_message_multi_topic_cold_start():
+    pm = _make_pm(topic=["t1", "t2"])
+    # Cold start: no values set, event not set
+
+    async def _set_staggered():
+        await asyncio.sleep(0.05)
+        pm.values[0] = 100.0
+        pm._message_event.set()
+        await asyncio.sleep(0.05)
+        pm.values[1] = 200.0
+        pm._message_event.set()
+
+    task = asyncio.create_task(_set_staggered())
+    await pm.wait_for_next_message(timeout=2)
+    await task
+    assert await pm.get_powermeter_watts() == [100.0, 200.0]
+
+
 # ---------------------------------------------------------------------------
 # Multi-phase constructor unit tests
 # ---------------------------------------------------------------------------

--- a/src/astrameter/powermeter/mqtt_test.py
+++ b/src/astrameter/powermeter/mqtt_test.py
@@ -112,7 +112,7 @@ async def test_wait_for_next_message_blocks_until_new():
 
     task = asyncio.create_task(_set_later())
     await pm.wait_for_next_message(timeout=2)
-    await task
+    assert task.done(), "wait_for_next_message returned before the setter task completed"
     assert pm.value == 42.0
 
 

--- a/src/astrameter/powermeter/pid.py
+++ b/src/astrameter/powermeter/pid.py
@@ -95,6 +95,9 @@ class PidPowermeter(Powermeter):
         """Pass through to wrapped powermeter."""
         return await self.wrapped_powermeter.wait_for_message(timeout)
 
+    async def wait_for_next_message(self, timeout=5):
+        return await self.wrapped_powermeter.wait_for_next_message(timeout)
+
     async def start(self):
         """Pass through to wrapped powermeter."""
         await self.wrapped_powermeter.start()

--- a/src/astrameter/powermeter/pid_test.py
+++ b/src/astrameter/powermeter/pid_test.py
@@ -11,6 +11,7 @@ def mock_powermeter():
     pm = Mock()
     pm.get_powermeter_watts = AsyncMock()
     pm.wait_for_message = AsyncMock()
+    pm.wait_for_next_message = AsyncMock()
     pm.start = AsyncMock()
     pm.stop = AsyncMock()
     return pm
@@ -238,6 +239,12 @@ async def test_wait_for_message_passthrough(mock_powermeter):
     pm = PidPowermeter(mock_powermeter, kp=1.0)
     await pm.wait_for_message(timeout=7)
     mock_powermeter.wait_for_message.assert_called_once_with(7)
+
+
+async def test_wait_for_next_message_passthrough(mock_powermeter):
+    pm = PidPowermeter(mock_powermeter, kp=1.0)
+    await pm.wait_for_next_message(timeout=3)
+    mock_powermeter.wait_for_next_message.assert_called_once_with(3)
 
 
 # ------------------------------------------------------------------

--- a/src/astrameter/powermeter/sma_energy_meter.py
+++ b/src/astrameter/powermeter/sma_energy_meter.py
@@ -238,3 +238,12 @@ class SmaEnergyMeter(Powermeter):
             await asyncio.wait_for(self._async_message_event.wait(), timeout)
         except asyncio.TimeoutError:
             raise TimeoutError("Timeout waiting for SMA Energy Meter data") from None
+
+    async def wait_for_next_message(self, timeout=5):
+        if self._async_message_event is None:
+            raise RuntimeError("start() must be called before wait_for_next_message()")
+        self._async_message_event.clear()
+        try:
+            await asyncio.wait_for(self._async_message_event.wait(), timeout)
+        except asyncio.TimeoutError:
+            raise TimeoutError("Timeout waiting for SMA Energy Meter data") from None

--- a/src/astrameter/powermeter/sma_energy_meter_test.py
+++ b/src/astrameter/powermeter/sma_energy_meter_test.py
@@ -322,6 +322,46 @@ class TestWaitForMessageAsync:
             await meter.wait_for_message(timeout=0)
 
 
+class TestWaitForNextMessage:
+    async def test_blocks_until_new(self):
+        meter = _create_meter()
+        meter._async_message_event = asyncio.Event()
+        packet = _build_packet(
+            [
+                _build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000),
+                _build_channel(CHANNEL_TOTAL_POWER_MINUS, 0),
+            ]
+        )
+        meter._handle_packet(packet)
+
+        async def _push_later():
+            await asyncio.sleep(0.05)
+            new_packet = _build_packet(
+                [
+                    _build_channel(CHANNEL_TOTAL_POWER_PLUS, 2000),
+                    _build_channel(CHANNEL_TOTAL_POWER_MINUS, 0),
+                ]
+            )
+            meter._handle_packet(new_packet)
+
+        task = asyncio.create_task(_push_later())
+        await meter.wait_for_next_message(timeout=2)
+        await task
+        assert await meter.get_powermeter_watts() == [200.0]
+
+    async def test_timeout(self):
+        meter = _create_meter()
+        meter._async_message_event = asyncio.Event()
+        meter._async_message_event.set()
+        with pytest.raises(TimeoutError):
+            await meter.wait_for_next_message(timeout=0)
+
+    async def test_not_started_raises(self):
+        meter = _create_meter()
+        with pytest.raises(RuntimeError):
+            await meter.wait_for_next_message(timeout=0)
+
+
 class TestLifecycle:
     async def test_stop_closes_transport(self):
         meter = _create_meter()

--- a/src/astrameter/powermeter/throttling.py
+++ b/src/astrameter/powermeter/throttling.py
@@ -31,6 +31,9 @@ class ThrottledPowermeter(Powermeter):
     async def wait_for_message(self, timeout=5):
         return await self.wrapped_powermeter.wait_for_message(timeout)
 
+    async def wait_for_next_message(self, timeout=5):
+        return await self.wrapped_powermeter.wait_for_next_message(timeout)
+
     async def start(self):
         await self.wrapped_powermeter.start()
 

--- a/src/astrameter/powermeter/throttling_test.py
+++ b/src/astrameter/powermeter/throttling_test.py
@@ -71,6 +71,15 @@ async def test_wait_for_message_passthrough():
     mock_pm.wait_for_message.assert_called_once_with(30)
 
 
+async def test_wait_for_next_message_passthrough():
+    mock_pm = Mock()
+    mock_pm.wait_for_next_message = AsyncMock()
+    throttled = ThrottledPowermeter(mock_pm, throttle_interval=1.0)
+
+    await throttled.wait_for_next_message(timeout=15)
+    mock_pm.wait_for_next_message.assert_called_once_with(15)
+
+
 async def test_exception_handling_with_cache():
     """Test that cached values are returned on error after a successful fetch."""
     mock_pm = Mock()

--- a/src/astrameter/powermeter/transform.py
+++ b/src/astrameter/powermeter/transform.py
@@ -34,6 +34,9 @@ class TransformedPowermeter(Powermeter):
     async def wait_for_message(self, timeout=5):
         return await self.wrapped_powermeter.wait_for_message(timeout)
 
+    async def wait_for_next_message(self, timeout=5):
+        return await self.wrapped_powermeter.wait_for_next_message(timeout)
+
     async def start(self):
         await self.wrapped_powermeter.start()
 

--- a/src/astrameter/powermeter/transform_test.py
+++ b/src/astrameter/powermeter/transform_test.py
@@ -10,6 +10,7 @@ def mock_powermeter():
     pm = Mock()
     pm.get_powermeter_watts = AsyncMock()
     pm.wait_for_message = AsyncMock()
+    pm.wait_for_next_message = AsyncMock()
     return pm
 
 
@@ -104,6 +105,12 @@ async def test_wait_for_message_default_timeout(mock_powermeter):
     t = TransformedPowermeter(mock_powermeter, [0.0], [1.0])
     await t.wait_for_message()
     mock_powermeter.wait_for_message.assert_called_once_with(5)
+
+
+async def test_wait_for_next_message_passthrough(mock_powermeter):
+    t = TransformedPowermeter(mock_powermeter, [0.0], [1.0])
+    await t.wait_for_next_message(timeout=10)
+    mock_powermeter.wait_for_next_message.assert_called_once_with(10)
 
 
 def test_empty_offsets_raises(mock_powermeter):


### PR DESCRIPTION
The CT002's before_send callback now awaits wait_for_next_message() before reading the powermeter, ensuring push-based meters (MQTT, SMA, HomeWizard, Home Assistant) deliver a fresh measurement for every battery request instead of re-serving stale cached values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added measurement synchronization to ensure power readings reflect the latest available data from connected meters.

* **Bug Fixes**
  * Improved phase charging detection to activate when either a phase is marked active or carries measurable power.
  * Fixed inspection mode to properly update consumer reports instead of skipping them.

* **Tests**
  * Added comprehensive test coverage for measurement synchronization behavior across all meter types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->